### PR TITLE
CalcEngine: Rename scimath.h/cpp to RationalMath.h/cpp

### DIFF
--- a/src/CalcManager/CEngine/RationalMath.cpp
+++ b/src/CalcManager/CEngine/RationalMath.cpp
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 #include "pch.h"
-#include "Header Files/scimath.h"
+#include "Header Files/RationalMath.h"
 
 using namespace std;
 using namespace CalcEngine;

--- a/src/CalcManager/CalcManager.vcxproj
+++ b/src/CalcManager/CalcManager.vcxproj
@@ -281,7 +281,7 @@
     <ClInclude Include="Header Files\Number.h" />
     <ClInclude Include="Header Files\RadixType.h" />
     <ClInclude Include="Header Files\Rational.h" />
-    <ClInclude Include="Header Files\scimath.h" />
+    <ClInclude Include="Header Files\RationalMath.h" />
     <ClInclude Include="pch.h" />
     <ClInclude Include="Ratpack\CalcErr.h" />
     <ClInclude Include="Ratpack\ratconst.h" />
@@ -300,7 +300,7 @@
     <ClCompile Include="CEngine\scicomm.cpp" />
     <ClCompile Include="CEngine\scidisp.cpp" />
     <ClCompile Include="CEngine\scifunc.cpp" />
-    <ClCompile Include="CEngine\scimath.cpp" />
+    <ClCompile Include="CEngine\RationalMath.cpp" />
     <ClCompile Include="CEngine\scioper.cpp" />
     <ClCompile Include="CEngine\sciset.cpp" />
     <ClCompile Include="ExpressionCommand.cpp" />

--- a/src/CalcManager/CalcManager.vcxproj.filters
+++ b/src/CalcManager/CalcManager.vcxproj.filters
@@ -32,9 +32,6 @@
     <ClCompile Include="CEngine\scifunc.cpp">
       <Filter>CEngine</Filter>
     </ClCompile>
-    <ClCompile Include="CEngine\scimath.cpp">
-      <Filter>CEngine</Filter>
-    </ClCompile>
     <ClCompile Include="CEngine\scioper.cpp">
       <Filter>CEngine</Filter>
     </ClCompile>
@@ -89,6 +86,9 @@
     <ClCompile Include="CEngine\Rational.cpp">
       <Filter>CEngine</Filter>
     </ClCompile>
+    <ClCompile Include="CEngine\RationalMath.cpp">
+      <Filter>CEngine</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Command.h" />
@@ -108,9 +108,6 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Header Files\EngineStrings.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Header Files\scimath.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Ratpack\CalcErr.h">
@@ -162,6 +159,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Header Files\RadixType.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="Header Files\RationalMath.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -23,8 +23,8 @@
 #include "History.h"  // for History Collector
 #include "CalcInput.h"
 #include "ICalcDisplay.h"
-#include "scimath.h"
 #include "Rational.h"
+#include "RationalMath.h"
 
 // The following are NOT real exports of CalcEngine, but for forward declarations
 // The real exports follows later

--- a/src/CalcManager/Header Files/Number.h
+++ b/src/CalcManager/Header Files/Number.h
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 #pragma once
 

--- a/src/CalcManager/Header Files/Rational.h
+++ b/src/CalcManager/Header Files/Rational.h
@@ -1,4 +1,5 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
 
 #pragma once
 

--- a/src/CalcManager/Header Files/RationalMath.h
+++ b/src/CalcManager/Header Files/RationalMath.h
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#pragma once
+
 #include "Rational.h"
 
 namespace CalcEngine::RationalMath


### PR DESCRIPTION
## Renames scimath.h/cpp to RationalMath.h/cpp.


### Description of the changes:
- Renames scimath.h/cpp to RationalMath.h/cpp for constistency with namespaces

### How changes were validated:
- Verified solution builds and runs locally
- Verified UTs build and run successfully locally

