### PR TITLE
Readability Improvements to Calculator.xaml

### DIFF
--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -13,7 +13,29 @@
              mc:Ignorable="d">
 
     <UserControl.Resources>
-        <automation:NarratorNotifier x:Name="NarratorNotifier" Announcement="{x:Bind Model.Announcement, Mode=OneWay}"/>
+        <!-- DataTemplates -->
+
+        <DataTemplate x:Key="Operand" x:DataType="common:DisplayExpressionToken">
+            <TextBlock Margin="2,0,0,0"
+                       Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
+                       IsTextScaleFactorEnabled="False"
+                       Text="{Binding Token, Mode=OneWay}"/>
+        </DataTemplate>
+
+        <DataTemplate x:Key="Operator" x:DataType="common:DisplayExpressionToken">
+            <TextBlock Margin="2,0,0,0"
+                       Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
+                       IsTextScaleFactorEnabled="False"
+                       Text="{Binding Token, Mode=OneWay}"/>
+        </DataTemplate>
+
+        <DataTemplate x:Key="Separator" x:DataType="common:DisplayExpressionToken">
+            <TextBlock x:Name="MainText"
+                       IsTextScaleFactorEnabled="False"
+                       Text="{Binding Token, Mode=OneWay}"/>
+        </DataTemplate>
+
+        <!-- TextBox Styles -->
 
         <Style x:Key="OperandTextBoxStyle" TargetType="controls:OperandTextBox">
             <Setter Property="MinWidth" Value="32"/>
@@ -114,139 +136,6 @@
             </Setter>
         </Style>
 
