### PR TITLE
Switch CI builds to use public machine pool

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -36,9 +36,15 @@ jobs:
 - template: ./templates/run-unit-tests.yaml
   parameters:
     platform: x64
+    reimageServiceConnection: essential-experiences-interactive-reimage
+    reimageSubscriptionId: a8f5eb47-e59c-44b4-8e42-e70811a047b5
+    reimageResourceGroup: EETestPublic
 
 - template: ./templates/run-unit-tests.yaml
   parameters:
     platform: x86
+    reimageServiceConnection: essential-experiences-interactive-reimage
+    reimageSubscriptionId: a8f5eb47-e59c-44b4-8e42-e70811a047b5
+    reimageResourceGroup: EETestPublic
 
 - template: ./templates/package-appxbundle.yaml

--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -38,10 +38,16 @@ jobs:
 - template: ./templates/run-unit-tests.yaml
   parameters:
     platform: x64
+    reimageServiceConnection: macool-sandbox-interactiveDesktopRS5
+    reimageSubscriptionId: 012a8008-c00f-45b3-9828-41ebba30141d
+    reimageResourceGroup: interactiveDesktopRS5
 
 - template: ./templates/run-unit-tests.yaml
   parameters:
     platform: x86
+    reimageServiceConnection: macool-sandbox-interactiveDesktopRS5
+    reimageSubscriptionId: 012a8008-c00f-45b3-9828-41ebba30141d
+    reimageResourceGroup: interactiveDesktopRS5
 
 - template: ./templates/package-appxbundle.yaml
 

--- a/build/pipelines/templates/run-unit-tests.yaml
+++ b/build/pipelines/templates/run-unit-tests.yaml
@@ -2,6 +2,9 @@
 
 parameters:
   platform: ''
+  reimageServiceConnection: ''
+  reimageSubscriptionId: ''
+  reimageResourceGroup: ''
 
 jobs:
 - job: UnitTests${{ parameters.platform }}
@@ -49,6 +52,6 @@ jobs:
     displayName: Reimage test machine
     inputs:
       connectionType: connectedServiceNameARM
-      azureServiceConnection: macool-sandbox-interactiveDesktopRS5
-      urlSuffix: subscriptions/012a8008-c00f-45b3-9828-41ebba30141d/resourceGroups/interactiveDesktopRS5/providers/Microsoft.Compute/virtualMachineScaleSets/essential/reimage?api-version=2018-10-01
+      azureServiceConnection: ${{ parameters.reimageServiceConnection }}
+      urlSuffix: subscriptions/${{ parameters.reimageSubscriptionId }}/resourceGroups/${{ parameters.reimageResourceGroup }}/providers/Microsoft.Compute/virtualMachineScaleSets/essential/reimage?api-version=2018-10-01
       body: '{ "instanceIds": ["$(agentInstanceId)"] }'


### PR DESCRIPTION
As part of our transition to publicly-visible CI builds, we have a new pool of machines to run unit tests on. Update the service connection details so the public pool is used in CI builds and the internal pool is used in release builds.