### PR TITLE
Resize app to appropriate dimensions on first launch

### DIFF
--- a/src/Calculator/App.xaml.cpp
+++ b/src/Calculator/App.xaml.cpp
@@ -255,9 +255,9 @@ void App::OnAppLaunch(IActivatedEventArgs^ args, String^ argument)
     // For very first launch, set the size of the calc as size of the default standard mode
     if (!localSettings->Values->HasKey(L"VeryFirstLaunch"))
     {
-        appView->PreferredLaunchViewSize = minWindowSize;
-        appView->PreferredLaunchWindowingMode = ApplicationViewWindowingMode::PreferredLaunchViewSize;
         localSettings->Values->Insert(ref new String(L"VeryFirstLaunch"), false);
+        appView->SetPreferredMinSize(minWindowSize);
+        appView->TryResizeView(minWindowSize);
     }
     else
     {


### PR DESCRIPTION
According to [PreferredLaunchViewSize docs](https://docs.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.applicationview.preferredlaunchviewsize#remarks) the current method we use to set the default launch size of the app on first run will not be applied until the next time the app is run. This change uses TryResizeView to resize the app instead.