### PR TITLE
Fix separators for unit tests

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -108,6 +108,18 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam)
         m_nTempCom = (INT)wParam;
     }
 
+    // Hardcoded settings for unit tests
+    if (wParam == IDC_TESTS)
+    {
+        m_decimalSeparator = L'.';
+        SetDecimalSeparator(m_decimalSeparator);
+        m_groupSeparator = L',';
+        m_decGrouping = DigitGroupingStringToGroupingVector(L"3;0");
+        m_input.SetDecimalSymbol(m_decimalSeparator);
+        m_HistoryCollector.SetDecimalSymbol(m_decimalSeparator);
+        s_engineStrings[IDS_DECIMAL] = m_decimalSeparator;
+    }
+
     if (m_bError)
     {
         if (wParam == IDC_CLEAR)

--- a/src/CalcManager/Command.h
+++ b/src/CalcManager/Command.h
@@ -222,6 +222,8 @@ namespace CalculationManager
         CommandBINPOS61 = 761,
         CommandBINPOS62 = 762,
         CommandBINPOS63 = 763,
-        CommandBINEDITEND = 763
+        CommandBINEDITEND = 763,
+
+        CommandTESTS = 999
     };
 }

--- a/src/CalcManager/Header Files/CCommand.h
+++ b/src/CalcManager/Header Files/CCommand.h
@@ -212,3 +212,4 @@
 #define IDS_ENGINESTR_FIRST     0
 #define IDS_ENGINESTR_MAX     200
 
+#define IDC_TESTS           999

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -144,6 +144,8 @@ namespace CalculatorManagerTest
                 m_calculatorManager->SendCommand(Command::ModeScientific);
             }
 
+            m_calculatorManager->SendCommand(Command::CommandTESTS);
+
             Command* currentCommand = testCommands;
             while (*currentCommand != Command::CommandNULL)
             {
@@ -309,6 +311,7 @@ namespace CalculatorManagerTest
     void CalculatorManagerTest::Cleanup()
     {
         m_calculatorManager->Reset();
+        m_calculatorManager->SendCommand(Command::CommandTESTS);
         m_calculatorDisplayTester->Reset();
     }
 


### PR DESCRIPTION
## Fixes #272.


### Description of the changes:
- Hardcoded separators for unit tests

### How changes were validated:
- manual