### PR TITLE
Removed duplicate zeros in Margin and Paddings

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -13,7 +13,7 @@
             </ResourceDictionary.MergedDictionaries>
             <ResourceDictionary.ThemeDictionaries>
                 <ResourceDictionary x:Key="Default">
-                    <Thickness x:Key="HighContrastThicknessTop">0,0,0,0</Thickness>
+                    <Thickness x:Key="HighContrastThicknessTop">0</Thickness>
                     <x:Double x:Key="HighContrastStrokeThickness">0</x:Double>
                     <Color x:Key="AltHighColor">#FF000000</Color>
                     <Color x:Key="ChromeMediumLowColor">#FF2B2B2B</Color>
@@ -45,7 +45,7 @@
                                   TintOpacity="0.7"/>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Light">
-                    <Thickness x:Key="HighContrastThicknessTop">0,0,0,0</Thickness>
+                    <Thickness x:Key="HighContrastThicknessTop">0</Thickness>
                     <x:Double x:Key="HighContrastStrokeThickness">0</x:Double>
                     <Color x:Key="AltHighColor">#FFF2F2F2</Color>
                     <Color x:Key="ChromeMediumLowColor">#FFE0E0E0</Color>
@@ -381,7 +381,7 @@
                                 </VisualStateManager.VisualStateGroups>
                                 <ScrollViewer x:Name="textContainer"
                                               Grid.Column="1"
-                                              Padding="0,0,0,0"
+                                              Padding="0"
                                               Style="{ThemeResource ResultsScrollerSnapped}"
                                               AutomationProperties.AccessibilityView="Raw">
                                     <TextBlock x:Name="normalOutput"
@@ -467,7 +467,7 @@
                                 </VisualStateManager.VisualStateGroups>
                                 <ScrollViewer x:Name="textContainer"
                                               Grid.Column="1"
-                                              Padding="0,0,0,0"
+                                              Padding="0"
                                               Style="{ThemeResource ResultsScrollerSnapped}"
                                               AutomationProperties.AccessibilityView="Raw">
                                     <TextBlock x:Name="normalOutput"
@@ -554,7 +554,7 @@
                                 </VisualStateManager.VisualStateGroups>
                                 <ScrollViewer x:Name="textContainer"
                                               Grid.Column="1"
-                                              Padding="0,0,0,0"
+                                              Padding="0"
                                               Style="{ThemeResource ResultsScrollerSnapped}"
                                               AutomationProperties.AccessibilityView="Raw">
                                     <TextBlock x:Name="normalOutput"
@@ -1222,7 +1222,7 @@
                                            Opacity="0"
                                            IsHitTestVisible="False"/>
                                 <Grid x:Name="ContentPresenterGrid"
-                                      Margin="0,0,0,0"
+                                      Margin="0"
                                       Background="Transparent">
                                     <Grid.RenderTransform>
                                         <TranslateTransform x:Name="ContentPresenterTranslateTransform"/>

--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -150,7 +150,7 @@
                                 </Grid.ColumnDefinitions>
                                 <ScrollViewer x:Name="expressionContainer"
                                               Grid.Column="1"
-                                              Padding="0,0,0,0"
+                                              Padding="0"
                                               VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                               Style="{StaticResource ResultsScrollerSnapped}"
                                               AutomationProperties.AccessibilityView="Raw"
@@ -265,7 +265,7 @@
             <Setter Property="FontSize" Value="{StaticResource CalcResultFontSizeL}"/>
             <Setter Property="MinFontSize" Value="12"/>
             <Setter Property="IsActive" Value="True"/>
-            <Setter Property="DisplayMargin" Value="0,0,0,0"/>
+            <Setter Property="DisplayMargin" Value="0"/>
             <Setter Property="MaxExpressionHistoryCharacters" Value="51"/>
         </Style>
 
@@ -278,7 +278,7 @@
             <Setter Property="FontSize" Value="{StaticResource CalcResultFontSizeM}"/>
             <Setter Property="MinFontSize" Value="12"/>
             <Setter Property="IsActive" Value="True"/>
-            <Setter Property="DisplayMargin" Value="0,0,0,0"/>
+            <Setter Property="DisplayMargin" Value="0"/>
             <Setter Property="MaxExpressionHistoryCharacters" Value="30"/>
         </Style>
 
@@ -291,7 +291,7 @@
             <Setter Property="FontSize" Value="{StaticResource CalcResultFontSizeS}"/>
             <Setter Property="MinFontSize" Value="12"/>
             <Setter Property="IsActive" Value="True"/>
-            <Setter Property="DisplayMargin" Value="0,0,0,0"/>
+            <Setter Property="DisplayMargin" Value="0"/>
             <Setter Property="MaxExpressionHistoryCharacters" Value="30"/>
         </Style>
 
@@ -299,7 +299,7 @@
 
         <Style x:Key="ScrollButtonStyle" TargetType="Button">
             <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="Padding" Value="0,0,0,0"/>
+            <Setter Property="Padding" Value="0"/>
             <Setter Property="VerticalAlignment" Value="Center"/>
             <Setter Property="VerticalContentAlignment" Value="Center"/>
             <Setter Property="HorizontalContentAlignment" Value="Center"/>
