### PR TITLE
CopyPasteManagerTest fails to test all values

### DIFF
--- a/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
+++ b/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
@@ -25,30 +25,17 @@ namespace CalculatorUnitTests
 
 #define ASSERT_POSITIVE_TESTCASES(func, dataSet) \
 {\
-    int size = sizeof(dataSet)/sizeof(*dataSet);\
-    while(--size >= 0)\
+    for(auto data : dataSet)\
     {\
-        VERIFY_ARE_EQUAL(func(dataSet[size]), dataSet[size]);\
+        VERIFY_ARE_EQUAL(func(data), data);\
     }\
 }
 
 #define ASSERT_NEGATIVE_TESTCASES(func, dataSet) \
 {\
-    int size = sizeof(dataSet)/sizeof(*dataSet);\
-    while(--size >= 0)\
+    for(auto data : dataSet)\
     {\
-        VERIFY_ARE_EQUAL(func(dataSet[size]), StringReference(L"NoOp"));\
-    }\
-}
-
-// returns a iterator from end
-#define START_LOOP(dataSet)\
-{\
-    int size = sizeof(dataSet)/sizeof(*dataSet);\
-    while(--size >= 0)\
-    {
-
-#define END_LOOP\
+        VERIFY_ARE_EQUAL(func(data), StringReference(L"NoOp"));\
     }\
 }
 
@@ -450,15 +437,16 @@ namespace CalculatorUnitTests
         // Doesn't have test where converter is involved. Will add such a test later.
         StandardCalculatorViewModel^ scvm = ref new StandardCalculatorViewModel();
         scvm->IsStandard = true;
-        String^ input[] = { L"123", L"12345", L"123+456", L"1,234", L"1 2 3", L"\n\r1,234\n", L"\n 1+\n2 ", L"1\"2" };
+        String^ inputs[] = { L"123", L"12345", L"123+456", L"1,234", L"1 2 3", L"\n\r1,234\n", L"\n 1+\n2 ", L"1\"2" };
 
-        START_LOOP(input)
+        for (String^ &input : inputs)
+        {
             // paste number in standard mode and then validate the pastability of displayed number for other modes
-            scvm->OnPaste(input[size], ViewMode::Standard);
+            scvm->OnPaste(input, ViewMode::Standard);
             VERIFY_ARE_EQUAL(ValidateStandardPasteExpression(scvm->DisplayValue), scvm->DisplayValue);
             VERIFY_ARE_EQUAL(ValidateScientificPasteExpression(scvm->DisplayValue), scvm->DisplayValue);
             VERIFY_ARE_EQUAL(ValidateProgrammerHexQwordPasteExpression(scvm->DisplayValue), scvm->DisplayValue);
-        END_LOOP
+        }
     }
 
 

--- a/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
+++ b/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
@@ -26,7 +26,7 @@ namespace CalculatorUnitTests
 #define ASSERT_POSITIVE_TESTCASES(func, dataSet) \
 {\
     int size = sizeof(dataSet)/sizeof(*dataSet);\
-    while(--size)\
+    while(--size >= 0)\
     {\
         VERIFY_ARE_EQUAL(func(dataSet[size]), dataSet[size]);\
     }\
@@ -35,7 +35,7 @@ namespace CalculatorUnitTests
 #define ASSERT_NEGATIVE_TESTCASES(func, dataSet) \
 {\
     int size = sizeof(dataSet)/sizeof(*dataSet);\
-    while(--size)\
+    while(--size >= 0)\
     {\
         VERIFY_ARE_EQUAL(func(dataSet[size]), StringReference(L"NoOp"));\
     }\
@@ -45,7 +45,7 @@ namespace CalculatorUnitTests
 #define START_LOOP(dataSet)\
 {\
     int size = sizeof(dataSet)/sizeof(*dataSet);\
-    while(--size)\
+    while(--size >= 0)\
     {
 
 #define END_LOOP\


### PR DESCRIPTION
CopyPasteManager unit tests were not fully run, the first item of arrays were never tested. (Luckily, the not-tested values were ok).

### Description of the changes:

`while(--size)`
the following code won't run the code in the loop with `size==0`.

Instead we should use:
`while(--size >= 0)`

**Before** (first value not tested):
![image](https://user-images.githubusercontent.com/1226538/54172460-646af080-443b-11e9-930f-2e245cd31c7c.png)


**After** (the test fails as expected):
![image](https://user-images.githubusercontent.com/1226538/54172389-15bd5680-443b-11e9-90f8-3e6972a07362.png)
