### PR TITLE
Fix license link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@ email to ensure we received your original message. Further information, includin
 ## License
 Copyright (c) Microsoft Corporation. All rights reserved.
 
-Licensed under the [MIT License](.\LICENSE).
+Licensed under the [MIT License](./LICENSE).


### PR DESCRIPTION
The link to the MIT License in README.md was broken.