### PR TITLE
Activate TextSelection on all interesting values/results

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -566,7 +566,7 @@
                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                Foreground="{TemplateBinding Foreground}"
                                                FontSize="{TemplateBinding FontSize}"
-                                               FontWeight="SemiBold"
+                                               FontWeight="Light"
                                                AutomationProperties.AccessibilityView="Raw"
                                                Text="{TemplateBinding DisplayValue}"
                                                TextAlignment="{TemplateBinding HorizontalContentAlignment}"

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -392,6 +392,7 @@
                                                FontSize="{TemplateBinding FontSize}"
                                                FontWeight="SemiBold"
                                                AutomationProperties.AccessibilityView="Raw"
+                                               IsTextSelectionEnabled="True"
                                                Text="{TemplateBinding DisplayValue}"
                                                TextAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                TextWrapping="NoWrap"/>
@@ -478,6 +479,7 @@
                                                FontSize="{TemplateBinding FontSize}"
                                                FontWeight="SemiBold"
                                                AutomationProperties.AccessibilityView="Raw"
+                                               IsTextSelectionEnabled="True"
                                                Text="{TemplateBinding DisplayValue}"
                                                TextAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                TextWrapping="NoWrap"/>
@@ -565,6 +567,7 @@
                                                FontSize="{TemplateBinding FontSize}"
                                                FontWeight="SemiBold"
                                                AutomationProperties.AccessibilityView="Raw"
+                                               IsTextSelectionEnabled="True"
                                                Text="{TemplateBinding DisplayValue}"
                                                TextAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                TextWrapping="NoWrap"/>

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -371,12 +371,13 @@
                                 </Grid.ColumnDefinitions>
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="ActiveStates">
-                                        <VisualState x:Name="Active"/>
-                                        <VisualState x:Name="Normal">
+                                        <VisualState x:Name="Active">
                                             <VisualState.Setters>
-                                                <Setter Target="normalOutput.FontWeight" Value="Light"/>
+                                                <Setter Target="normalOutput.FontWeight" Value="SemiBold"/>
+                                                <Setter Target="normalOutput.IsTextSelectionEnabled" Value="True"/>
                                             </VisualState.Setters>
                                         </VisualState>
+                                        <VisualState x:Name="Normal"/>
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
                                 <ScrollViewer x:Name="textContainer"
@@ -390,9 +391,8 @@
                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                Foreground="{TemplateBinding Foreground}"
                                                FontSize="{TemplateBinding FontSize}"
-                                               FontWeight="SemiBold"
+                                               FontWeight="Light"
                                                AutomationProperties.AccessibilityView="Raw"
-                                               IsTextSelectionEnabled="True"
                                                Text="{TemplateBinding DisplayValue}"
                                                TextAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                TextWrapping="NoWrap"/>
@@ -458,12 +458,13 @@
                                 </Grid.ColumnDefinitions>
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="ActiveStates">
-                                        <VisualState x:Name="Active"/>
-                                        <VisualState x:Name="Normal">
+                                        <VisualState x:Name="Active">
                                             <VisualState.Setters>
-                                                <Setter Target="normalOutput.FontWeight" Value="Light"/>
+                                                <Setter Target="normalOutput.IsTextSelectionEnabled" Value="True"/>
+                                                <Setter Target="normalOutput.FontWeight" Value="SemiBold"/>
                                             </VisualState.Setters>
                                         </VisualState>
+                                        <VisualState x:Name="Normal"/>
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
                                 <ScrollViewer x:Name="textContainer"
@@ -477,9 +478,8 @@
                                                VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
                                                Foreground="{TemplateBinding Foreground}"
                                                FontSize="{TemplateBinding FontSize}"
-                                               FontWeight="SemiBold"
+                                               FontWeight="Light"
                                                AutomationProperties.AccessibilityView="Raw"
-                                               IsTextSelectionEnabled="True"
                                                Text="{TemplateBinding DisplayValue}"
                                                TextAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                TextWrapping="NoWrap"/>
@@ -546,12 +546,13 @@
                                 </Grid.ColumnDefinitions>
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="ActiveStates">
-                                        <VisualState x:Name="Active"/>
-                                        <VisualState x:Name="Normal">
+                                        <VisualState x:Name="Active">
                                             <VisualState.Setters>
-                                                <Setter Target="normalOutput.FontWeight" Value="Light"/>
+                                                <Setter Target="normalOutput.FontWeight" Value="SemiBold"/>
+                                                <Setter Target="normalOutput.IsTextSelectionEnabled" Value="True"/>
                                             </VisualState.Setters>
                                         </VisualState>
+                                        <VisualState x:Name="Normal"/>
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
                                 <ScrollViewer x:Name="textContainer"
@@ -567,7 +568,6 @@
                                                FontSize="{TemplateBinding FontSize}"
                                                FontWeight="SemiBold"
                                                AutomationProperties.AccessibilityView="Raw"
-                                               IsTextSelectionEnabled="True"
                                                Text="{TemplateBinding DisplayValue}"
                                                TextAlignment="{TemplateBinding HorizontalContentAlignment}"
                                                TextWrapping="NoWrap"/>

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -595,8 +595,7 @@
             <!-- Resulting Date -->
             <TextBlock x:Uid="DateLabel"
                        Grid.Row="8"
