### PR TITLE
Fix scientific notation for crypto currencies

### DIFF
--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -22,7 +22,7 @@
 
 using namespace std;
 
-static constexpr int MAX_ZEROS_AFTER_DECIMAL = 2;
+static constexpr int MAX_ZEROS_AFTER_DECIMAL = 7;
 
 // digits 0..64 used by bases 2 .. 64
 static constexpr wstring_view DIGITS = L"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz_@";


### PR DESCRIPTION
## Fixes #.
It's not helpful to calculate crypto currency values with scientific notation. All values up to 7 decimals should be in standard format.

### Description of the changes:
- Changed maximum number of zeros after decimal to 7 (smallest unit "1 satoshi" in crypto currencies have 7 zeros).

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manual
