### PR TITLE
Move RADIX_TYPE enum into its own header

### DIFF
--- a/src/CalcManager/CalcManager.vcxproj
+++ b/src/CalcManager/CalcManager.vcxproj
@@ -279,6 +279,7 @@
     <ClInclude Include="Header Files\CalcInput.h" />
     <ClInclude Include="Header Files\IHistoryDisplay.h" />
     <ClInclude Include="Header Files\Number.h" />
+    <ClInclude Include="Header Files\RadixType.h" />
     <ClInclude Include="Header Files\Rational.h" />
     <ClInclude Include="Header Files\scimath.h" />
     <ClInclude Include="pch.h" />

--- a/src/CalcManager/CalcManager.vcxproj.filters
+++ b/src/CalcManager/CalcManager.vcxproj.filters
@@ -161,5 +161,8 @@
     <ClInclude Include="Header Files\Rational.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="Header Files\RadixType.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -20,6 +20,7 @@
 #include "../Command.h"
 #include "../CalculatorVector.h"
 #include "../ExpressionCommand.h"
+#include "RadixType.h"
 #include "History.h"  // for History Collector
 #include "CalcInput.h"
 #include "ICalcDisplay.h"
@@ -37,15 +38,6 @@ enum eNUM_WIDTH {
 };
 typedef enum eNUM_WIDTH NUM_WIDTH;
 static constexpr size_t NUM_WIDTH_LENGTH = 4;
-
-// This is expected to be in same order as IDM_HEX, IDM_DEC, IDM_OCT, IDM_BIN
-enum eRADIX_TYPE {
-    HEX_RADIX,
-    DEC_RADIX,
-    OCT_RADIX,
-    BIN_RADIX
-};
-typedef enum eRADIX_TYPE RADIX_TYPE;
 
 namespace CalculationManager
 {

--- a/src/CalcManager/Header Files/Number.h
+++ b/src/CalcManager/Header Files/Number.h
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include "RatPack/ratpak.h"
+#include "Ratpack/ratpak.h"
 
 namespace CalcEngine
 {

--- a/src/CalcManager/Header Files/RadixType.h
+++ b/src/CalcManager/Header Files/RadixType.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+// This is expected to be in same order as IDM_HEX, IDM_DEC, IDM_OCT, IDM_BIN
+enum eRADIX_TYPE {
+    HEX_RADIX,
+    DEC_RADIX,
+    OCT_RADIX,
+    BIN_RADIX
+};
+typedef enum eRADIX_TYPE RADIX_TYPE;

--- a/src/Calculator/Converters/RadixToStringConverter.cpp
+++ b/src/Calculator/Converters/RadixToStringConverter.cpp
@@ -3,7 +3,7 @@
 
 #include "pch.h"
 #include "RadixToStringConverter.h"
-#include "CalcManager/Header Files/CalcEngine.h"
+#include "CalcManager/Header Files/RadixType.h"
 #include "CalcViewModel/Common/AppResourceProvider.h"
 
 using namespace Platform;


### PR DESCRIPTION
This change moves the RADIX_TYPE enum into its own header. This resolves a compilation error and reduces the dependency graph by allowing RadixToStringConverter to include just the enum header rather than the entire CalcEngine header.

Change verified by ensuring Calculator build locally.