### PR TITLE
Fixes Issue #162 Pasting long decimal number results in Invalid input

### DIFF
--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -307,11 +307,12 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
             // or which will break conversion from string-to-ULL.
             wstring operandValue = SanitizeOperand(operand);
 
-            // If an operand exceeds the maximum length allowed, break and return.
-            if (OperandLength(operandValue, mode, modeType, programmerNumberBase) > maxOperandLength)
+            // If an operand exceeds the maximum length allowed, trim it to its allowed length.
+            size_t OperandLen = OperandLength(operandValue, mode, modeType, programmerNumberBase);
+            if (OperandLen > maxOperandLength)
             {
-                expMatched = false;
-                break;
+                // Try to trim the length to allowed length
+                TrimOperand(operandValue, OperandLen - maxOperandLength);
             }
 
             // If maxOperandValue is set and the operandValue exceeds it, break and return.
@@ -337,6 +338,11 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
     }
 
     return expMatched;
+}
+
+void CopyPasteManager::TrimOperand(std::wstring& operand, size_t exceededBy)
+{
+    operand = operand.substr(0, operand.length() - exceededBy);
 }
 
 pair<size_t, uint64_t> CopyPasteManager::GetMaxOperandLengthAndValue(ViewMode mode, CategoryGroupType modeType, int programmerNumberBase, int bitLengthType)

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -58,6 +58,7 @@ namespace CalculatorApp
         static size_t OperandLength(std::wstring operand, CalculatorApp::Common::ViewMode mode, CalculatorApp::Common::CategoryGroupType modeType, int programmerNumberBase = -1);
         static size_t StandardScientificOperandLength(std::wstring operand);
         static size_t ProgrammerOperandLength(const std::wstring& operand, int numberBase);
+        static void TrimOperand(std::wstring& operand, size_t exceededBy);
 
         static constexpr size_t MaxStandardOperandLength = 16;
         static constexpr size_t MaxScientificOperandLength = 32;


### PR DESCRIPTION
## Fixes #162.
Change has been made to retrieve a substring of the given string by considering its maximum length.

### Summary of the issue 
When pasting a long decimal number, the calculator display shows "Invalid Input".

### Description of the changes:
Added the following in a function to trim.
`operand = operand.substr(0, operand.length() - exceededBy);`

### How changes were validated:
- Tested with long operands, whose values will be trimmed when the length exceeds the maximum value. 
- Also tested by giving long invalid numbers (like 0.23459288484823nj) to make sure they are still treated as "Invalid Inputs".

Note: Further modifications to the UnitTests will be made once this change is agreed.