### PR TITLE
Fixes #282 Narrator does not convey error information when no more Right Parenthesis can be added in expression.

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -546,7 +546,7 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam)
         {
             if (!m_openParenCount && !nx)
             {
-                m_pCalcDisplay->OnNoParenAdded();
+                m_pCalcDisplay->OnNoRightParenAdded();
             }
 
             HandleErrorCommand(wParam);

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -544,6 +544,11 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam)
         if ((m_openParenCount >= MAXPRECDEPTH && nx) || (!m_openParenCount && !nx)
             || ((m_precedenceOpCount >= MAXPRECDEPTH && m_nPrecOp[m_precedenceOpCount - 1] != 0)))
         {
+            if (!m_openParenCount && !nx)
+            {
+                m_pCalcDisplay->OnNoParenAdded();
+            }
+
             HandleErrorCommand(wParam);
             break;
         }

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -118,6 +118,15 @@ namespace CalculationManager
     }
 
     /// <summary>
+    /// Callback from the engine
+    /// Used to set the narrator text when no parenthesis can be added
+    /// </summary>
+    void CalculatorManager::OnNoParenAdded()
+    {
+        m_displayCallback->OnNoParenAdded();
+    }
+
+    /// <summary>
     /// Reset CalculatorManager.
     /// Set the mode to the standard calculator
     /// Set the degree mode as regular degree (as oppose to Rad or Grad)

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -118,7 +118,6 @@ namespace CalculationManager
 
     /// <summary>
     /// Callback from the engine
-    /// Used to set the narrator text when no parenthesis can be added
     /// </summary>
     void CalculatorManager::OnNoRightParenAdded()
     {

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -109,7 +109,6 @@ namespace CalculationManager
 
     /// <summary>
     /// Callback from the engine
-    /// Used to set the current unmatched open parenthesis count
     /// </summary>
     /// <param name="parenthesisCount">string containing the parenthesis count</param>
     void CalculatorManager::SetParenDisplayText(const wstring& parenthesisCount)
@@ -121,9 +120,9 @@ namespace CalculationManager
     /// Callback from the engine
     /// Used to set the narrator text when no parenthesis can be added
     /// </summary>
-    void CalculatorManager::OnNoParenAdded()
+    void CalculatorManager::OnNoRightParenAdded()
     {
-        m_displayCallback->OnNoParenAdded();
+        m_displayCallback->OnNoRightParenAdded();
     }
 
     /// <summary>

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -95,7 +95,7 @@ namespace CalculationManager
         void SetMemorizedNumbers(_In_ const std::vector<std::wstring>& memorizedNumbers) override;
         void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) override;
         void SetParenDisplayText(const std::wstring& parenthesisCount) override;
-        void OnNoParenAdded() override;
+        void OnNoRightParenAdded() override;
         void DisplayPasteError();
         void MaxDigitsReached() override;
         void BinaryOperatorReceived() override;

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -42,7 +42,7 @@ namespace CalculationManager
         MemorizedNumberClear = 335
     };
 
-    class CalculatorManager sealed : public virtual ICalcDisplay
+    class CalculatorManager sealed : public ICalcDisplay
     {
     private:
         ICalcDisplay* const m_displayCallback;
@@ -94,7 +94,8 @@ namespace CalculationManager
         void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands) override;
         void SetMemorizedNumbers(_In_ const std::vector<std::wstring>& memorizedNumbers) override;
         void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) override;
-        void SetParenDisplayText(const std::wstring& parenthesisCount);
+        void SetParenDisplayText(const std::wstring& parenthesisCount) override;
+        void OnNoParenAdded() override;
         void DisplayPasteError();
         void MaxDigitsReached() override;
         void BinaryOperatorReceived() override;

--- a/src/CalcManager/Header Files/ICalcDisplay.h
+++ b/src/CalcManager/Header Files/ICalcDisplay.h
@@ -13,6 +13,7 @@ public:
     virtual void SetIsInError(bool isInError) = 0;
     virtual void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands) = 0;
     virtual void SetParenDisplayText(const std::wstring& pszText) = 0;
+    virtual void OnNoParenAdded() = 0;
     virtual void MaxDigitsReached() = 0; // not an error but still need to inform UI layer.
     virtual void BinaryOperatorReceived() = 0;
     virtual void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) = 0;

--- a/src/CalcManager/Header Files/ICalcDisplay.h
+++ b/src/CalcManager/Header Files/ICalcDisplay.h
@@ -13,7 +13,7 @@ public:
     virtual void SetIsInError(bool isInError) = 0;
     virtual void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands) = 0;
     virtual void SetParenDisplayText(const std::wstring& pszText) = 0;
-    virtual void OnNoParenAdded() = 0;
+    virtual void OnNoRightParenAdded() = 0;
     virtual void MaxDigitsReached() = 0; // not an error but still need to inform UI layer.
     virtual void BinaryOperatorReceived() = 0;
     virtual void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) = 0;

--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include "pch.h"
@@ -20,6 +20,8 @@ namespace CalculatorApp::Common::Automation
         StringReference CategoryNameChanged(L"CategoryNameChanged");
         StringReference UpdateCurrencyRates(L"UpdateCurrencyRates");
         StringReference DisplayCopied(L"DisplayCopied");
+        StringReference OpenParenthesisCountChanged(L"OpenParenthesisCountChanged");
+        StringReference NoParenthesisAdded(L"NoParenthesisAdded");
     }
 }
 
