### PR TITLE
Fix small Dutch translation error

### DIFF
--- a/src/Calculator/Resources/nl-NL/CEngineStrings.resw
+++ b/src/Calculator/Resources/nl-NL/CEngineStrings.resw
@@ -142,7 +142,7 @@
     <comment>Same 101</comment>
   </data>
   <data name="119" xml:space="preserve">
-    <value>Overflow</value>
+    <value>Overloop</value>
     <comment>Same as 107</comment>
   </data>
   <data name="120" xml:space="preserve">


### PR DESCRIPTION
## Fixes #.
Everywhere _overflow_ was neatly translated to _overloop_, except on one
oversight. This small commit fixes that.

### Description of the changes:
 * A single string

### How changes were validated:
Not applicable
