### PR TITLE
Date Calculation: Updated AdjustCalendarDate() to ensure we always add 365 when adding 1 year for Japanese calendar

### DIFF
--- a/src/CalcViewModel/Common/DateCalculator.cpp
+++ b/src/CalcViewModel/Common/DateCalculator.cpp
@@ -273,31 +273,33 @@ bool DateCalculationEngine::TryGetCalendarDaysInYear(_In_ DateTime date, _Out_ U
 // Adds/Subtracts certain value for a particular date unit
 DateTime DateCalculationEngine::AdjustCalendarDate(Windows::Foundation::DateTime date, DateUnit dateUnit, int difference)
 {
-    auto currentCalendarSystem = m_calendar->GetCalendarSystem();
 
     m_calendar->SetDateTime(date);
 
     switch (dateUnit)
     {
-    case DateUnit::Year:
-        // In the Japanese calendar, transition years have 2 partial years.
-        // It is not guaranteed that adding 1 year will always add 365 days in the Japanese Calendar.
-        // To work around this quirk, we will change the calendar system to Gregorian before adding 1 year in the Japanese Calendar case only.
-        // We will then return the calendar system back to the Japanese Calendar.
-        if (currentCalendarSystem == CalendarIdentifiers::Japanese)
+        case DateUnit::Year:
         {
-            m_calendar->ChangeCalendarSystem(CalendarIdentifiers::Gregorian);
-        }
+            // In the Japanese calendar, transition years have 2 partial years.
+            // It is not guaranteed that adding 1 year will always add 365 days in the Japanese Calendar.
+            // To work around this quirk, we will change the calendar system to Gregorian before adding 1 year in the Japanese Calendar case only.
+            // We will then return the calendar system back to the Japanese Calendar.
+            auto currentCalendarSystem = m_calendar->GetCalendarSystem();
+            if (currentCalendarSystem == CalendarIdentifiers::Japanese)
+            {
+                m_calendar->ChangeCalendarSystem(CalendarIdentifiers::Gregorian);
+            }
 
-        m_calendar->AddYears(difference);
-        m_calendar->ChangeCalendarSystem(currentCalendarSystem);
-        break;
-    case DateUnit::Month:
-        m_calendar->AddMonths(difference);
-        break;
-    case DateUnit::Week:
-        m_calendar->AddWeeks(difference);
-        break;
+            m_calendar->AddYears(difference);
+            m_calendar->ChangeCalendarSystem(currentCalendarSystem);
+            break;
+        }
+        case DateUnit::Month:
+            m_calendar->AddMonths(difference);
+            break;
+        case DateUnit::Week:
+            m_calendar->AddWeeks(difference);
+            break;
     }
 
     return m_calendar->GetDateTime();


### PR DESCRIPTION
In the Japanese calendar, a transition year consists of 2 partial years. So it is not always guaranteed that adding 1 year will add 365 days. In the case where the Japanese calendar is being used, we change the calendar to Gregorian before adding 1 year and then change it back. This ensures we are adding 365 days when we call m_calendar->AddYear(1).

Tested manually using both Japanese and English US calendars.