@@ -139,6 +141,24 @@ NarratorAnnouncement^ CalculatorAnnouncement::GetDisplayCopiedAnnouncement(Strin
     return ref new NarratorAnnouncement(
         announcement,
         CalculatorActivityIds::DisplayCopied,
+        AutomationNotificationKind::ActionCompleted,
+        AutomationNotificationProcessing::ImportantMostRecent);
+}
+
+NarratorAnnouncement^ CalculatorAnnouncement::GetOpenParenethisCount(String^ announcement)
+{
+    return ref new NarratorAnnouncement(
+        announcement,
+        CalculatorActivityIds::OpenParenthesisCountChanged,
+        AutomationNotificationKind::ActionCompleted,
+        AutomationNotificationProcessing::ImportantMostRecent);
+}
+
+NarratorAnnouncement^ CalculatorAnnouncement::GetNoParenthesisAddedAnnouncement(String^ announcement)
+{
+    return ref new NarratorAnnouncement(
+        announcement,
+        CalculatorActivityIds::NoParenthesisAdded,
         AutomationNotificationKind::ActionCompleted,
         AutomationNotificationProcessing::ImportantMostRecent);
 }

--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
@@ -145,7 +145,7 @@ NarratorAnnouncement^ CalculatorAnnouncement::GetDisplayCopiedAnnouncement(Strin
         AutomationNotificationProcessing::ImportantMostRecent);
 }
 
-NarratorAnnouncement^ CalculatorAnnouncement::GetOpenParenethisCount(String^ announcement)
+NarratorAnnouncement^ CalculatorAnnouncement::GetOpenParenthesisCountChangedAnnouncement(String^ announcement)
 {
     return ref new NarratorAnnouncement(
         announcement,
@@ -154,7 +154,7 @@ NarratorAnnouncement^ CalculatorAnnouncement::GetOpenParenethisCount(String^ ann
         AutomationNotificationProcessing::ImportantMostRecent);
 }
 
-NarratorAnnouncement^ CalculatorAnnouncement::GetNoParenthesisAddedAnnouncement(String^ announcement)
+NarratorAnnouncement^ CalculatorAnnouncement::GetNoRightParenthesisAddedAnnouncement(String^ announcement)
 {
     return ref new NarratorAnnouncement(
         announcement,

--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
@@ -91,7 +91,7 @@ namespace CalculatorApp::Common::Automation
         
         static NarratorAnnouncement^ GetDisplayCopiedAnnouncement(Platform::String^ announcement);
 
-        static NarratorAnnouncement^ GetOpenParenethisCount(Platform::String^ announcement);
-        static NarratorAnnouncement^ GetNoParenthesisAddedAnnouncement(Platform::String ^ announcement);
+        static NarratorAnnouncement^ GetOpenParenthesisCountChangedAnnouncement(Platform::String^ announcement);
+        static NarratorAnnouncement^ GetNoRightParenthesisAddedAnnouncement(Platform::String ^ announcement);
     };
 }

--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -90,5 +90,8 @@ namespace CalculatorApp::Common::Automation
         static NarratorAnnouncement^ GetUpdateCurrencyRatesAnnouncement(Platform::String^ announcement);
         
         static NarratorAnnouncement^ GetDisplayCopiedAnnouncement(Platform::String^ announcement);
+
+        static NarratorAnnouncement^ GetOpenParenethisCount(Platform::String^ announcement);
+        static NarratorAnnouncement^ GetNoParenthesisAddedAnnouncement(Platform::String ^ announcement);
     };
 }

--- a/src/CalcViewModel/Common/CalculatorDisplay.cpp
+++ b/src/CalcViewModel/Common/CalculatorDisplay.cpp
@@ -49,6 +49,18 @@ void CalculatorDisplay::SetParenDisplayText(_In_ const std::wstring& parenthesis
     }
 }
 
