### PR TITLE
Fix memory leak

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -525,6 +525,7 @@ void StandardCalculatorViewModel::HandleUpdatedOperandData(Command cmdenum)
             length = m_selectedExpressionLastData->Length() + 1;
             if (length > 50)
             {
+                delete [] temp;
                 return;
             }
             for (; i < length; ++i)


### PR DESCRIPTION
Function was returning before attempting to free the memory allocated to `temp`.
This PR fixes it: frees the memory and then returns.