### PR TITLE
Minor README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,3 @@ email to ensure we received your original message. Further information, includin
 Copyright (c) Microsoft Corporation. All rights reserved.
 
 Licensed under the [MIT License](.\LICENSE).
-
-## Contact
-Questions that can't be answered on GitHub? Reach out to the team: <[calculator@microsoft.com](mailto:calculator@microsoft.com)>


### PR DESCRIPTION
Removing the team contact email address from the README (which has been disabled from
accepting incoming mail from external users).  We want to encourage open communication
with the community, and so would prefer to defer all communication to open channels
whenever possible.