### PR TITLE
Fixed Mismatched operator new[] and delete #173

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -505,7 +505,7 @@ void StandardCalculatorViewModel::HandleUpdatedOperandData(Command cmdenum)
         {
             if (commandIndex == 0)
             {
-                delete temp;
+                delete[] temp;
                 return;
             }
 


### PR DESCRIPTION
Added [] to delete statement to fix Issue # 173.

## Fixes #173 


### Description of the changes:
- Just added [] to the delete statement.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Ran and passed all unit tests.
- Built the solution, made sure there was no build errors.
- Did a few manual tests for sanity.

