### PR TITLE
Eliminate redundant copies of EMPTY_UNIT object, saving 2.5 KB.

### DIFF
--- a/src/CalcManager/UnitConverter.h
+++ b/src/CalcManager/UnitConverter.h
@@ -51,7 +51,7 @@ namespace UnitConversionManager
     // null checks.
     //
     // unitId, name, abbreviation, isConversionSource, isConversionTarget, isWhimsical
-    extern __declspec(selectany) const Unit EMPTY_UNIT = Unit{ -1, L"", L"", true, true, false };
+    inline const Unit EMPTY_UNIT = Unit{ -1, L"", L"", true, true, false };
 
     struct Category
     {

--- a/src/CalcManager/UnitConverter.h
+++ b/src/CalcManager/UnitConverter.h
@@ -51,7 +51,7 @@ namespace UnitConversionManager
     // null checks.
     //
     // unitId, name, abbreviation, isConversionSource, isConversionTarget, isWhimsical
-    const Unit EMPTY_UNIT = Unit{ -1, L"", L"", true, true, false };
+    extern __declspec(selectany) const Unit EMPTY_UNIT = Unit{ -1, L"", L"", true, true, false };
 
     struct Category
     {


### PR DESCRIPTION
### Description of the changes:

There are currently 11 copies of the `EMPTY_UNIT` object in the
`Calculator.exe` binary, which not only wastes space/footprint in the
binary itself, but also means that each copy must be separately
initialized, which effects performance.

The reason for this is that the object is defined in a shared header
file, which then is included by multiple .cpp files, causing each
translation unit (.obj) to get a full complete copy of the object.

By marking the object as `inline` we can
instruct the linker to define the object once, as we do
not need to have 11 unique versions of the EMPTY_UNIT object,
we only need 1.

The net result is that the `Calculator.exe` binary size is reduced by
2,560 bytes (or 2.5 KB) with no change in behavior, other than
the small performance benefit of not initializing 10 redundant copies
of the object.

### How changes were validated:
- Manually tested.