+void CalculatorDisplay::OnNoParenAdded()
+{
+    if (m_callbackReference != nullptr)
+    {
+        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
+        if (calcVM)
+        {
+            calcVM->SetNoParenAddedNarratorAnnouncement();
+        }
+    }
+}
+
 void CalculatorDisplay::SetIsInError(bool isError)
 {
     if (m_callbackReference != nullptr)

--- a/src/CalcViewModel/Common/CalculatorDisplay.cpp
+++ b/src/CalcViewModel/Common/CalculatorDisplay.cpp
@@ -29,8 +29,7 @@ void CalculatorDisplay::SetPrimaryDisplay(_In_ const wstring& displayStringValue
 {
     if (m_callbackReference)
     {
-        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
-        if (calcVM)
+        if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
             calcVM->SetPrimaryDisplay(displayStringValue, isError);
         }
@@ -41,22 +40,20 @@ void CalculatorDisplay::SetParenDisplayText(_In_ const std::wstring& parenthesis
 {
     if (m_callbackReference != nullptr)
     {
-        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
-        if (calcVM)
+        if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
             calcVM->SetParenthesisCount(parenthesisCount);
         }
     }
 }
 
-void CalculatorDisplay::OnNoParenAdded()
+void CalculatorDisplay::OnNoRightParenAdded()
 {
     if (m_callbackReference != nullptr)
     {
-        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
-        if (calcVM)
+        if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
-            calcVM->SetNoParenAddedNarratorAnnouncement();
+            calcVM->OnNoRightParenAdded();
         }
     }
 }
@@ -65,8 +62,7 @@ void CalculatorDisplay::SetIsInError(bool isError)
 {
     if (m_callbackReference != nullptr)
     {
-        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
-        if (calcVM)
+        if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
             calcVM->IsInError = isError;
         }
@@ -77,8 +73,7 @@ void CalculatorDisplay::SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorV
 {
     if (m_callbackReference != nullptr)
     {
-        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
-        if (calcVM)
+        if(auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
             calcVM->SetExpressionDisplay(tokens, commands);
         }
@@ -89,8 +84,7 @@ void CalculatorDisplay::SetMemorizedNumbers(_In_ const vector<std::wstring>& new
 {
     if (m_callbackReference != nullptr)
     {
-        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
-        if (calcVM)
+        if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
             calcVM->SetMemorizedNumbers(newMemorizedNumbers);
         }
@@ -101,8 +95,7 @@ void CalculatorDisplay::OnHistoryItemAdded(_In_ unsigned int addedItemIndex)
 {
     if (m_historyCallbackReference != nullptr)
     {
-        auto historyVM = m_historyCallbackReference.Resolve<ViewModel::HistoryViewModel>();
-        if (historyVM)
+        if (auto historyVM = m_historyCallbackReference.Resolve<ViewModel::HistoryViewModel>())
         {
             historyVM->OnHistoryItemAdded(addedItemIndex);
         }
@@ -113,8 +106,7 @@ void CalculatorDisplay::MaxDigitsReached()
 {
     if (m_callbackReference != nullptr)
     {
-        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
-        if (calcVM)
+        if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
             calcVM->OnMaxDigitsReached();
         }
@@ -125,8 +117,7 @@ void CalculatorDisplay::BinaryOperatorReceived()
 {
     if (m_callbackReference != nullptr)
     {
-        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
-        if (calcVM)
+        if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
             calcVM->OnBinaryOperatorReceived();
         }
@@ -137,8 +128,7 @@ void CalculatorDisplay::MemoryItemChanged(unsigned int indexOfMemory)
 {
     if (m_callbackReference != nullptr)
     {
-        auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>();
-        if (calcVM)
+        if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
             calcVM->OnMemoryItemChanged(indexOfMemory);
         }

--- a/src/CalcViewModel/Common/CalculatorDisplay.h
+++ b/src/CalcViewModel/Common/CalculatorDisplay.h
@@ -22,7 +22,7 @@ namespace CalculatorApp
         void SetMemorizedNumbers(_In_ const std::vector<std::wstring>& memorizedNumbers) override;
         void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) override;
         void SetParenDisplayText(_In_ const std::wstring& parenthesisCount) override;
-        void OnNoParenAdded() override;
+        void OnNoRightParenAdded() override;
         void MaxDigitsReached() override;
         void BinaryOperatorReceived() override;
         void MemoryItemChanged(unsigned int indexOfMemory) override;

--- a/src/CalcViewModel/Common/CalculatorDisplay.h
+++ b/src/CalcViewModel/Common/CalculatorDisplay.h
@@ -22,6 +22,7 @@ namespace CalculatorApp
         void SetMemorizedNumbers(_In_ const std::vector<std::wstring>& memorizedNumbers) override;
         void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) override;
         void SetParenDisplayText(_In_ const std::wstring& parenthesisCount) override;
+        void OnNoParenAdded() override;
         void MaxDigitsReached() override;
         void BinaryOperatorReceived() override;
         void MemoryItemChanged(unsigned int indexOfMemory) override;

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -52,7 +52,8 @@ namespace CalculatorApp::ViewModel
         StringReference DecButton(L"Format_DecButtonValue");
         StringReference OctButton(L"Format_OctButtonValue");
         StringReference BinButton(L"Format_BinButtonValue");
-        StringReference LeftParenthesisAutomationFormat(L"Format_OpenParenthesisAutomationNamePrefix");
+        StringReference OpenParenthesisCountAutomationFormat(L"Format_OpenParenthesisCountAutomationNamePrefix");
+        StringReference NoParenthesisAdded(L"NoParenthesisAdded_Announcement");
         StringReference MaxDigitsReachedFormat(L"Format_MaxDigitsReached");
         StringReference ButtonPressFeedbackFormat(L"Format_ButtonPressAuditoryFeedback");
         StringReference MemorySave(L"Format_MemorySave");
@@ -92,7 +93,9 @@ StandardCalculatorViewModel::StandardCalculatorViewModel() :
     m_localizedMemorySavedAutomationFormat(nullptr),
     m_localizedMemoryItemChangedAutomationFormat(nullptr),
     m_localizedMemoryItemClearedAutomationFormat(nullptr),
-    m_localizedMemoryCleared(nullptr)
+    m_localizedMemoryCleared(nullptr),
+    m_localizedOpenParenthesisCountChangedAutomationFormat(nullptr),
+    m_localizaedNoParenthesisAddedAutomationFormat(nullptr)
 {
     WeakReference calculatorViewModel(this);
     m_calculatorDisplay.SetCallback(calculatorViewModel);
@@ -103,7 +106,6 @@ StandardCalculatorViewModel::StandardCalculatorViewModel() :
     m_localizedDecimalAutomationFormat = AppResourceProvider::GetInstance().GetResourceString(CalculatorResourceKeys::DecButton);
     m_localizedOctalAutomationFormat = AppResourceProvider::GetInstance().GetResourceString(CalculatorResourceKeys::OctButton);
     m_localizedBinaryAutomationFormat = AppResourceProvider::GetInstance().GetResourceString(CalculatorResourceKeys::BinButton);
-    m_leftParenthesisAutomationFormat = AppResourceProvider::GetInstance().GetResourceString(CalculatorResourceKeys::LeftParenthesisAutomationFormat);
 
     // Initialize the Automation Name
     CalculationResultAutomationName = GetLocalizedStringFormat(m_localizedCalculationResultAutomationFormat, m_DisplayValue);
@@ -222,8 +224,30 @@ void StandardCalculatorViewModel::SetParenthesisCount(_In_ const wstring& parent
     if (IsProgrammer || IsScientific)
     {
         OpenParenthesisCount = ref new String(parenthesisCount.c_str());
-        RaisePropertyChanged("LeftParenthesisAutomationName");
     }
+}
+
+void StandardCalculatorViewModel::OpenParenthesisCountNarratorAnnouncment()
+{
+    String^ parenthesisCount = ((m_OpenParenthesisCount == nullptr) ? "0" : m_OpenParenthesisCount);
+    wstring localizedParenthesisCount = std::wstring(parenthesisCount->Data());
+    LocalizationSettings::GetInstance().LocalizeDisplayValue(&localizedParenthesisCount);
+
+    String^ announcement = LocalizationStringUtil::GetLocalizedNarratorAnnouncement(
+        CalculatorResourceKeys::OpenParenthesisCountAutomationFormat,
+        m_localizedOpenParenthesisCountChangedAutomationFormat,
+        localizedParenthesisCount.c_str());
+
+    Announcement = CalculatorAnnouncement::GetOpenParenethisCount(announcement);
+}
+
+void StandardCalculatorViewModel::SetNoParenAddedNarratorAnnouncement()
+{
+    String^ announcement = LocalizationStringUtil::GetLocalizedNarratorAnnouncement(
+        CalculatorResourceKeys::NoParenthesisAdded,
+        m_localizaedNoParenthesisAddedAutomationFormat);
+
+    Announcement = CalculatorAnnouncement::GetNoParenthesisAddedAnnouncement(announcement);
 }
 
 void StandardCalculatorViewModel::DisableButtons(CommandType selectedExpressionCommandType)
@@ -252,15 +276,6 @@ void StandardCalculatorViewModel::DisableButtons(CommandType selectedExpressionC
         IsNegateEnabled = true;
         IsDecimalEnabled = false;
     }
-}
-
-String ^ StandardCalculatorViewModel::GetLeftParenthesisAutomationName()
-{
-    String^ parenthesisCount = ((m_OpenParenthesisCount == nullptr) ? "0" : m_OpenParenthesisCount);
-    wstring localizedParenthesisCount = std::wstring(parenthesisCount->Data());
-    LocalizationSettings::GetInstance().LocalizeDisplayValue(&localizedParenthesisCount);
-
-    return GetLocalizedStringFormat(m_leftParenthesisAutomationFormat, ref new String(localizedParenthesisCount.c_str()));
 }
 
 void StandardCalculatorViewModel::SetExpressionDisplay(_Inout_ shared_ptr<CalculatorVector<pair<wstring, int>>> const &tokens, _Inout_ shared_ptr<CalculatorVector <shared_ptr<IExpressionCommand>>> const &commands)
@@ -566,6 +581,8 @@ void StandardCalculatorViewModel::OnButtonPressed(Object^ parameter)
     m_feedbackForButtonPress = CalculatorButtonPressedEventArgs::GetAuditoryFeedbackFromCommandParameter(parameter);
     NumbersAndOperatorsEnum numOpEnum = CalculatorButtonPressedEventArgs::GetOperationFromCommandParameter(parameter);
     Command cmdenum = ConvertToOperatorsEnum(numOpEnum);
+    bool isOperator = IsOperator(cmdenum);
+    String^ previousParenthesisCount = m_OpenParenthesisCount;
 
     TraceLogger::GetInstance().UpdateFunctionUsage((int)numOpEnum);
 
@@ -642,6 +659,11 @@ void StandardCalculatorViewModel::OnButtonPressed(Object^ parameter)
             }
 
             m_standardCalculatorManager.SendCommand(cmdenum);
+        }
+
+        if (numOpEnum == NumbersAndOperatorsEnum::OpenParenthesis || (numOpEnum == NumbersAndOperatorsEnum::CloseParenthesis && previousParenthesisCount) )
+        {
+            OpenParenthesisCountNarratorAnnouncment();
         }
     }
 }

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -581,7 +581,6 @@ void StandardCalculatorViewModel::OnButtonPressed(Object^ parameter)
     m_feedbackForButtonPress = CalculatorButtonPressedEventArgs::GetAuditoryFeedbackFromCommandParameter(parameter);
     NumbersAndOperatorsEnum numOpEnum = CalculatorButtonPressedEventArgs::GetOperationFromCommandParameter(parameter);
     Command cmdenum = ConvertToOperatorsEnum(numOpEnum);
-    bool isOperator = IsOperator(cmdenum);
     String^ previousParenthesisCount = m_OpenParenthesisCount;
 
     TraceLogger::GetInstance().UpdateFunctionUsage((int)numOpEnum);

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -55,7 +55,7 @@ namespace CalculatorApp::ViewModel
         StringReference BinButton(L"Format_BinButtonValue");
         StringReference LeftParenthesisAutomationFormat(L"Format_OpenParenthesisAutomationNamePrefix");
         StringReference OpenParenthesisCountAutomationFormat(L"Format_OpenParenthesisCountAutomationNamePrefix");
-        StringReference NoParenthesisAdded(L"NoParenthesisAdded_Announcement");
+        StringReference NoParenthesisAdded(L"NoRightParenthesisAdded_Announcement");
         StringReference MaxDigitsReachedFormat(L"Format_MaxDigitsReached");
         StringReference ButtonPressFeedbackFormat(L"Format_ButtonPressAuditoryFeedback");
         StringReference MemorySave(L"Format_MemorySave");
@@ -97,7 +97,7 @@ StandardCalculatorViewModel::StandardCalculatorViewModel() :
     m_localizedMemoryItemClearedAutomationFormat(nullptr),
     m_localizedMemoryCleared(nullptr),
     m_localizedOpenParenthesisCountChangedAutomationFormat(nullptr),
-    m_localizedNoRightParenthesisAddedAutomationFormat(nullptr)
+    m_localizedNoRightParenthesisAddedFormat(nullptr)
 {
     WeakReference calculatorViewModel(this);
     m_calculatorDisplay.SetCallback(calculatorViewModel);
@@ -254,7 +254,7 @@ void StandardCalculatorViewModel::SetNoParenAddedNarratorAnnouncement()
 {
     String^ announcement = LocalizationStringUtil::GetLocalizedNarratorAnnouncement(
         CalculatorResourceKeys::NoParenthesisAdded,
-        m_localizedNoRightParenthesisAddedAutomationFormat);
+        m_localizedNoRightParenthesisAddedFormat);
 
     Announcement = CalculatorAnnouncement::GetNoRightParenthesisAddedAnnouncement(announcement);
 }

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -261,14 +261,6 @@ namespace CalculatorApp
                 void set(bool value) { m_completeTextSelection = value; }
             }
 
-            property Platform::String^ LeftParenthesisAutomationName
-            {
-                Platform::String^ get() 
-                {
-                    return GetLeftParenthesisAutomationName();
-                }
-            }
-
         internal:
             void OnPaste(Platform::String^ pastedString, CalculatorApp::Common::ViewMode mode);
             void OnCopyCommand(Platform::Object^ parameter);
@@ -284,12 +276,15 @@ namespace CalculatorApp
             void OnMemoryClear(_In_ Platform::Object^ memoryItemPosition);
             void OnPinUnpinCommand(Platform::Object^ parameter);
 
+            void OpenParenthesisCountNarratorAnnouncment();
+
             void SetPrimaryDisplay(_In_ std::wstring const&displayString, _In_ bool isError);
             void DisplayPasteError();
             void SetTokens(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens);
             void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands);
             void SetHistoryExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector <std::shared_ptr<IExpressionCommand>>> const &commands);
             void SetParenthesisCount(_In_ const std::wstring& parenthesisCount);
+            void SetNoParenAddedNarratorAnnouncement();
             void OnMaxDigitsReached();
             void OnBinaryOperatorReceived();
             void OnMemoryItemChanged(unsigned int indexOfMemory);
@@ -337,6 +332,8 @@ namespace CalculatorApp
             Platform::String^ m_localizedMemoryItemChangedAutomationFormat;
             Platform::String^ m_localizedMemoryItemClearedAutomationFormat;
             Platform::String^ m_localizedMemoryCleared;
+            Platform::String^ m_localizedOpenParenthesisCountChangedAutomationFormat;
+            Platform::String^ m_localizaedNoParenthesisAddedAutomationFormat;
 
             bool m_pinned;
             bool m_isOperandEnabled;
@@ -355,7 +352,6 @@ namespace CalculatorApp
             bool m_isLastOperationHistoryLoad;
             Platform::String^ m_selectedExpressionLastData;
             Common::DisplayExpressionToken^ m_selectedExpressionToken;
-            Platform::String^ m_leftParenthesisAutomationFormat;
 
             Platform::String^ LocalizeDisplayValue(_In_ std::wstring const &displayValue, _In_ bool isError);
             Platform::String^ CalculateNarratorDisplayValue(_In_ std::wstring const &displayValue, _In_ Platform::String^ localizedDisplayValue, _In_ bool isError);
@@ -365,7 +361,6 @@ namespace CalculatorApp
 
             CalculationManager::Command ConvertToOperatorsEnum(NumbersAndOperatorsEnum operation);
             void DisableButtons(CalculationManager::CommandType selectedExpressionCommandType);
-            Platform::String^ GetLeftParenthesisAutomationName();
 
             Platform::String^ m_feedbackForButtonPress;
             void OnButtonPressed(Platform::Object^ parameter);

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -36,6 +36,7 @@ namespace CalculatorApp
             extern Platform::StringReference IsMemoryEmpty;
             extern Platform::StringReference IsInError;
             extern Platform::StringReference BinaryDisplayValue;
+            extern Platform::StringReference OpenParenthesisCount;
         }
 
         [Windows::UI::Xaml::Data::Bindable]
@@ -261,6 +262,14 @@ namespace CalculatorApp
                 void set(bool value) { m_completeTextSelection = value; }
             }
 
+            property Platform::String^ LeftParenthesisAutomationName
+            {
+                Platform::String^ get()
+                {
+                    return GetLeftParenthesisAutomationName();
+                }
+            }
+
         internal:
             void OnPaste(Platform::String^ pastedString, CalculatorApp::Common::ViewMode mode);
             void OnCopyCommand(Platform::Object^ parameter);
@@ -276,14 +285,14 @@ namespace CalculatorApp
             void OnMemoryClear(_In_ Platform::Object^ memoryItemPosition);
             void OnPinUnpinCommand(Platform::Object^ parameter);
 
-            void OpenParenthesisCountNarratorAnnouncment();
-
             void SetPrimaryDisplay(_In_ std::wstring const&displayString, _In_ bool isError);
             void DisplayPasteError();
             void SetTokens(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens);
             void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands);
             void SetHistoryExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector <std::shared_ptr<IExpressionCommand>>> const &commands);
             void SetParenthesisCount(_In_ const std::wstring& parenthesisCount);