-                       Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
-                       IsTextSelectionEnabled="True"/>
+                       Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"/>
 
             <TextBlock x:Name="DateResultLabel"
                        Grid.Row="9"

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -459,11 +459,13 @@
                        AutomationProperties.LiveSetting="Polite"
                        AutomationProperties.Name="{Binding StrDateDiffResultAutomationName}"
                        ContextFlyout="{StaticResource ResultsContextMenu}"
+                       IsTextSelectionEnabled="True"
                        Text="{Binding StrDateDiffResult}"/>
             <TextBlock Grid.Row="10"
                        Style="{ThemeResource BaseTextBlockStyle}"
                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                        ContextFlyout="{StaticResource ResultsContextMenu}"
+                       IsTextSelectionEnabled="True"
                        Text="{Binding StrDateDiffResultInDays, Mode=OneWay}"
                        Visibility="{Binding IsDiffInDays, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
         </Grid>
@@ -593,7 +595,8 @@
             <!-- Resulting Date -->
             <TextBlock x:Uid="DateLabel"
                        Grid.Row="8"
-                       Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"/>
+                       Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
+                       IsTextSelectionEnabled="True"/>
 
             <TextBlock x:Name="DateResultLabel"
                        Grid.Row="9"
@@ -602,6 +605,7 @@
                        AutomationProperties.LiveSetting="Polite"
                        AutomationProperties.Name="{Binding StrDateResultAutomationName}"
                        ContextFlyout="{StaticResource ResultsContextMenu}"
+                       IsTextSelectionEnabled="True"
                        Text="{Binding StrDateResult}"/>
         </Grid>
     </Grid>

--- a/src/Calculator/Views/HistoryList.xaml
+++ b/src/Calculator/Views/HistoryList.xaml
@@ -64,6 +64,7 @@
                                 ContextFlyout="{StaticResource HistoryContextMenu}">
                         <TextBlock x:Name="exprTextBlock"
                                    Margin="0,0,0,4"
+                                   HorizontalAlignment="Right"
                                    Style="{ThemeResource BodyTextBlockMediumStyle}"
                                    AutomationProperties.Name="{x:Bind AccExpression}"
                                    IsTextSelectionEnabled="True"
@@ -71,6 +72,7 @@
                                    TextAlignment="Right"
                                    TextWrapping="Wrap"/>
                         <TextBlock x:Name="resultTextBlock"
+                                   HorizontalAlignment="Right"
                                    Style="{ThemeResource TitleTextBlockStyle}"
                                    FontWeight="SemiBold"
                                    AutomationProperties.Name="{x:Bind AccResult}"

--- a/src/Calculator/Views/HistoryList.xaml
+++ b/src/Calculator/Views/HistoryList.xaml
@@ -66,6 +66,7 @@
                                    Margin="0,0,0,4"
                                    Style="{ThemeResource BodyTextBlockMediumStyle}"
                                    AutomationProperties.Name="{x:Bind AccExpression}"
+                                   IsTextSelectionEnabled="True"
                                    Text="{x:Bind Expression}"
                                    TextAlignment="Right"
                                    TextWrapping="Wrap"/>
@@ -73,6 +74,7 @@
                                    Style="{ThemeResource TitleTextBlockStyle}"
                                    FontWeight="SemiBold"
                                    AutomationProperties.Name="{x:Bind AccResult}"
+                                   IsTextSelectionEnabled="True"
                                    Text="{x:Bind Result}"
                                    TextAlignment="Right"
                                    TextWrapping="Wrap"/>

--- a/src/Calculator/Views/MemoryListItem.xaml
+++ b/src/Calculator/Views/MemoryListItem.xaml
@@ -59,6 +59,7 @@
                        Style="{ThemeResource TitleTextBlockStyle}"
                        FontWeight="SemiBold"
                        FlowDirection="LeftToRight"
+                       IsTextSelectionEnabled="True"
                        Text="{x:Bind Model.Value, Mode=OneWay}"
                        TextAlignment="Right"
                        TextReadingOrder="DetectFromContent"

--- a/src/Calculator/Views/MemoryListItem.xaml
+++ b/src/Calculator/Views/MemoryListItem.xaml
@@ -56,6 +56,7 @@
                 <RowDefinition Height="Auto"/>
             </Grid.RowDefinitions>
             <TextBlock Margin="0,2,14,0"
+                       HorizontalAlignment="Right"
                        Style="{ThemeResource TitleTextBlockStyle}"
                        FontWeight="SemiBold"
                        FlowDirection="LeftToRight"


### PR DESCRIPTION
Fixes #223 

Ctrl+C is already supported in the app, but:
- not Tablet/Device without keyboard-friendly
- It's not really easy to guess that you can Ctrl+C without selecting the result.
- You can't copy an operation in the history
- You can't copy a part of a result (to ignore the fractional part of a number for example)

If we allow users to select texts, the application will feel more like a "Desktop app", will be easier to use on a tablet and users will be more prompt to use Ctrl+C to use the result in another app. 

![2702B760-4B01-4F28-B444-05728DA30F76](https://user-images.githubusercontent.com/1226538/54065190-025b8280-41d2-11e9-8869-4029cf4532ea.GIF)

## Note:
I didn't enabled TextSelection on `CalculationResult` when the control isn't "active" (text in bold), if we do,  the textblock can't catch the `Tap` events on the textblock, needed to allow users to activate the control.