@@ -628,7 +628,7 @@
             <controls:CalculationResult x:Name="Results"
                                         x:Uid="CalculatorResults"
                                         Grid.Row="2"
-                                        Margin="0,0,0,0"
+                                        Margin="0"
                                         Style="{ThemeResource ResultsStyleM}"
                                         AutomationProperties.AutomationId="CalculatorResults"
                                         AutomationProperties.HeadingLevel="Level1"

--- a/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml
@@ -23,7 +23,7 @@
             <Setter Property="FontSize" Value="20"/>
             <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundTransparentBrush}"/>
-            <Setter Property="Padding" Value="0,0,0,0"/>
+            <Setter Property="Padding" Value="0"/>
             <Setter Property="MinWidth" Value="12"/>
             <Setter Property="MinHeight" Value="20"/>
             <Setter Property="HorizontalAlignment" Value="Stretch"/>

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -21,7 +21,7 @@
         </DataTemplate>
 
         <Style x:Key="DateCalculation_ComboStyle" TargetType="ComboBox">
-            <Setter Property="Padding" Value="0,0,0,0"/>
+            <Setter Property="Padding" Value="0"/>
             <Setter Property="MinHeight" Value="20"/>
             <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
             <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundTransparentBrush}"/>
@@ -242,7 +242,7 @@
                                                             </VisualStateManager.VisualStateGroups>
                                                             <ContentPresenter Grid.Row="1"
                                                                               Grid.Column="1"
-                                                                              Margin="0,0,0,0"
+                                                                              Margin="0"
                                                                               HorizontalAlignment="Stretch"
                                                                               VerticalAlignment="Top"
                                                                               Background="{ThemeResource SystemControlBackgroundChromeMediumLowBrush}"
@@ -440,7 +440,7 @@
                        TextWrapping="Wrap"/>
             <CalendarDatePicker x:Name="DateDiff_ToDate"
                                 Grid.Row="5"
-                                Margin="0,0,0,0"
+                                Margin="0"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
                                 AutomationProperties.LabeledBy="{x:Bind Date_ToLabel}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
@@ -450,7 +450,7 @@
             <!-- Difference Result -->
             <TextBlock x:Uid="Date_DifferenceLabel"
                        Grid.Row="7"
-                       Margin="0,0,0,0"
+                       Margin="0"
                        Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"/>
             <TextBlock x:Name="DateDiffAllUnitsResultLabel"
                        Grid.Row="8"
@@ -498,7 +498,7 @@
                        TextWrapping="Wrap"/>
             <CalendarDatePicker x:Name="AddSubtract_FromDate"
                                 Grid.Row="2"
-                                Margin="0,0,0,0"
+                                Margin="0"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
                                 AutomationProperties.LabeledBy="{x:Bind AddSubtract_Date_FromLabel}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"

--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -19,12 +19,12 @@
     <Page.Resources>
         <automation:NarratorNotifier x:Name="NarratorNotifier"/>
         <Style x:Name="CalculatorBaseStyle" TargetType="local:Calculator">
-            <Setter Property="Margin" Value="0,0,0,0"/>
+            <Setter Property="Margin" Value="0"/>
         </Style>
         <Style x:Name="UnitConverterBaseStyle" TargetType="local:UnitConverter">
             <Setter Property="Visibility" Value="Collapsed"/>
             <Setter Property="IsEnabled" Value="False"/>
-            <Setter Property="Margin" Value="0,0,0,0"/>
+            <Setter Property="Margin" Value="0"/>
         </Style>
         <Style x:Key="AboutFlyoutPresenterStyle" TargetType="FlyoutPresenter">
             <Setter Property="IsTabStop" Value="False"/>

--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -203,7 +203,7 @@
             <Setter Property="FontWeight" Value="Light"/>
             <Setter Property="HorizontalContentAlignment" Value="Left"/>
             <Setter Property="VerticalContentAlignment" Value="Bottom"/>
-            <Setter Property="Margin" Value="0,0,0,0"/>
+            <Setter Property="Margin" Value="0"/>
             <Setter Property="DisplayMargin" Value="0,0,0,4"/>
         </Style>
         <Style x:Key="ValueSmallStyle"
@@ -216,7 +216,7 @@
             <Setter Property="FontWeight" Value="Light"/>
             <Setter Property="HorizontalContentAlignment" Value="Left"/>
             <Setter Property="VerticalContentAlignment" Value="Bottom"/>
-            <Setter Property="Margin" Value="0,0,0,0"/>
+            <Setter Property="Margin" Value="0"/>
             <Setter Property="DisplayMargin" Value="0,0,0,4"/>
         </Style>
 


### PR DESCRIPTION
## Fixes #.


### Description of the changes:
Removed unuseful duplicated zeros for Margin and Paddings which they're same, like `0,0,0,0` and `0`.

### How changes were validated:

1. As said [here](https://docs.microsoft.com/en-us/dotnet/api/system.windows.frameworkelement.margin?view=netframework-4.7.2#xaml-values) in Microsoft Docs:

> For instance, Margin="20" will be interpreted to mean a Thickness with all properties set to 20.

2. Double checked all the views manually.