### PR TITLE
Move the CalculatorManager instance to be direct member data of the StandardCalculatorViewModel class.

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -214,7 +214,7 @@ namespace CalculatorApp
             }
 
             property bool IsEngineRecording {
-                bool get() { return m_standardCalculatorManager->IsEngineRecording(); }
+                bool get() { return m_standardCalculatorManager.IsEngineRecording(); }
             }
 
             property bool  IsOperandEnabled {
@@ -311,7 +311,7 @@ namespace CalculatorApp
             void ResetDisplay();
             RADIX_TYPE GetCurrentRadixType() { return (RADIX_TYPE)m_CurrentRadixType; }
             void SetPrecision(int32_t precision);
-            void UpdateMaxIntDigits() { m_standardCalculatorManager->UpdateMaxIntDigits(); }
+            void UpdateMaxIntDigits() { m_standardCalculatorManager.UpdateMaxIntDigits(); }
             NumbersAndOperatorsEnum GetCurrentAngleType() { return m_CurrentAngleType; }
 
         private:
@@ -323,7 +323,7 @@ namespace CalculatorApp
             wchar_t m_decimalSeparator;
             CalculatorDisplay m_calculatorDisplay;
             CalculatorApp::EngineResourceProvider m_resourceProvider;
-            std::unique_ptr<CalculationManager::CalculatorManager> m_standardCalculatorManager;
+            CalculationManager::CalculatorManager m_standardCalculatorManager;
             Platform::String^ m_expressionAutomationNameFormat;
             Platform::String^ m_localizedCalculationResultAutomationFormat;
             Platform::String^ m_localizedCalculationResultDecimalAutomationFormat;

--- a/src/CalculatorUnitTests/HistoryTests.cpp
+++ b/src/CalculatorUnitTests/HistoryTests.cpp
@@ -46,17 +46,17 @@ namespace CalculatorFunctionalTests
         {
             m_standardViewModel = ref new StandardCalculatorViewModel();
             m_standardViewModel->IsStandard = true;
-            m_historyViewModel = ref new HistoryViewModel(m_standardViewModel->m_standardCalculatorManager.get());
+            m_historyViewModel = ref new HistoryViewModel(&(m_standardViewModel->m_standardCalculatorManager));
             m_historyViewModel->SetCalculatorDisplay(m_standardViewModel->m_calculatorDisplay);
         }
 
         void Cleanup(unsigned int windowId = 0)
         {
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeBasic);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
             m_historyViewModel->OnClearCommand(nullptr);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
             m_historyViewModel->OnClearCommand(nullptr);
-            m_standardViewModel->m_standardCalculatorManager->Reset();
+            m_standardViewModel->m_standardCalculatorManager.Reset();
         }
 
         bool IsHistoryContainerEmpty(_In_ String^ historyContainerKey)
@@ -83,12 +83,12 @@ namespace CalculatorFunctionalTests
         {
             Initialize(windowId);
             int initialSize = m_historyViewModel->ItemSize;
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command8);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command8);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             int sizeAfterItemAdd = m_historyViewModel->ItemSize;
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
             String^ expression = UtfUtils::LRO + L"1   +   8 =" + UtfUtils::PDF;
             String ^result = StringReference(L"9");
             VERIFY_ARE_EQUAL(initialSize + 1, sizeAfterItemAdd);
@@ -101,33 +101,33 @@ namespace CalculatorFunctionalTests
         {
             Initialize(windowId);
             int initialSize = m_historyViewModel->ItemSize;
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
-            for (int i = 1; i < m_standardViewModel->m_standardCalculatorManager->MaxHistorySize(); i++)
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            for (int i = 1; i < m_standardViewModel->m_standardCalculatorManager.MaxHistorySize(); i++)
             {
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command2);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             }
-            VERIFY_ARE_EQUAL(m_historyViewModel->ItemSize, m_standardViewModel->m_standardCalculatorManager->MaxHistorySize());
+            VERIFY_ARE_EQUAL(m_historyViewModel->ItemSize, m_standardViewModel->m_standardCalculatorManager.MaxHistorySize());
             String ^expression = UtfUtils::LRO + L"1   +   1 =" + UtfUtils::PDF;
             int output = 2;
             String ^result = output.ToString();
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
             VERIFY_ARE_EQUAL(expression, StringReference(historyItem->historyItemVector.expression.c_str()));
             VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