+            void SetOpenParenthesisCountNarratorAnnouncement();
+            void OnNoRightParenAdded();
             void SetNoParenAddedNarratorAnnouncement();
             void OnMaxDigitsReached();
             void OnBinaryOperatorReceived();
@@ -333,7 +342,7 @@ namespace CalculatorApp
             Platform::String^ m_localizedMemoryItemClearedAutomationFormat;
             Platform::String^ m_localizedMemoryCleared;
             Platform::String^ m_localizedOpenParenthesisCountChangedAutomationFormat;
-            Platform::String^ m_localizaedNoParenthesisAddedAutomationFormat;
+            Platform::String^ m_localizedNoRightParenthesisAddedAutomationFormat;
 
             bool m_pinned;
             bool m_isOperandEnabled;
@@ -352,6 +361,7 @@ namespace CalculatorApp
             bool m_isLastOperationHistoryLoad;
             Platform::String^ m_selectedExpressionLastData;
             Common::DisplayExpressionToken^ m_selectedExpressionToken;
+            Platform::String^ m_leftParenthesisAutomationFormat;
 
             Platform::String^ LocalizeDisplayValue(_In_ std::wstring const &displayValue, _In_ bool isError);
             Platform::String^ CalculateNarratorDisplayValue(_In_ std::wstring const &displayValue, _In_ Platform::String^ localizedDisplayValue, _In_ bool isError);