-        <!-- Used by hidden shortcut buttons -->
-        <x:Int32 x:Key="Zero">0</x:Int32>
-
-        <DataTemplate x:Key="Operand" x:DataType="common:DisplayExpressionToken">
-            <TextBlock Margin="2,0,0,0"
-                       Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
-                       IsTextScaleFactorEnabled="False"
-                       Text="{Binding Token, Mode=OneWay}"/>
-        </DataTemplate>
-
-        <DataTemplate x:Key="Operator" x:DataType="common:DisplayExpressionToken">
-            <TextBlock Margin="2,0,0,0"
-                       Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
-                       IsTextScaleFactorEnabled="False"
-                       Text="{Binding Token, Mode=OneWay}"/>
-        </DataTemplate>
-
-        <DataTemplate x:Key="Separator" x:DataType="common:DisplayExpressionToken">
-            <TextBlock x:Name="MainText"
-                       IsTextScaleFactorEnabled="False"
-                       Text="{Binding Token, Mode=OneWay}"/>
-        </DataTemplate>
-
-        <Style x:Key="ExpressionBaseContainerStyle" TargetType="ListViewItem">
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Margin" Value="0"/>
-            <Setter Property="MinWidth" Value="0"/>
-            <Setter Property="MinHeight" Value="0"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="VerticalAlignment" Value="Stretch"/>
-            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-            <Setter Property="VerticalContentAlignment" Value="Center"/>
-            <Setter Property="Template">
-                <Setter.Value>
-                    <ControlTemplate TargetType="ListViewItem">
-                        <ListViewItemPresenter Padding="0"
-                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                                               ContentMargin="0"
-                                               DisabledOpacity="{ThemeResource ListViewItemDisabledThemeOpacity}"
-                                               DragOpacity="{ThemeResource ListViewItemDragThemeOpacity}"
-                                               PointerOverBackground="{ThemeResource SystemControlHighlightListAccentLowBrush}"
-                                               PointerOverBackgroundMargin="0"
-                                               SelectedBackground="{ThemeResource SystemControlBackgroundAccentBrush}"
-                                               SelectedBorderThickness="0"
-                                               SelectedForeground="{ThemeResource SystemControlForegroundChromeWhiteBrush}"
-                                               SelectedPointerOverBackground="{ThemeResource SystemControlHighlightListAccentLowBrush}"
-                                               SelectedPointerOverBorderBrush="Transparent"
-                                               SelectionCheckMarkVisualEnabled="False"/>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-        </Style>
-
-        <Style x:Key="NonEditableOperatorContainerStyle"
-               BasedOn="{StaticResource ExpressionBaseContainerStyle}"
-               TargetType="ListViewItem">
-            <Setter Property="IsHitTestVisible" Value="False"/>
-            <Setter Property="IsTabStop" Value="False"/>
-            <Setter Property="MinWidth" Value="4"/>
-        </Style>
-
-        <Style x:Key="EditableOperatorContainerStyle"
-               BasedOn="{StaticResource ExpressionBaseContainerStyle}"
-               TargetType="ListViewItem">
-            <Setter Property="IsHitTestVisible" Value="True"/>
-            <Setter Property="MinWidth" Value="32"/>
-        </Style>
-
-        <converters:ExpressionItemTemplateSelector x:Key="ExpressionItemTemplateSelector"
-                                                   OperandTemplate="{StaticResource Operand}"
-                                                   OperatorTemplate="{StaticResource Operator}"
-                                                   SeparatorTemplate="{StaticResource Separator}"/>
-
-        <converters:ExpressionItemContainerStyle x:Key="ExpressionItemContainerStyle"
-                                                 EditableOperatorStyle="{StaticResource NonEditableOperatorContainerStyle}"
-                                                 NonEditableOperatorStyle="{StaticResource NonEditableOperatorContainerStyle}"
-                                                 OperandStyle="{StaticResource NonEditableOperatorContainerStyle}"
-                                                 SeparatorStyle="{StaticResource NonEditableOperatorContainerStyle}"/>
-
-        <Style x:Key="ResultsStyleL"
-               x:Name="ResultsStyleL"
-               BasedOn="{StaticResource CalculationResultStyleL}"
-               TargetType="controls:CalculationResult">
-            <Setter Property="HorizontalContentAlignment" Value="Right"/>
-            <Setter Property="VerticalContentAlignment" Value="Top"/>
-            <Setter Property="FontSize" Value="{StaticResource CalcResultFontSizeL}"/>
-            <Setter Property="MinFontSize" Value="12"/>
-            <Setter Property="IsActive" Value="True"/>
-            <Setter Property="DisplayMargin" Value="0,0,0,0"/>
-            <Setter Property="MaxExpressionHistoryCharacters" Value="51"/>
-        </Style>
-
-        <Style x:Key="ResultsStyleM"
-               x:Name="ResultsStyleM"
-               BasedOn="{StaticResource CalculationResultStyleM}"
-               TargetType="controls:CalculationResult">
-            <Setter Property="HorizontalContentAlignment" Value="Right"/>
-            <Setter Property="VerticalContentAlignment" Value="Top"/>
-            <Setter Property="FontSize" Value="{StaticResource CalcResultFontSizeM}"/>
-            <Setter Property="MinFontSize" Value="12"/>
-            <Setter Property="IsActive" Value="True"/>
-            <Setter Property="DisplayMargin" Value="0,0,0,0"/>
-            <Setter Property="MaxExpressionHistoryCharacters" Value="30"/>
-        </Style>
-
-        <Style x:Key="ResultsStyleS"
-               x:Name="ResultsStyleS"
-               BasedOn="{StaticResource CalculationResultStyleS}"
-               TargetType="controls:CalculationResult">
-            <Setter Property="HorizontalContentAlignment" Value="Right"/>
-            <Setter Property="VerticalContentAlignment" Value="Top"/>
-            <Setter Property="FontSize" Value="{StaticResource CalcResultFontSizeS}"/>
-            <Setter Property="MinFontSize" Value="12"/>
-            <Setter Property="IsActive" Value="True"/>
-            <Setter Property="DisplayMargin" Value="0,0,0,0"/>
-            <Setter Property="MaxExpressionHistoryCharacters" Value="30"/>
-        </Style>
-
-        <Style x:Key="ScrollButtonStyle" TargetType="Button">
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="0,0,0,0"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="VerticalContentAlignment" Value="Center"/>
-            <Setter Property="HorizontalContentAlignment" Value="Center"/>
-            <Setter Property="Width" Value="20"/>
-            <Setter Property="MinWidth" Value="20"/>
-            <Setter Property="MinHeight" Value="24"/>
-            <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundAccentBrush}"/>
-            <Setter Property="Background" Value="Transparent"/>
-            <Setter Property="Visibility" Value="Collapsed"/>
-        </Style>
-
         <Style TargetType="controls:OverflowTextBlock">
             <Setter Property="HorizontalAlignment" Value="Stretch"/>
             <Setter Property="Template">
@@ -317,6 +206,113 @@
             </Setter>
         </Style>
 