-            VERIFY_ARE_EQUAL(m_historyViewModel->ItemSize, m_standardViewModel->m_standardCalculatorManager->MaxHistorySize());
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            VERIFY_ARE_EQUAL(m_historyViewModel->ItemSize, m_standardViewModel->m_standardCalculatorManager.MaxHistorySize());
             expression = UtfUtils::LRO + L"1   +   2 =" + UtfUtils::PDF;
             output = 3;
             result = output.ToString();
-            historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
             VERIFY_ARE_EQUAL(expression, StringReference(historyItem->historyItemVector.expression.c_str()));
             VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
             Cleanup(windowId);
@@ -137,30 +137,30 @@ namespace CalculatorFunctionalTests
         {
             Initialize(windowId);
 
-            m_standardViewModel->m_standardCalculatorManager->Reset();
+            m_standardViewModel->m_standardCalculatorManager.Reset();
             int scientificItems = 5;
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
             for (int i = 0; i < scientificItems; i++)
             {
                 Command nextCommand = Command(130 + i);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(nextCommand);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(nextCommand);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             }
 
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeBasic);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
             int standardItems = 2;
             for (int i = 0; i < standardItems; i++)
             {
                 Command nextCommand = Command(130 + i);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(nextCommand);
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(nextCommand);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             }
 
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
             m_historyViewModel->ReloadHistory(ViewMode::Scientific);
             VERIFY_ARE_EQUAL(scientificItems, m_historyViewModel->ItemSize);
             for (int i = 0; i < scientificItems; i++)
@@ -169,13 +169,13 @@ namespace CalculatorFunctionalTests
                 expr = UtfUtils::LRO + expr + UtfUtils::PDF;
                 int output = 1 + i;
                 String ^result = output.ToString();
-                auto historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(i);
+                auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(i);
                 VERIFY_ARE_EQUAL(expr, historyItem->historyItemVector.expression);
                 VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
             }
 
             m_historyViewModel->ReloadHistory(ViewMode::Standard);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeBasic);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
             VERIFY_ARE_EQUAL(standardItems, m_historyViewModel->ItemSize);
             for (int i = 0; i < standardItems; i++)
             {
@@ -183,7 +183,7 @@ namespace CalculatorFunctionalTests
                 expr = UtfUtils::LRO + expr + UtfUtils::PDF;
                 int output = 1 + i;
                 String ^result = output.ToString();
-                auto historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(i);
+                auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(i);
                 VERIFY_ARE_EQUAL(expr, historyItem->historyItemVector.expression);
                 VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
             }
@@ -193,16 +193,16 @@ namespace CalculatorFunctionalTests
         void ClearHistory(unsigned int windowId = 0)
         {
             Initialize(windowId);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeBasic);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             m_historyViewModel->OnClearCommand(nullptr);
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
             VERIFY_IS_TRUE(IsHistoryContainerEmpty(GetHistoryContainerKeyHelper(CM_STD)));
@@ -213,15 +213,15 @@ namespace CalculatorFunctionalTests
         void SerializeDeSerializeHistoryItem(unsigned int windowId = 0)
         {
             Initialize(windowId);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
-            auto itemBeforeSerializeDeserialize = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            auto itemBeforeSerializeDeserialize = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
             m_historyViewModel->SaveHistory();
             m_historyViewModel->ReloadHistory(ViewMode::Scientific);
-            auto itemAfterSerializeDeserialize = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            auto itemAfterSerializeDeserialize = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
             VERIFY_IS_TRUE((itemBeforeSerializeDeserialize->historyItemVector.expression == itemAfterSerializeDeserialize->historyItemVector.expression) && (itemBeforeSerializeDeserialize->historyItemVector.result == itemAfterSerializeDeserialize->historyItemVector.result) && (itemBeforeSerializeDeserialize->historyItemVector.spCommands == itemAfterSerializeDeserialize->historyItemVector.spCommands) && (itemBeforeSerializeDeserialize->historyItemVector.spTokens == itemAfterSerializeDeserialize->historyItemVector.spTokens));
             Cleanup(windowId);
         }
