### PR TITLE
Fix file path in CalculatorUnitTests.vcxproj.filters

### DIFF
--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
@@ -57,6 +57,6 @@
     <AppxManifest Include="Package.appxmanifest" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="CalculatorUnitTests_VS_TemporaryKey.pfx" />
+    <None Include="CalculatorUnitTests_TemporaryKey.pfx" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
A file was renamed in #4. The reference in the .vcsproj.filters file needs to be renamed too.