### PR TITLE
Reject text from clipboard when it contains a dot and the local decimal separator is not one

### DIFF
--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -136,6 +136,13 @@ String^ CopyPasteManager::ValidatePasteExpression(String^ pastedText, ViewMode m
 
     wstring pasteExpression = pastedText->Data();
 
+    // Reject strings with '.' when the local decimal separator is different
+    wchar_t decimalSeparator = LocalizationSettings::GetInstance().GetDecimalSeparator();
+    if (decimalSeparator != '.' && pasteExpression.find('.') != std::string::npos)
+    {
+        return StringReference(PasteErrorString);
+    }
+
     // Get english translated expression 
     String^ englishString = LocalizationSettings::GetInstance().GetEnglishValueFromLocalizedDigits(pasteExpression);
 


### PR DESCRIPTION
The calculator accepts numbers with '.' even if the local decimal separator is different (',' in French for example).

The character will then be ignored by `StandardCalculatorViewModel::OnPaste` and will display a faulty result.

- This is import for a big part of Europe, Africa and South america where ',' is used as a decimal separator, it's probably better to reject the text pasted (copied from an US website for example, etc..) rather than display a faulty result.
   - A future improvement can be to inform users than the string uses the wrong format and ask them they accept the app to automatically convert it.
 
![image](https://user-images.githubusercontent.com/1226538/53939585-5c403900-4068-11e9-882a-4839272f6821.png)
_Left: current version, Right: modified version._