### PR TITLE
Change m_nPrecNum from int to size_t and rename to m_precedenceOpCount

### DIFF
--- a/src/CalcManager/CEngine/calc.cpp
+++ b/src/CalcManager/CEngine/calc.cpp
@@ -65,7 +65,7 @@ CCalcEngine::CCalcEngine(bool fPrecedence, bool fIntegerMode, CalculationManager
     m_nOpCode(0),
     m_nPrevOpCode(0),
     m_openParenCount(0),
-    m_nPrecNum(0),
+    m_precedenceOpCount(0),
     m_nTempCom(0),
     m_nLastCom(0),
     m_parenVals{},

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -112,7 +112,7 @@ private:
     int m_openParenCount; // Number of open parentheses.
     std::array<int, MAXPRECDEPTH> m_nOp;        /* Holding array for parenthesis operations.    */
     std::array<int, MAXPRECDEPTH> m_nPrecOp;    /* Holding array for precedence  operations.    */
-    int m_nPrecNum;     /* Current number of precedence ops in holding. */
+    size_t m_precedenceOpCount;     /* Current number of precedence ops in holding. */
     int m_nLastCom;   // Last command entered.
     ANGLE_TYPE m_angletype;  // Current Angle type when in dec mode. one of deg, rad or grad
     NUM_WIDTH m_numwidth;  // one of qword, dword, word or byte mode.


### PR DESCRIPTION
## Change m_nPrecNum from int to size_t and rename to m_precedenceOpCount.


### Description of the changes:
- Convert m_nPrecNum to size_t to resolve signed/unsigned conversion warning
- Rename to m_precedenceOpCount for clarity

### How changes were validated:
- Verified app builds and runs locally
- Verified unit tests build and run locally

