### PR TITLE
updating nuget.org source to point to V3

### DIFF
--- a/internal/nuget.config
+++ b/internal/nuget.config
@@ -4,7 +4,7 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <packageSources>
-    <add key="NuGet official package source" value="https://nuget.org/api/v2/" />
+    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="MitaLite" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/MitaLite/nuget/v3/index.json" />
     <add key="Taef" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/Taef/nuget/v3/index.json" />
     <add key="Test.Net" value="https://microsoft.pkgs.visualstudio.com/DefaultCollection/_packaging/Test.Net/nuget/v3/index.json" />

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -4,7 +4,7 @@
     <add key="disableSourceControlIntegration" value="true" />
   </solution>
   <packageSources>
-    <add key="NuGet official package source" value="https://nuget.org/api/v2/" />
+    <add key="NuGet official package source" value="https://api.nuget.org/v3/index.json" />
     <add key="EEApps" value="https://eeapps.blob.core.windows.net/eeapps/index.json" />
   </packageSources>
   <config>


### PR DESCRIPTION
V2 is deprecated. Updating the config to use V3.
See https://docs.microsoft.com/en-us/nuget/faqs/nuget-faq#what-is-the-api-endpoint-for-nugetorg