@@ -361,6 +371,7 @@ namespace CalculatorApp
 
             CalculationManager::Command ConvertToOperatorsEnum(NumbersAndOperatorsEnum operation);
             void DisableButtons(CalculationManager::CommandType selectedExpressionCommandType);
+            Platform::String^ GetLeftParenthesisAutomationName();
 
             Platform::String^ m_feedbackForButtonPress;
             void OnButtonPressed(Platform::Object^ parameter);

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -342,7 +342,7 @@ namespace CalculatorApp
             Platform::String^ m_localizedMemoryItemClearedAutomationFormat;
             Platform::String^ m_localizedMemoryCleared;
             Platform::String^ m_localizedOpenParenthesisCountChangedAutomationFormat;
-            Platform::String^ m_localizedNoRightParenthesisAddedAutomationFormat;
+            Platform::String^ m_localizedNoRightParenthesisAddedFormat;
 
             bool m_pinned;
             bool m_isOperandEnabled;

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -1313,7 +1313,7 @@
     <value>Left parenthesis</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-    <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
+  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
     <value>Left parenthesis, open parenthesis count %1</value>
     <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
   </data>
@@ -1325,7 +1325,7 @@
     <value>Open parenthesis count %1</value>
     <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific and programmer operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
   </data>
-  <data name="NoParenthesisAdded_Announcement" xml:space="preserve">
+  <data name="NoRightParenthesisAdded_Announcement" xml:space="preserve">
     <value>There are no open parentheses to close.</value>
     <comment>{Locked="%1"} Screen reader prompt for the Calculator when the ")" button on the scientific and programmer operator keypad cannot be added to the equation. e.g. "1+)".</comment>
   </data>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -1313,13 +1313,17 @@
     <value>Left parenthesis</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Left parenthesis, open parenthesis count %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Right parenthesis</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>
