### PR TITLE
windows store is now called microsoft store

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 The Windows Calculator app is a modern Windows app written in C++ that ships pre-installed with Windows.
 The app provides standard, scientific, and programmer calculator functionality, as well as a set of converters between various units of measurement and currencies.
 
-Calculator ships regularly with new features and bug fixes. You can get the latest version of Calculator in the [Windows Store.](https://www.microsoft.com/store/apps/9WZDNCRFHVN5)
+Calculator ships regularly with new features and bug fixes. You can get the latest version of Calculator in the [Microsoft Store.](https://www.microsoft.com/store/apps/9WZDNCRFHVN5)
 
 [![Build Status](https://dev.azure.com/ms/calculator/_apis/build/status/Calculator-CI?branchName=master)](https://dev.azure.com/ms/calculator/_build/latest?definitionId=57&branchName=master)
 


### PR DESCRIPTION
## Fixes #.
- the windows store has been renamed to the Microsoft Store. this PR updates the readme to reflect this. 

### Description of the changes:
- changes the single instance of "windows store" to "Microsoft store".


### How changes were validated:
![image](https://user-images.githubusercontent.com/16927294/53907200-87dc0880-4001-11e9-968a-f7d04c7388f8.png)

![image](https://user-images.githubusercontent.com/16927294/53907250-a0e4b980-4001-11e9-99aa-f3af5aa5bcfe.png)


