### PR TITLE
Fix #178: Wrong Date Calculation on last Saturday to Sunday in March

### DIFF
--- a/src/CalcViewModel/Common/DateCalculator.cpp
+++ b/src/CalcViewModel/Common/DateCalculator.cpp
@@ -206,7 +206,8 @@ void DateCalculationEngine::GetDateDifference(_In_ DateTime date1, _In_ DateTime
 int DateCalculationEngine::GetDifferenceInDays(DateTime date1, DateTime date2)
 {
     // A tick is defined as the number of 100 nanoseconds
-    long long ticksDifference = date2.UniversalTime - date1.UniversalTime;
+    // Add one hour to the difference to have correct number of days when change of daylight time (winter to summer) happens between date1 and date2
+    long long ticksDifference = date2.UniversalTime - date1.UniversalTime + c_hour;
     return static_cast<int>(ticksDifference / static_cast<long long>(c_day));
 }
 


### PR DESCRIPTION
## Fixes #178.

Solve issue [#178](https://github.com/Microsoft/calculator/issues/178)

### Description of the changes:
- Include daylight time support in date difference calculation (when switching from winter to summer)

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

Manual testing

**Before change :** 

![image](https://user-images.githubusercontent.com/2892643/53987432-45a9e880-4121-11e9-9c2e-244939694a64.png)

![image](https://user-images.githubusercontent.com/2892643/53987455-59ede580-4121-11e9-921e-2123e0e55de1.png)

**After Change:**

![image](https://user-images.githubusercontent.com/2892643/53987240-bb618480-4120-11e9-8114-fc3ef66937d4.png)

![image](https://user-images.githubusercontent.com/2892643/53987311-ed72e680-4120-11e9-84c4-d31537d8f93d.png)
