### PR TITLE
Fix spelling in some comments

### DIFF
--- a/src/CalcManager/CEngine/CalcInput.cpp
+++ b/src/CalcManager/CEngine/CalcInput.cpp
@@ -39,7 +39,7 @@ bool CalcInput::TryToggleSign(bool isIntegerMode, wstring_view maxNumStr)
     }
     else
     {
-        // When in integer only mode, it isnt always allowed to toggle, as toggling can cause the num to be out of 
+        // When in integer only mode, it isn't always allowed to toggle, as toggling can cause the num to be out of
         // bounds. For eg. in byte -128 is valid, but when it toggled it becomes 128, which is more than 127.
         if (isIntegerMode && m_base.IsNegative())
         {
@@ -74,7 +74,7 @@ bool CalcInput::TryAddDigit(unsigned int value, uint32_t radix, bool isIntegerMo
         pNumSec = &m_base;
         maxCount = maxDigits;
         // Don't include the decimal point in the count. In that way you can enter the maximum allowed precision.
-        // Precision doesnt include decimal point.
+        // Precision doesn't include decimal point.
         if (HasDecimalPt())
         {
             maxCount++;

--- a/src/CalcManager/CEngine/History.cpp
+++ b/src/CalcManager/CEngine/History.cpp
@@ -110,7 +110,7 @@ void CHistoryCollector::RemoveLastOpndFromHistory()
     TruncateEquationSzFromIch(m_lastOpStartIndex);
     SetExpressionDisplay();
     m_lastOpStartIndex = -1;
-    // This will not restore the m_lastBinOpStartIndex, as it isnt possible to remove that also later
+    // This will not restore the m_lastBinOpStartIndex, as it isn't possible to remove that also later
 }
 
 void CHistoryCollector::AddBinOpToHistory(int nOpCode, bool fNoRepetition)

--- a/src/CalcManager/CEngine/calc.cpp
+++ b/src/CalcManager/CEngine/calc.cpp
@@ -44,7 +44,7 @@ void CCalcEngine::InitialOneTimeOnlySetup(CalculationManager::IResourceProvider&
 {
     LoadEngineStrings(resourceProvider);
 
-    // we must now setup all the ratpak constants and our arrayed pointers
+    // we must now set up all the ratpak constants and our arrayed pointers
     // to these constants.
     ChangeBaseConstants(DEFAULT_RADIX, DEFAULT_MAX_DIGITS, DEFAULT_PRECISION);
 }
@@ -112,8 +112,8 @@ void CCalcEngine::InitChopNumbers()
     m_chopNumbers[2] = Rational{ rat_word };
     m_chopNumbers[3] = Rational{ rat_byte };
 
-    // initialize the max dec number you can support for each of the supported bit length
-    // this is basically max num in that width  / 2 in integer
+    // initialize the max dec number you can support for each of the supported bit lengths
+    // this is basically max num in that width / 2 in integer
     assert(m_chopNumbers.size() == m_maxDecimalValueStrings.size());
     for (size_t i = 0; i < m_chopNumbers.size(); i++)
     {


### PR DESCRIPTION
Fix spelling and grammar in a few comments in the calc engine.

I'm testing a change in our build system configuration and need a branch with a trivial change to test with. Note to future observers: there are a lot of low-quality comments in the calc engine code, and in general we don't want to spend time cleaning them up unless we're also fixing the code--so please don't submit more PRs like this one.