### PR TITLE
Remove unused MSBuild directives

### DIFF
--- a/src/Calculator/Calculator.vcxproj
+++ b/src/Calculator/Calculator.vcxproj
@@ -136,11 +136,6 @@
     <AppxPackageSigningEnabled>false</AppxPackageSigningEnabled>
     <AppxBundle>Never</AppxBundle>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(XefOutputRoot)' != ''">
-    <AppxBundle>Always</AppxBundle>
-    <AppxBundlePlatforms>$(Platform)</AppxBundlePlatforms>
-    <AppxBundlePlatforms Condition="'$(Platform)'=='win32'">x86</AppxBundlePlatforms>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
       <AdditionalOptions>/bigobj /await /std:c++17 </AdditionalOptions>


### PR DESCRIPTION
Remove some properties which were only used when XefOutputRoot was set in the previous internal-only build environment.