@@ -229,30 +229,30 @@ namespace CalculatorFunctionalTests
         void SaveAndReloadHistory(unsigned int windowid = 0)
         {
             Initialize(windowid);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command8);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeBasic);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command6);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command8);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command6);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             int itemsBeforeSaveAndReload = m_historyViewModel->ItemSize;
             m_historyViewModel->SaveHistory();
             m_historyViewModel->ReloadHistory(ViewMode::Scientific);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
             wstring expr = L"1   +   8 =";
             // add double quotes around the expression
             expr = UtfUtils::LRO + expr + UtfUtils::PDF;
             String ^result = StringReference(L"9");
             int itemsAfterSaveAndReload = m_historyViewModel->ItemSize;
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
 
             VERIFY_ARE_EQUAL(expr, historyItem->historyItemVector.expression);
             VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
@@ -271,16 +271,16 @@ namespace CalculatorFunctionalTests
             ResourceLoader^ m_uiResourceLoader = ResourceLoader::GetForViewIndependentUse(L"CEngineStrings");
             int itemIndex = 0;
             int commandResource = 67;
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
             for (int index = 0; index < modes; index++)
             {
-                m_standardViewModel->m_standardCalculatorManager->SendCommand(mode[index]);
+                m_standardViewModel->m_standardCalculatorManager.SendCommand(mode[index]);
                 for (int command = 0; command < commandsSize; command++)
                 {
-                    m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-                    m_standardViewModel->m_standardCalculatorManager->SendCommand(commands[command]);
-                    m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
-                    auto historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(itemIndex);
+                    m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+                    m_standardViewModel->m_standardCalculatorManager.SendCommand(commands[command]);
+                    m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+                    auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(itemIndex);
                     String^ expression = m_uiResourceLoader->GetString(commandResource.ToString());
                     expression += L"( 1 ) =";
                     wstring expr = wstring(expression->Data());
@@ -297,20 +297,20 @@ namespace CalculatorFunctionalTests
         {
             Initialize(windowId);
             ResourceLoader^ m_uiResourceLoader = ResourceLoader::GetForViewIndependentUse(L"CEngineStrings");
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandDEG);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandSIN);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandRAD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandSIN);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandGRAD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandSIN);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandDEG);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandSIN);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandRAD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandSIN);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandGRAD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandSIN);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
             String^ expression = m_uiResourceLoader->GetString(L"67");
             expression += L"( 1 )   +   ";
             expression += m_uiResourceLoader->GetString(L"73");
@@ -327,14 +327,14 @@ namespace CalculatorFunctionalTests
         void HistoryItemClicked(unsigned int windowId = 0)
         {
             Initialize(windowId);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command3);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command3);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
             String^ expression = StringReference(historyItem->historyItemVector.expression.c_str());
             String^ result = StringReference(historyItem->historyItemVector.result.c_str());
             HistoryItemViewModel ^ item = ref new HistoryItemViewModel(expression, result, historyItem->historyItemVector.spTokens, historyItem->historyItemVector.spCommands);