+  </data>
+  <data name="Format_OpenParenthesisCountAutomationNamePrefix" xml:space="preserve">
+    <value>Open parenthesis count %1</value>
+    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
+  </data>
+  <data name="NoParenthesisAdded_Announcement" xml:space="preserve">
+    <value>There are no open parentheses to close.</value>
+    <comment>{Locked="%1"} Screen reader prompt for the Calculator when the ")" button on the scientific or programmer operator keypad cannot be added to the equation. e.g. "1+)".</comment>
   </data>
   <data name="ftoeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Scientific notation</value>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -1313,17 +1313,21 @@
     <value>Left parenthesis</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
+    <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
+    <value>Left parenthesis, open parenthesis count %1</value>
+    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
+  </data>
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Right parenthesis</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>
   </data>
   <data name="Format_OpenParenthesisCountAutomationNamePrefix" xml:space="preserve">
     <value>Open parenthesis count %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
+    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific and programmer operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
   </data>
   <data name="NoParenthesisAdded_Announcement" xml:space="preserve">
     <value>There are no open parentheses to close.</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator when the ")" button on the scientific or programmer operator keypad cannot be added to the equation. e.g. "1+)".</comment>
+    <comment>{Locked="%1"} Screen reader prompt for the Calculator when the ")" button on the scientific and programmer operator keypad cannot be added to the equation. e.g. "1+)".</comment>
   </data>
   <data name="ftoeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Scientific notation</value>

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
@@ -10,6 +10,7 @@
              d:DesignHeight="395"
              d:DesignWidth="315"
              Loaded="OnLoaded"
+             Unloaded="OnUnloaded"
              mc:Ignorable="d">
 
     <Grid x:Name="ProgRadixOps">
@@ -408,6 +409,7 @@
                                    Style="{StaticResource ParenthesisCalcButtonStyle}"
                                    FontSize="18"
                                    AutomationProperties.AutomationId="openParenthesisButton"
+                                   AutomationProperties.Name="{Binding LeftParenthesisAutomationName}"
                                    ButtonId="OpenParenthesis"
                                    Content="("
                                    Tag="{x:Bind Model.OpenParenthesisCount, Mode=OneWay}"/>

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
@@ -408,7 +408,6 @@
                                    Style="{StaticResource ParenthesisCalcButtonStyle}"
                                    FontSize="18"
                                    AutomationProperties.AutomationId="openParenthesisButton"
-                                   AutomationProperties.Name="{Binding LeftParenthesisAutomationName}"
                                    ButtonId="OpenParenthesis"
                                    Content="("
                                    Tag="{x:Bind Model.OpenParenthesisCount, Mode=OneWay}"/>

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //
@@ -34,8 +34,12 @@ CalculatorProgrammerRadixOperators::CalculatorProgrammerRadixOperators() :
 
 void CalculatorProgrammerRadixOperators::OnLoaded(Object^, RoutedEventArgs^)
 {
-    auto viewmodel = safe_cast<StandardCalculatorViewModel^>(this->DataContext);
-    viewmodel->ProgModeRadixChange += ref new ProgModeRadixChangeHandler(this, &CalculatorProgrammerRadixOperators::ProgModeRadixChange);
+    Model->ProgModeRadixChange += ref new ProgModeRadixChangeHandler(this, &CalculatorProgrammerRadixOperators::ProgModeRadixChange);
+    m_propertyChangedToken = Model->PropertyChanged += ref new PropertyChangedEventHandler(this, &CalculatorProgrammerRadixOperators::OnPropertyChanged);
+}
+void CalculatorProgrammerRadixOperators::OnUnloaded(Object^, RoutedEventArgs^)
+{
+    Model->PropertyChanged -=  m_propertyChangedToken;
 }
 
 void CalculatorProgrammerRadixOperators::Shift_Clicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