+        <!-- ListViewItem Styles -->
+
+        <Style x:Key="ExpressionBaseContainerStyle" TargetType="ListViewItem">
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Margin" Value="0"/>
+            <Setter Property="MinWidth" Value="0"/>
+            <Setter Property="MinHeight" Value="0"/>
+            <Setter Property="HorizontalAlignment" Value="Center"/>
+            <Setter Property="VerticalAlignment" Value="Stretch"/>
+            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="Template">
+                <Setter.Value>
+                    <ControlTemplate TargetType="ListViewItem">
+                        <ListViewItemPresenter Padding="0"
+                                               HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                               VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                                               ContentMargin="0"
+                                               DisabledOpacity="{ThemeResource ListViewItemDisabledThemeOpacity}"
+                                               DragOpacity="{ThemeResource ListViewItemDragThemeOpacity}"
+                                               PointerOverBackground="{ThemeResource SystemControlHighlightListAccentLowBrush}"
+                                               PointerOverBackgroundMargin="0"
+                                               SelectedBackground="{ThemeResource SystemControlBackgroundAccentBrush}"
+                                               SelectedBorderThickness="0"
+                                               SelectedForeground="{ThemeResource SystemControlForegroundChromeWhiteBrush}"
+                                               SelectedPointerOverBackground="{ThemeResource SystemControlHighlightListAccentLowBrush}"
+                                               SelectedPointerOverBorderBrush="Transparent"
+                                               SelectionCheckMarkVisualEnabled="False"/>
+                    </ControlTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style>
+
+        <Style x:Key="NonEditableOperatorContainerStyle"
+               BasedOn="{StaticResource ExpressionBaseContainerStyle}"
+               TargetType="ListViewItem">
+            <Setter Property="IsHitTestVisible" Value="False"/>
+            <Setter Property="IsTabStop" Value="False"/>
+            <Setter Property="MinWidth" Value="4"/>
+        </Style>
+
+        <Style x:Key="EditableOperatorContainerStyle"
+               BasedOn="{StaticResource ExpressionBaseContainerStyle}"
+               TargetType="ListViewItem">
+            <Setter Property="IsHitTestVisible" Value="True"/>
+            <Setter Property="MinWidth" Value="32"/>
+        </Style>
+
+        <!-- Calculation Result Styles -->
+
+        <Style x:Key="ResultsStyleL"
+               x:Name="ResultsStyleL"
+               BasedOn="{StaticResource CalculationResultStyleL}"
+               TargetType="controls:CalculationResult">
+            <Setter Property="HorizontalContentAlignment" Value="Right"/>
+            <Setter Property="VerticalContentAlignment" Value="Top"/>
+            <Setter Property="FontSize" Value="{StaticResource CalcResultFontSizeL}"/>
+            <Setter Property="MinFontSize" Value="12"/>
+            <Setter Property="IsActive" Value="True"/>
+            <Setter Property="DisplayMargin" Value="0,0,0,0"/>
+            <Setter Property="MaxExpressionHistoryCharacters" Value="51"/>
+        </Style>
+
+        <Style x:Key="ResultsStyleM"
+               x:Name="ResultsStyleM"
+               BasedOn="{StaticResource CalculationResultStyleM}"
+               TargetType="controls:CalculationResult">
+            <Setter Property="HorizontalContentAlignment" Value="Right"/>
+            <Setter Property="VerticalContentAlignment" Value="Top"/>
+            <Setter Property="FontSize" Value="{StaticResource CalcResultFontSizeM}"/>
+            <Setter Property="MinFontSize" Value="12"/>
+            <Setter Property="IsActive" Value="True"/>
+            <Setter Property="DisplayMargin" Value="0,0,0,0"/>
+            <Setter Property="MaxExpressionHistoryCharacters" Value="30"/>
+        </Style>
+
+        <Style x:Key="ResultsStyleS"
+               x:Name="ResultsStyleS"
+               BasedOn="{StaticResource CalculationResultStyleS}"
+               TargetType="controls:CalculationResult">
+            <Setter Property="HorizontalContentAlignment" Value="Right"/>
+            <Setter Property="VerticalContentAlignment" Value="Top"/>
+            <Setter Property="FontSize" Value="{StaticResource CalcResultFontSizeS}"/>
+            <Setter Property="MinFontSize" Value="12"/>
+            <Setter Property="IsActive" Value="True"/>
+            <Setter Property="DisplayMargin" Value="0,0,0,0"/>
+            <Setter Property="MaxExpressionHistoryCharacters" Value="30"/>
+        </Style>
+
+        <!-- Button Styles -->
+
+        <Style x:Key="ScrollButtonStyle" TargetType="Button">
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="Padding" Value="0,0,0,0"/>
+            <Setter Property="VerticalAlignment" Value="Center"/>
+            <Setter Property="VerticalContentAlignment" Value="Center"/>
+            <Setter Property="HorizontalContentAlignment" Value="Center"/>
+            <Setter Property="Width" Value="20"/>
+            <Setter Property="MinWidth" Value="20"/>
+            <Setter Property="MinHeight" Value="24"/>
+            <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundAccentBrush}"/>
+            <Setter Property="Background" Value="Transparent"/>
+            <Setter Property="Visibility" Value="Collapsed"/>
+        </Style>
+
+        <!-- Flyout Styles -->
+
         <Style x:Key="MemoryFlyoutStyle" TargetType="FlyoutPresenter">
             <Setter Property="MinWidth" Value="200"/>
             <Setter Property="MaxHeight" Value="2400"/>
