### PR TITLE
Fix CI build versioning

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -11,7 +11,7 @@ pr:
 - master
 - servicing/*
 
-name: 0.$(Date:yyMM).$(Date:dd)$(Rev:rr).0
+name: 0.$(Date:yyMM).$(DayOfMonth)$(Rev:rr).0
 
 jobs:
 - template: ./templates/build-app-public.yaml


### PR DESCRIPTION
CI builds are failing with error C00CE169 when the minor version number has a leading zero, like "0.1903.0101.0". Get rid of the leading zero.