@@ -354,32 +354,32 @@ namespace CalculatorFunctionalTests
         void HistoryItemLoadAndContinueCalculation(unsigned int windowId = 0)
         {
             Initialize(windowId);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeBasic);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command3);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command3);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
 
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
             String^ expression = StringReference(historyItem->historyItemVector.expression.c_str());
             String^ result = StringReference(historyItem->historyItemVector.result.c_str());
             HistoryItemViewModel ^ item = ref new HistoryItemViewModel(expression, result, historyItem->historyItemVector.spTokens, historyItem->historyItemVector.spCommands);
             MockOnHistoryItemClicked(item);
 
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             VERIFY_ARE_EQUAL(StringReference(L"14"), m_standardViewModel->DisplayValue);
-            historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(0);
+            historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
             expression = StringReference(historyItem->historyItemVector.expression.c_str());
             result = StringReference(historyItem->historyItemVector.result.c_str());
             item = ref new HistoryItemViewModel(expression, result, historyItem->historyItemVector.spTokens, historyItem->historyItemVector.spCommands);
             MockOnHistoryItemClicked(item);
             VERIFY_ARE_EQUAL(StringReference(L"9"), m_standardViewModel->DisplayValue);
 
-            historyItem = m_standardViewModel->m_standardCalculatorManager->GetHistoryItem(1);
+            historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(1);
             expression = StringReference(historyItem->historyItemVector.expression.c_str());
             result = StringReference(historyItem->historyItemVector.result.c_str());
             item = ref new HistoryItemViewModel(expression, result, historyItem->historyItemVector.spTokens, historyItem->historyItemVector.spCommands);
@@ -391,26 +391,26 @@ namespace CalculatorFunctionalTests
         void DisplayValueAutomationNames(unsigned int windowId = 0)
         {
             Initialize(windowId);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command8);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command8);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             String ^expression = StringReference(L"Display is 9");
             VERIFY_ARE_EQUAL(expression, m_standardViewModel->CalculationResultAutomationName);
 
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             expression = StringReference(L"Display is 6");
             VERIFY_ARE_EQUAL(expression, m_standardViewModel->CalculationResultAutomationName);
 
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeProgrammer);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeProgrammer);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             expression = StringReference(L"Display is 3");
             VERIFY_ARE_EQUAL(expression, m_standardViewModel->CalculationResultAutomationName);
 
@@ -420,12 +420,12 @@ namespace CalculatorFunctionalTests
         void RadixAutomationName(unsigned int windowId = 0)
         {
             Initialize(windowId);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeProgrammer);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeProgrammer);
             m_standardViewModel->IsProgrammer = true;
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::Command7);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::CommandEQU);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command7);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             String ^expression = L"HexaDecimal" + L" 8";
             String ^result = L"HexaDecimal " + Utils::GetStringValue(m_standardViewModel->HexDisplayValue);
             VERIFY_ARE_EQUAL(expression, result);
@@ -442,7 +442,7 @@ namespace CalculatorFunctionalTests
         {
             Initialize(windowId);
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
             Cleanup(windowId);
         }
