### PR TITLE
Fix Log10 function

### DIFF
--- a/src/CalcManager/CEngine/scimath.cpp
+++ b/src/CalcManager/CEngine/scimath.cpp
@@ -136,7 +136,7 @@ Rational RationalMath::Log(Rational const& rat, int32_t precision)
 
 Rational RationalMath::Log10(Rational const& rat, int32_t precision)
 {
-    return Log(rat, precision).Div(10, precision);
+    return Log(rat, precision).Div(Rational{ ln_ten }, precision);
 }
 
 Rational RationalMath::Invert(Rational const& rat, int32_t precision)


### PR DESCRIPTION
## Fixes unit test failure CalculatorManagerTestScientific2.


### Description of the changes:
- Fixes Log10 function to perform ln(x) / ln(10) rather than ln(x) / 10

### How changes were validated:
- Verified app builds locally and unit tests are passing
