### PR TITLE
Remove .editorconfig from sln

### DIFF
--- a/src/Calculator.sln
+++ b/src/Calculator.sln
@@ -9,7 +9,6 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CalcManager", "CalcManager\
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{3A5DF651-B8A1-45CA-9135-964A6FC7F5D1}"
 	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
 		nuget.config = nuget.config
 	EndProjectSection
 EndProject


### PR DESCRIPTION
## Fixes #257

Clean the `.sln` to remove the reference to the extra `.editorconfig` already removed by another diff.
