### PR TITLE
Fix formatting issues with CurrencyConverter and some locales

### DIFF
--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -53,6 +53,7 @@ constexpr size_t SELECTED_TARGET_UNIT = 2;
 
 // x millisecond delay before we consider conversion to be final
 constexpr unsigned int CONVERSION_FINALIZED_DELAY_IN_MS = 1000;
+const wregex regexTrimSpacesStart = wregex(L"^\\s+");
 const wregex regexTrimSpacesEnd = wregex(L"\\s+$");
 
 namespace CalculatorApp::ViewModel
@@ -350,9 +351,13 @@ String^ UnitConverterViewModel::ConvertToLocalizedString(const std::wstring& str
             {
                 currencyResult.erase(pos, currencyCode.length());
                 std::wsmatch sm;
+                if (regex_search(currencyResult, sm, regexTrimSpacesStart))
+                {
+                    currencyResult.erase(sm.prefix().length(), sm.length());
+                }
+
                 if (regex_search(currencyResult, sm, regexTrimSpacesEnd))
                 {
-                    currencyResult.erase(pos, 1);
                     currencyResult.erase(sm.prefix().length(), sm.length());
                 }
             }

--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -53,6 +53,7 @@ constexpr size_t SELECTED_TARGET_UNIT = 2;
 
 // x millisecond delay before we consider conversion to be final
 constexpr unsigned int CONVERSION_FINALIZED_DELAY_IN_MS = 1000;
+const wregex regexTrimSpacesEnd = wregex(L"\\s+$");
 
 namespace CalculatorApp::ViewModel
 {
@@ -348,10 +349,11 @@ String^ UnitConverterViewModel::ConvertToLocalizedString(const std::wstring& str
             if (pos != wstring::npos)
             {
                 currencyResult.erase(pos, currencyCode.length());
-                pos = currencyResult.find(L'\u00a0'); // non-breaking space
-                if (pos != wstring::npos)
+                std::wsmatch sm;
+                if (regex_search(currencyResult, sm, regexTrimSpacesEnd))
                 {
                     currencyResult.erase(pos, 1);
+                    currencyResult.erase(sm.prefix().length(), sm.length());
                 }
             }
 


### PR DESCRIPTION
## Fixes #240 and #232 

The ViewModel wrongly assumed that non-breaking spaces were only used between the value and the symbol. It's not the case of all locales using non-breaking spaces as a thousand delimiter (French for example).

When it was the case, the function only replaced the first thousand delimiter found and kept the extra space at the end of the string, generating 2 issues:

- Extra space at the end: https://github.com/Microsoft/calculator/issues/240 
- Bad formatting of the number: https://github.com/Microsoft/calculator/issues/232

### Description of the changes:

Replace `currencyResult.find(L'\u00a0')` by a regex only removing spaces at the end of the string.

### Screenshots
Before:

![image](https://user-images.githubusercontent.com/1226538/54079359-d4d50e80-428f-11e9-8780-53dfbc82599e.png)

After:

![image](https://user-images.githubusercontent.com/1226538/54079342-9f302580-428f-11e9-8856-2e7564a59eb7.png)