@@ -378,6 +374,8 @@
             </Setter>
         </Style>
 
+        <!-- Storyboards -->
+
         <Storyboard x:Name="Animate">
             <DoubleAnimationUsingKeyFrames Storyboard.TargetName="NumpadPanel" Storyboard.TargetProperty="(UIElement.RenderTransform).(CompositeTransform.ScaleX)">
                 <EasingDoubleKeyFrame KeyTime="0" Value="0.92">
@@ -432,8 +430,31 @@
             </DoubleAnimationUsingKeyFrames>
         </Storyboard>
 
+        <!-- Value Converters -->
+
         <converters:BooleanToVisibilityNegationConverter x:Key="BooleanToVisibilityNegationConverter"/>
+
         <converters:BooleanNegationConverter x:Key="BooleanNegationConverter"/>
+
+        <!-- DataTemplate Selectors and Style Selectors -->
+
+        <converters:ExpressionItemTemplateSelector x:Key="ExpressionItemTemplateSelector"
+                                                   OperandTemplate="{StaticResource Operand}"
+                                                   OperatorTemplate="{StaticResource Operator}"
+                                                   SeparatorTemplate="{StaticResource Separator}"/>
+
+        <converters:ExpressionItemContainerStyle x:Key="ExpressionItemContainerStyle"
+                                                 EditableOperatorStyle="{StaticResource NonEditableOperatorContainerStyle}"
+                                                 NonEditableOperatorStyle="{StaticResource NonEditableOperatorContainerStyle}"
+                                                 OperandStyle="{StaticResource NonEditableOperatorContainerStyle}"
+                                                 SeparatorStyle="{StaticResource NonEditableOperatorContainerStyle}"/>
+
+        <!-- Miscellaneous Resources -->
+
+        <automation:NarratorNotifier x:Name="NarratorNotifier" Announcement="{x:Bind Model.Announcement, Mode=OneWay}"/>
+
+        <!-- Used by hidden shortcut buttons -->
+        <x:Int32 x:Key="Zero">0</x:Int32>
 
         <MenuFlyout x:Key="DisplayContextMenu">
             <MenuFlyoutItem x:Name="CopyMenuItem"


### PR DESCRIPTION
## Summary

Improved human readability of the XAML in Calculator.xaml document. 

_If this PR is accepted, I will work my way through the rest of the solution and apply readability improvements to other locations._

### Description of the changes:
- Added XAML comments to describe the resource's responsibility
- Grouped resources according to responsibility
- Cleaned up newlines (removed extra ones, added one where needed)

To explain with a single screenshot, here's what the Resources section now looks like:

![image](https://user-images.githubusercontent.com/3520532/53642014-a788c080-3bfe-11e9-8736-da8e03da90fd.png)


### How changes were validated:

Improving the readability of code is critical to good open source. For XAML documents specifically, having clear resource sections, with understandable code comments, goes a long way to easily understanding the code.

Specifically, the changes in this PR cleans up the primary XAML document for the application. Allowing any developers browsing the code to quickly and easily understand the responsibilty of the DataTemplate, Style, Selector or Converter.

The spacing changes help visually separate the distinct compnents (e.g. having a space in between Grid.RowDefinitions and the first child element) and significantly reduces cognitive load.

### Testing
- The changes meet all the XAML Styler guidelines (i.e. passes Settings.XamlStyler rules).
- No functional changes were made, existing tests are sufficient