@@ -451,7 +451,7 @@ namespace CalculatorFunctionalTests
         {
             Initialize(windowId);
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
-            m_standardViewModel->m_standardCalculatorManager->SendCommand(Command::ModeScientific);
+            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
             m_historyViewModel->OnClearCommand(nullptr);
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
             Cleanup(windowId);

--- a/src/CalculatorUnitTests/MultiWindowUnitTests.cpp
+++ b/src/CalculatorUnitTests/MultiWindowUnitTests.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include "pch.h"
@@ -411,7 +411,7 @@ namespace CalculatorUnitTests
                 ChangeMode(viewModels[i], i);
 
                 // Validate that the history items list is initially empty
-                VERIFY_IS_TRUE(0 == viewModels[i]->m_standardCalculatorManager->GetHistoryItems().size());
+                VERIFY_IS_TRUE(0 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
             }
 
             // Perform Calculations on both the instances and check that the History items work independently
@@ -440,9 +440,9 @@ namespace CalculatorUnitTests
             ValidateViewModelByCommands(viewModels[1], scientificModeTestItems, true);
 
             // Assert for the history list items of 1st instance
-            VERIFY_IS_TRUE(1 == viewModels[0]->m_standardCalculatorManager->GetHistoryItems().size());
+            VERIFY_IS_TRUE(1 == viewModels[0]->m_standardCalculatorManager.GetHistoryItems().size());
 
-            auto item1 = viewModels[0]->m_standardCalculatorManager->GetHistoryItem(0);
+            auto item1 = viewModels[0]->m_standardCalculatorManager.GetHistoryItem(0);
             String ^expression1 = UtfUtils::LRO + L"1   +   2 =" + UtfUtils::PDF;
             String^ result1 = L"3";
 
@@ -450,9 +450,9 @@ namespace CalculatorUnitTests
             VERIFY_ARE_EQUAL(result1, StringReference(item1->historyItemVector.result.c_str()));
 
             // Assert for the history list items of 2nd instance
-            VERIFY_IS_TRUE(1 == viewModels[1]->m_standardCalculatorManager->GetHistoryItems().size());
+            VERIFY_IS_TRUE(1 == viewModels[1]->m_standardCalculatorManager.GetHistoryItems().size());
 
-            auto item2 = viewModels[1]->m_standardCalculatorManager->GetHistoryItem(0);
+            auto item2 = viewModels[1]->m_standardCalculatorManager.GetHistoryItem(0);
             String^ expression2 = UtfUtils::LRO + L"1   +   2   " + UtfUtils::MUL + L"   3 =" + UtfUtils::PDF;
             String^ result2 = L"7";
 
@@ -474,7 +474,7 @@ namespace CalculatorUnitTests
                 ChangeMode(viewModels[i], 0);
 
                 // Validate that the history items list is initially empty
-                VERIFY_IS_TRUE(0 == viewModels[i]->m_standardCalculatorManager->GetHistoryItems().size());
+                VERIFY_IS_TRUE(0 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
             }
 
             // Perform Calculations on both the instances and check that the History items work independently
@@ -513,9 +513,9 @@ namespace CalculatorUnitTests
             // Assert for the history list items of the instances
             for (int i = 0; i < 2; i++)
             {
-                VERIFY_IS_TRUE(1 == viewModels[i]->m_standardCalculatorManager->GetHistoryItems().size());
+                VERIFY_IS_TRUE(1 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
 
-                auto item = viewModels[i]->m_standardCalculatorManager->GetHistoryItem(0);
+                auto item = viewModels[i]->m_standardCalculatorManager.GetHistoryItem(0);
 
                 VERIFY_ARE_EQUAL(expression[i], StringReference(item->historyItemVector.expression.c_str()));
                 VERIFY_ARE_EQUAL(result[i], StringReference(item->historyItemVector.result.c_str()));
@@ -536,7 +536,7 @@ namespace CalculatorUnitTests
                 ChangeMode(viewModels[i], 1);
 
                 // Validate that the history items list is initially empty
-                VERIFY_IS_TRUE(0 == viewModels[i]->m_standardCalculatorManager->GetHistoryItems().size());
+                VERIFY_IS_TRUE(0 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
             }
 
             // Perform Calculations on both the instances and check that the History items work independently
@@ -575,9 +575,9 @@ namespace CalculatorUnitTests
             // Assert for the history list items of the instances
             for (int i = 0; i < 2; i++)
             {
-                VERIFY_IS_TRUE(1 == viewModels[i]->m_standardCalculatorManager->GetHistoryItems().size());
+                VERIFY_IS_TRUE(1 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
 
-                auto item = viewModels[i]->m_standardCalculatorManager->GetHistoryItem(0);
+                auto item = viewModels[i]->m_standardCalculatorManager.GetHistoryItem(0);
 
                 VERIFY_ARE_EQUAL(expression[i], StringReference(item->historyItemVector.expression.c_str()));
                 VERIFY_ARE_EQUAL(result[i], StringReference(item->historyItemVector.result.c_str()));


### PR DESCRIPTION
Move the CalculatorManager instance to be direct member data of the StandardCalculatorViewModel class.

Previously, the CalculatorManager was managed with a unique_ptr that was instantiated in the ViewModel's constructor and was never re-assigned.  Objects with long lifetime and larger memory footprint should live in dynamic memory, but the ViewModel itself lives in dynamic memory so that goal is still satisfied by storing the CalculatorManager directly in the class. The change allows the compiler to write a more efficient memory footprint for the same data.

- Verified by testing basic app functionality and running unit tests locally.