@@ -92,5 +96,13 @@ void CalculatorProgrammerRadixOperators::IsErrorVisualState::set(bool value)
         String^ newState = m_isErrorVisualState ? L"ErrorLayout" : L"NoErrorLayout";
         VisualStateManager::GoToState(this, newState, false);
         NumberPad->IsErrorVisualState = m_isErrorVisualState;
+    }
+}
+
+void CalculatorProgrammerRadixOperators::OnPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e)
+{
+    if (e->PropertyName == CalculatorViewModelProperties::OpenParenthesisCount && closeParenthesisButton->FocusState != Windows::UI::Xaml::FocusState::Unfocused)
+    {
+        Model->SetOpenParenthesisCountNarratorAnnouncement();
     }
 }

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
@@ -34,11 +34,12 @@ CalculatorProgrammerRadixOperators::CalculatorProgrammerRadixOperators() :
 
 void CalculatorProgrammerRadixOperators::OnLoaded(Object^, RoutedEventArgs^)
 {
-    Model->ProgModeRadixChange += ref new ProgModeRadixChangeHandler(this, &CalculatorProgrammerRadixOperators::ProgModeRadixChange);
-    m_propertyChangedToken = Model->PropertyChanged += ref new PropertyChangedEventHandler(this, &CalculatorProgrammerRadixOperators::OnPropertyChanged);
+    m_progModeRadixChangeToken = Model->ProgModeRadixChange += ref new ProgModeRadixChangeHandler(this, &CalculatorProgrammerRadixOperators::ProgModeRadixChange);
+    m_propertyChangedToken = Model->PropertyChanged += ref new PropertyChangedEventHandler(this, &CalculatorProgrammerRadixOperators::OnViewModelPropertyChanged);
 }
 void CalculatorProgrammerRadixOperators::OnUnloaded(Object^, RoutedEventArgs^)
 {
+    Model->ProgModeRadixChange -= m_progModeRadixChangeToken;
     Model->PropertyChanged -=  m_propertyChangedToken;
 }
 
@@ -99,9 +100,9 @@ void CalculatorProgrammerRadixOperators::IsErrorVisualState::set(bool value)
     }
 }
 
-void CalculatorProgrammerRadixOperators::OnPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e)
+void CalculatorProgrammerRadixOperators::OnViewModelPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e)
 {
-    if (e->PropertyName == CalculatorViewModelProperties::OpenParenthesisCount && closeParenthesisButton->FocusState != Windows::UI::Xaml::FocusState::Unfocused)
+    if (e->PropertyName == CalculatorViewModelProperties::OpenParenthesisCount && closeParenthesisButton->FocusState != ::FocusState::Unfocused)
     {
         Model->SetOpenParenthesisCountNarratorAnnouncement();
     }

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
@@ -35,9 +35,10 @@ namespace CalculatorApp
         void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void ProgModeRadixChange();
-        void OnPropertyChanged(Platform::Object^ sender, Windows::UI::Xaml::Data::PropertyChangedEventArgs ^ e);
+        void OnViewModelPropertyChanged(Platform::Object^ sender, Windows::UI::Xaml::Data::PropertyChangedEventArgs ^ e);
 
         bool m_isErrorVisualState;
+        Windows::Foundation::EventRegistrationToken m_progModeRadixChangeToken;
         Windows::Foundation::EventRegistrationToken m_propertyChangedToken;
     };
 }

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -33,8 +33,11 @@ namespace CalculatorApp
         void Shift_Clicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void SetVisibilityBinding(Windows::UI::Xaml::FrameworkElement^ element, Platform::String^ path, Windows::UI::Xaml::Data::IValueConverter^ converter);
         void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void ProgModeRadixChange();
+        void OnPropertyChanged(Platform::Object^ sender, Windows::UI::Xaml::Data::PropertyChangedEventArgs ^ e);
 
         bool m_isErrorVisualState;
+        Windows::Foundation::EventRegistrationToken m_propertyChangedToken;
     };
 }

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -727,7 +727,6 @@
                                    Style="{StaticResource ParenthesisCalcButtonStyle}"
                                    FontSize="19"
                                    AutomationProperties.AutomationId="openParenthesisButton"
-                                   AutomationProperties.Name="{Binding LeftParenthesisAutomationName}"
                                    ButtonId="OpenParenthesis"
                                    Content="("
                                    Tag="{x:Bind Model.OpenParenthesisCount, Mode=OneWay}"/>

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -11,6 +11,8 @@
              x:Name="ControlRoot"
              d:DesignHeight="400"
              d:DesignWidth="315"
+             Loaded="OnLoaded"
+             Unloaded="OnUnloaded"
              mc:Ignorable="d">
     <UserControl.Resources>
         <converters:BooleanNegationConverter x:Key="BooleanNegationConverter"/>
@@ -727,6 +729,7 @@
                                    Style="{StaticResource ParenthesisCalcButtonStyle}"
                                    FontSize="19"
                                    AutomationProperties.AutomationId="openParenthesisButton"
+                                   AutomationProperties.Name="{Binding LeftParenthesisAutomationName}"
                                    ButtonId="OpenParenthesis"
                                    Content="("
                                    Tag="{x:Bind Model.OpenParenthesisCount, Mode=OneWay}"/>

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
@@ -40,7 +40,7 @@ CalculatorScientificOperators::CalculatorScientificOperators()
 
 void CalculatorScientificOperators::OnLoaded(Object^, RoutedEventArgs^)
 {
-    m_propertyChangedToken = Model->PropertyChanged += ref new PropertyChangedEventHandler(this, &CalculatorScientificOperators::OnPropertyChanged);
+    m_propertyChangedToken = Model->PropertyChanged += ref new PropertyChangedEventHandler(this, &CalculatorScientificOperators::OnViewModelPropertyChanged);
 }
 void CalculatorScientificOperators::OnUnloaded(Object^, RoutedEventArgs^)
 {
@@ -107,9 +107,9 @@ void CalculatorScientificOperators::SetOperatorRowVisibility()
     InvRow2->Visibility = invRowVis;
 }
 
-void CalculatorScientificOperators::OnPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e)
+void CalculatorScientificOperators::OnViewModelPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e)
 {
-    if (e->PropertyName == CalculatorViewModelProperties::OpenParenthesisCount && closeParenthesisButton->FocusState != Windows::UI::Xaml::FocusState::Unfocused)
+    if (e->PropertyName == CalculatorViewModelProperties::OpenParenthesisCount && closeParenthesisButton->FocusState != ::FocusState::Unfocused)
     {
         Model->SetOpenParenthesisCountNarratorAnnouncement();
     }

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //
@@ -36,6 +36,15 @@ CalculatorScientificOperators::CalculatorScientificOperators()
 
     expButton->SetValue(Common::KeyboardShortcutManager::VirtualKeyProperty, Common::MyVirtualKey::E);
     Common::KeyboardShortcutManager::ShiftButtonChecked(false);
+}
+
+void CalculatorScientificOperators::OnLoaded(Object^, RoutedEventArgs^)
+{
+    m_propertyChangedToken = Model->PropertyChanged += ref new PropertyChangedEventHandler(this, &CalculatorScientificOperators::OnPropertyChanged);
+}
+void CalculatorScientificOperators::OnUnloaded(Object^, RoutedEventArgs^)
+{
+    Model->PropertyChanged -= m_propertyChangedToken;
 }
 
 void CalculatorScientificOperators::ShortLayout_Completed(_In_ Platform::Object^ /*sender*/, _In_ Platform::Object^ /*e*/)
@@ -96,4 +105,12 @@ void CalculatorScientificOperators::SetOperatorRowVisibility()
     Row2->Visibility = rowVis;
     InvRow1->Visibility = invRowVis;
     InvRow2->Visibility = invRowVis;
+}
+
+void CalculatorScientificOperators::OnPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e)
+{
+    if (e->PropertyName == CalculatorViewModelProperties::OpenParenthesisCount && closeParenthesisButton->FocusState != Windows::UI::Xaml::FocusState::Unfocused)
+    {
+        Model->SetOpenParenthesisCountNarratorAnnouncement();
+    }
 }

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //
@@ -41,5 +41,10 @@ namespace CalculatorApp
         void shiftButton_Check(_In_ Platform::Object^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs^ e);
         void shiftButton_IsEnabledChanged(_In_ Platform::Object^ sender, _In_ Windows::UI::Xaml::DependencyPropertyChangedEventArgs^ e);
         void SetOperatorRowVisibility();
+        void OnPropertyChanged(Platform::Object^ sender, Windows::UI::Xaml::Data::PropertyChangedEventArgs ^ e);
+        void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+
+        Windows::Foundation::EventRegistrationToken m_propertyChangedToken;
     };
 }

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.h
@@ -41,7 +41,7 @@ namespace CalculatorApp
         void shiftButton_Check(_In_ Platform::Object^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs^ e);
         void shiftButton_IsEnabledChanged(_In_ Platform::Object^ sender, _In_ Windows::UI::Xaml::DependencyPropertyChangedEventArgs^ e);
         void SetOperatorRowVisibility();
-        void OnPropertyChanged(Platform::Object^ sender, Windows::UI::Xaml::Data::PropertyChangedEventArgs ^ e);
+        void OnViewModelPropertyChanged(Platform::Object^ sender, Windows::UI::Xaml::Data::PropertyChangedEventArgs ^ e);
         void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -62,7 +62,7 @@ namespace CalculatorManagerTest
             m_parenDisplay = parenthesisCount;
         }
 
-        void OnNoParenAdded() override
+        void OnNoRightParenAdded() override
         {
             // This method is used to create a narrator announcement when a close parenthesis cannot be added because there are no open parentheses
         }

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -62,6 +62,11 @@ namespace CalculatorManagerTest
             m_parenDisplay = parenthesisCount;
         }
 
+        void OnNoParenAdded() override
+        {
+            // This method is used to create a narrator announcement when a close parenthesis cannot be added because there are no open parentheses
+        }
+
         const wstring& GetPrimaryDisplay() const
         {
             return m_primaryDisplay;


### PR DESCRIPTION
## Fixes #282 Narrator does not convey error information when no more Right Parenthesis can be added in expression.


### Description of the changes:
- Removes left parenthesis only narrator announcment.
- Updates open parentheses count narrator announcement to be triggered when both right and left parenthesis buttons are clicked.
- Adds a narrator announcement for the case when there are no open parentheses and the right parenthesis button is clicked.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually tested the open parenthesis count narrator announcement occurred for left and right parenthesis clicks in Scientific and Programmer calculator modes.
- Manually tested the no open parenthesis narrator announcement occurred when the right parenthesis button was clicked and there were no open parentheses in Scientific and Programmer calculator modes.
- Tested the announcements were not triggered by clear in Scientific and Programmer calculator modes.
- Ran automated unit tests.

