### PR TITLE
Code analysis

### DIFF
--- a/src/CalcManager/CalculatorHistory.h
+++ b/src/CalcManager/CalculatorHistory.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -32,12 +32,12 @@ namespace CalculationManager
 
     public:
         CalculatorHistory(CALCULATOR_MODE eMode, const size_t maxSize);
-        unsigned int AddToHistory(_In_ std::shared_ptr<CalculatorVector <std::pair<std::wstring, int>>> const &spTokens, _In_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &spCommands, std::wstring_view result);
+        unsigned int AddToHistory(_In_ std::shared_ptr<CalculatorVector <std::pair<std::wstring, int>>> const &spTokens, _In_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &spCommands, _In_ std::wstring_view result);
         std::vector<std::shared_ptr<HISTORYITEM>> const& GetHistory();
-        std::shared_ptr<HISTORYITEM> const& GetHistoryItem(unsigned int uIdx);
+        std::shared_ptr<HISTORYITEM> const& GetHistoryItem(_In_ unsigned int uIdx);
         void ClearHistory();
         unsigned int AddItem(_In_ std::shared_ptr<HISTORYITEM> const &spHistoryItem);
-        bool RemoveItem(unsigned int uIdx);
+        bool RemoveItem(_In_ unsigned int uIdx);
         const size_t MaxHistorySize() const { return m_maxHistorySize; }
         ~CalculatorHistory(void);
 

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -101,7 +101,7 @@ namespace CalculationManager
         void MemoryItemChanged(unsigned int indexOfMemory) override;
 
 
-        CalculatorManager(ICalcDisplay* displayCallback, IResourceProvider* resourceProvider);
+        CalculatorManager(_In_ ICalcDisplay* displayCallback, _In_ IResourceProvider* resourceProvider);
         ~CalculatorManager();
 
         void Reset(bool clearMemory = true);

--- a/src/CalcManager/Ratpack/basex.cpp
+++ b/src/CalcManager/Ratpack/basex.cpp
@@ -34,7 +34,7 @@ void _mulnumx( PNUMBER *pa, PNUMBER b );
 //
 //----------------------------------------------------------------------------
 
-void __inline mulnumx( PNUMBER *pa, PNUMBER b )
+void __inline mulnumx( _Inout_ PNUMBER *pa, _In_ PNUMBER b )
 
 {
     if ( b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0 )
@@ -174,7 +174,7 @@ void _mulnumx( PNUMBER *pa, PNUMBER b )
 //
 //-----------------------------------------------------------------------------
 
-void numpowlongx( _Inout_ PNUMBER *proot, _In_ long power )
+void numpowlongx( _Inout_ PNUMBER *proot, long power )
 
 {
     PNUMBER lret = longtonum( 1, BASEX );
@@ -201,7 +201,7 @@ void numpowlongx( _Inout_ PNUMBER *proot, _In_ long power )
     
 }
 
-void _divnumx( PNUMBER *pa, PNUMBER b, int32_t precision);
+void _divnumx( _Inout_ PNUMBER *pa, _In_ PNUMBER b, int32_t precision);
 
 //----------------------------------------------------------------------------
 //
@@ -218,7 +218,7 @@ void _divnumx( PNUMBER *pa, PNUMBER b, int32_t precision);
 //
 //----------------------------------------------------------------------------
 
-void __inline divnumx( PNUMBER *pa, PNUMBER b, int32_t precision)
+void __inline divnumx( _Inout_ PNUMBER *pa, _In_ PNUMBER b, int32_t precision)
 
 {
     if ( b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0 )
@@ -257,7 +257,7 @@ void __inline divnumx( PNUMBER *pa, PNUMBER b, int32_t precision)
 //
 //----------------------------------------------------------------------------
 
-void _divnumx( PNUMBER *pa, PNUMBER b, int32_t precision)
+void _divnumx( _Inout_ PNUMBER *pa, _In_ PNUMBER b, int32_t precision)
 
 {
     PNUMBER a= nullptr;         // a is the dereferenced number pointer from *pa

--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -78,7 +78,7 @@ void _dupnum(_In_ PNUMBER dest, _In_ PNUMBER src)
 //
 //-----------------------------------------------------------------------------
 
-void _destroynum( _In_ PNUMBER pnum )
+void _destroynum( _Frees_ptr_opt_ PNUMBER pnum )
 
 {
     if ( pnum != nullptr)
@@ -101,7 +101,7 @@ void _destroynum( _In_ PNUMBER pnum )
 //
 //-----------------------------------------------------------------------------
 
-void _destroyrat( _In_ PRAT prat )
+void _destroyrat( _Frees_ptr_opt_ PRAT prat )
 
 {
     if ( prat != nullptr)
@@ -301,7 +301,7 @@ PNUMBER nRadixxtonum( _In_ PNUMBER a, uint32_t radix, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-PNUMBER numtonRadixx(_In_ PNUMBER a, uint32_t radix)
+PNUMBER numtonRadixx(PNUMBER a, uint32_t radix)
 {
     PNUMBER pnumret = longtonum(0, BASEX); // pnumret is the number in internal form.
     PNUMBER num_radix = longtonum(radix, BASEX);
@@ -716,7 +716,7 @@ PNUMBER StringToNumber(wstring_view numberString, uint32_t radix, int32_t precis
 //
 //-----------------------------------------------------------------------------
 
-PRAT longtorat( _In_ long inlong )
+PRAT longtorat(long inlong )
 
 {
     PRAT pratret= nullptr;
@@ -740,7 +740,7 @@ PRAT longtorat( _In_ long inlong )
 //
 //-----------------------------------------------------------------------------
 
-PRAT Ulongtorat( _In_ unsigned long inulong )
+PRAT Ulongtorat(unsigned long inulong )
 
 {
     PRAT pratret= nullptr;

--- a/src/CalcManager/Ratpack/exp.cpp
+++ b/src/CalcManager/Ratpack/exp.cpp
@@ -41,7 +41,7 @@
 //
 //-----------------------------------------------------------------------------
 
-void _exprat( PRAT *px, int32_t precision)
+void _exprat( _Inout_ PRAT *px, int32_t precision)
 
 {
     CREATETAYLOR();
@@ -59,7 +59,7 @@ void _exprat( PRAT *px, int32_t precision)
     DESTROYTAYLOR();
 }
 
-void exprat( PRAT *px, uint32_t radix, int32_t precision)
+void exprat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     PRAT pwr= nullptr;
@@ -152,7 +152,7 @@ void _lograt( PRAT *px, int32_t precision)
 }
 
 
-void lograt( PRAT *px, int32_t precision)
+void lograt( _Inout_ PRAT *px, int32_t precision)
 
 {
     bool fneglog;
@@ -227,7 +227,7 @@ void lograt( PRAT *px, int32_t precision)
     destroyrat(pwr);    
 }
     
-void log10rat( PRAT *px, int32_t precision)
+void log10rat( _Inout_ PRAT *px, int32_t precision)
 
 {
     lograt(px, precision);
@@ -270,7 +270,7 @@ bool IsEven(PRAT x, uint32_t radix, int32_t precision)
 //
 //
 //---------------------------------------------------------------------------
-void powrat(PRAT *px, PRAT y, uint32_t radix, int32_t precision)
+void powrat(_Inout_ PRAT *px, _In_ PRAT y, uint32_t radix, int32_t precision)
 {
     // Handle cases where px or y is 0 by calling powratcomp directly
     if (zerrat(*px) || zerrat(y))
@@ -297,7 +297,7 @@ void powrat(PRAT *px, PRAT y, uint32_t radix, int32_t precision)
     }
 }
 
-void powratNumeratorDenominator(PRAT *px, PRAT y, uint32_t radix, int32_t precision)
+void powratNumeratorDenominator(_Inout_ PRAT *px, _In_ PRAT y, uint32_t radix, int32_t precision)
 {
     // Prepare rationals
     PRAT yNumerator = nullptr;
@@ -406,7 +406,7 @@ void powratNumeratorDenominator(PRAT *px, PRAT y, uint32_t radix, int32_t precis
 //
 //
 //---------------------------------------------------------------------------
-void powratcomp(PRAT *px, PRAT y, uint32_t radix, int32_t precision)
+void powratcomp(_Inout_ PRAT *px, _In_ PRAT y, uint32_t radix, int32_t precision)
 {
     long sign = ((*px)->pp->sign * (*px)->pq->sign);
 

--- a/src/CalcManager/Ratpack/fact.cpp
+++ b/src/CalcManager/Ratpack/fact.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //-----------------------------------------------------------------------------
@@ -193,7 +193,7 @@ void _gamma( PRAT *pn, uint32_t radix, int32_t precision)
     destroyrat(sum);
 }
 
-void factrat( PRAT *px, uint32_t radix, int32_t precision)
+void factrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     PRAT fact = nullptr;

--- a/src/CalcManager/Ratpack/itrans.cpp
+++ b/src/CalcManager/Ratpack/itrans.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //-----------------------------------------------------------------------------
@@ -89,7 +89,7 @@ void asinanglerat( _Inout_ PRAT *pa, ANGLE_TYPE angletype, uint32_t radix, int32
     ascalerat( pa, angletype, precision);
 }
 
-void asinrat( PRAT *px, uint32_t radix, int32_t precision)
+void asinrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     long sgn;
@@ -201,7 +201,7 @@ void _acosrat( PRAT *px, int32_t precision)
     DESTROYTAYLOR();
 }
 
-void acosrat( PRAT *px, uint32_t radix, int32_t precision)
+void acosrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     long sgn;
@@ -288,7 +288,7 @@ void _atanrat( PRAT *px, int32_t precision)
     DESTROYTAYLOR();
 }
 
-void atanrat( PRAT *px, uint32_t radix, int32_t precision)
+void atanrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     long sgn;

--- a/src/CalcManager/Ratpack/itransh.cpp
+++ b/src/CalcManager/Ratpack/itransh.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //-----------------------------------------------------------------------------
@@ -50,7 +50,7 @@
 //
 //-----------------------------------------------------------------------------
 
-void asinhrat( PRAT *px, uint32_t radix, int32_t precision)
+void asinhrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     PRAT neg_pt_eight_five = nullptr;
@@ -107,7 +107,7 @@ void asinhrat( PRAT *px, uint32_t radix, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void acoshrat( PRAT *px, uint32_t radix, int32_t precision)
+void acoshrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     if ( rat_lt( *px, rat_one, precision) )
@@ -144,7 +144,7 @@ void acoshrat( PRAT *px, uint32_t radix, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void atanhrat( PRAT *px, int32_t precision)
+void atanhrat( _Inout_ PRAT *px, int32_t precision)
 
 {
     PRAT ptmp = nullptr;

--- a/src/CalcManager/Ratpack/logic.cpp
+++ b/src/CalcManager/Ratpack/logic.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //---------------------------------------------------------------------------
@@ -18,7 +18,7 @@
 
 
 
-void lshrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void lshrat( _Inout_ PRAT *pa, _In_ PRAT b, uint32_t radix, int32_t precision)
 
 {
     PRAT pwr= nullptr;
@@ -41,7 +41,7 @@ void lshrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
         }
 }
 
-void rshrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void rshrat( _Inout_ PRAT *pa, _In_ PRAT b, uint32_t radix, int32_t precision)
 
 {
     PRAT pwr= nullptr;
@@ -74,19 +74,19 @@ enum {
     FUNC_XOR
 } BOOL_FUNCS;
 
-void andrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void andrat( _Inout_ PRAT *pa, _In_ PRAT b, uint32_t radix, int32_t precision)
 
 {
     boolrat( pa, b, FUNC_AND, radix, precision);
 }
 
-void orrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void orrat( _Inout_ PRAT *pa, _In_ PRAT b, uint32_t radix, int32_t precision)
 
 {
     boolrat( pa, b, FUNC_OR, radix, precision);
 }
 
-void xorrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void xorrat( _Inout_ PRAT *pa, _In_ PRAT b, uint32_t radix, int32_t precision)
 
 {
     boolrat( pa, b, FUNC_XOR, radix, precision);
@@ -195,7 +195,7 @@ void boolnum( PNUMBER *pa, PNUMBER b, int func )
 //
 //-----------------------------------------------------------------------------
 
-void modrat( PRAT *pa, PRAT b )
+void modrat( _Inout_ PRAT *pa, _In_ PRAT b )
 
 {
     PRAT tmp = nullptr;

--- a/src/CalcManager/Ratpack/num.cpp
+++ b/src/CalcManager/Ratpack/num.cpp
@@ -40,9 +40,9 @@ using namespace std;
 //
 //----------------------------------------------------------------------------
 
-void _addnum( PNUMBER *pa, PNUMBER b, uint32_t radix);
+void _addnum( _Inout_ PNUMBER *pa, _In_ PNUMBER b, uint32_t radix);
 
-void __inline addnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
+void __inline addnum( _Inout_ PNUMBER *pa, _In_ PNUMBER b, uint32_t radix)
 
 {
     if ( b->cdigit > 1 || b->mant[0] != 0 )
@@ -58,7 +58,7 @@ void __inline addnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
         }
 }
 
-void _addnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
+void _addnum( _Inout_ PNUMBER *pa, _In_ PNUMBER b, uint32_t radix)
 
 {
     PNUMBER c= nullptr;     // c will contain the result.
@@ -192,9 +192,9 @@ void _addnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
 //
 //----------------------------------------------------------------------------
 
-void _mulnum( PNUMBER *pa, PNUMBER b, uint32_t radix);
+void _mulnum( _Inout_ PNUMBER *pa, _In_ _Const_ PNUMBER b, uint32_t radix);
 
-void __inline mulnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
+void __inline mulnum( _Inout_ PNUMBER *pa, _In_ PNUMBER b, uint32_t radix)
 
 {
     if ( b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0 )
@@ -216,7 +216,7 @@ void __inline mulnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
         }
 }
 
-void _mulnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
+void _mulnum( _Inout_ PNUMBER *pa, _In_ _Const_ PNUMBER b, uint32_t radix)
 
 {
     PNUMBER c= nullptr;         // c will contain the result.
@@ -312,7 +312,7 @@ void _mulnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
 //
 //----------------------------------------------------------------------------
 
-void remnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
+void remnum( _Inout_ PNUMBER *pa, _In_ PNUMBER b, uint32_t radix)
 
 {
     PNUMBER tmp = nullptr;     // tmp is the working remainder.
@@ -375,9 +375,9 @@ void remnum( PNUMBER *pa, PNUMBER b, uint32_t radix)
 //
 //---------------------------------------------------------------------------
 
-void _divnum( PNUMBER *pa, PNUMBER b, uint32_t radix, int32_t precision);
+void _divnum( _Inout_ PNUMBER *pa, _In_ _Const_ PNUMBER b, uint32_t radix, int32_t precision);
 
-void __inline divnum( PNUMBER *pa, PNUMBER b, uint32_t radix, int32_t precision)
+void __inline divnum( _Inout_ PNUMBER *pa, _In_ PNUMBER b, uint32_t radix, int32_t precision)
 
 {
     if ( b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0 )
@@ -391,7 +391,7 @@ void __inline divnum( PNUMBER *pa, PNUMBER b, uint32_t radix, int32_t precision)
         }
 }
 
-void _divnum( PNUMBER *pa, PNUMBER b, uint32_t radix, int32_t precision)
+void _divnum( _Inout_ PNUMBER *pa, _In_ _Const_ PNUMBER b, uint32_t radix, int32_t precision)
 {
     PNUMBER a = *pa;
     long thismax = precision + 2;
@@ -502,7 +502,7 @@ void _divnum( PNUMBER *pa, PNUMBER b, uint32_t radix, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-bool equnum( PNUMBER a, PNUMBER b )
+bool equnum( _In_ PNUMBER a, _In_ PNUMBER b )
 
 {
     long diff;
@@ -570,7 +570,7 @@ bool equnum( PNUMBER a, PNUMBER b )
 //
 //---------------------------------------------------------------------------
 
-bool lessnum( PNUMBER a, PNUMBER b )
+bool lessnum( _In_ PNUMBER a, _In_ PNUMBER b )
 
 {
     long diff;
@@ -632,7 +632,7 @@ bool lessnum( PNUMBER a, PNUMBER b )
 //
 //----------------------------------------------------------------------------
 
-bool zernum( PNUMBER a )
+bool zernum( _In_ PNUMBER a )
 
 {
     long length;

--- a/src/CalcManager/Ratpack/rat.cpp
+++ b/src/CalcManager/Ratpack/rat.cpp
@@ -38,7 +38,7 @@ using namespace std;
 //
 //-----------------------------------------------------------------------------
 
-void gcdrat( PRAT *pa, int32_t precision)
+void gcdrat( _Inout_ PRAT *pa, int32_t precision)
 
 {
     PNUMBER pgcd= nullptr;
@@ -71,7 +71,7 @@ void gcdrat( PRAT *pa, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void fracrat( PRAT *pa , uint32_t radix, int32_t precision)
+void fracrat( _Inout_ PRAT *pa , uint32_t radix, int32_t precision)
 {
     // Only do the flatrat operation if number is nonzero.
     // and only if the bottom part is not one.
@@ -99,7 +99,7 @@ void fracrat( PRAT *pa , uint32_t radix, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void mulrat( PRAT *pa, PRAT b, int32_t precision)
+void mulrat( _Inout_ PRAT *pa, _In_ PRAT b, int32_t precision)
     
     {
     // Only do the multiply if it isn't zero.
@@ -135,7 +135,7 @@ void mulrat( PRAT *pa, PRAT b, int32_t precision)
 //-----------------------------------------------------------------------------
 
 
-void divrat( PRAT *pa, PRAT b, int32_t precision)
+void divrat( _Inout_ PRAT *pa, _In_ PRAT b, int32_t precision)
 
 {
 
@@ -187,7 +187,7 @@ void divrat( PRAT *pa, PRAT b, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void subrat( PRAT *pa, PRAT b, int32_t precision)
+void subrat( _Inout_ PRAT *pa, _In_ PRAT b, int32_t precision)
 
 {
     b->pp->sign *= -1;
@@ -208,7 +208,7 @@ void subrat( PRAT *pa, PRAT b, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void addrat( PRAT *pa, PRAT b, int32_t precision)
+void addrat( _Inout_ PRAT *pa, _In_ PRAT b, int32_t precision)
 
 {
     PNUMBER bot= nullptr;
@@ -263,7 +263,7 @@ void addrat( PRAT *pa, PRAT b, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void rootrat( PRAT *py, PRAT n, uint32_t radix, int32_t precision)
+void rootrat( _Inout_ PRAT *py, _In_ PRAT n, uint32_t radix, int32_t precision)
 {    
     // Initialize 1/n
     PRAT oneovern= nullptr;
@@ -289,7 +289,7 @@ void rootrat( PRAT *py, PRAT n, uint32_t radix, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-bool zerrat( PRAT a )
+bool zerrat( _In_ PRAT a )
 
 {
     return( zernum(a->pp) );

--- a/src/CalcManager/Ratpack/ratpak.h
+++ b/src/CalcManager/Ratpack/ratpak.h
@@ -413,8 +413,8 @@ extern void tananglerat( _Inout_ PRAT *px, ANGLE_TYPE angletype, uint32_t radix,
 
 extern void _dupnum(_In_ PNUMBER dest, _In_ PNUMBER src);
 
-extern void _destroynum( _In_ PNUMBER pnum );
-extern void _destroyrat( _In_ PRAT prat );
+extern void _destroynum( _Frees_ptr_opt_ PNUMBER pnum );
+extern void _destroyrat( _Frees_ptr_opt_ PRAT prat );
 extern void addnum( _Inout_ PNUMBER *pa, _In_ PNUMBER b, uint32_t radix);
 extern void addrat( _Inout_ PRAT *pa, _In_ PRAT b, int32_t precision);
 extern void andrat( _Inout_ PRAT *pa, _In_ PRAT b, uint32_t radix, int32_t precision);
@@ -450,7 +450,7 @@ extern bool rat_gt( _In_ PRAT a, _In_ PRAT b, int32_t precision);
 extern bool rat_ge( _In_ PRAT a, _In_ PRAT b, int32_t precision);
 extern bool rat_lt( _In_ PRAT a, _In_ PRAT b, int32_t precision);
 extern bool rat_le( _In_ PRAT a, _In_ PRAT b, int32_t precision);
-extern void inbetween( _In_ PRAT *px, _In_ PRAT range, int32_t precision);
+extern void inbetween( _Inout_ PRAT *px, _In_ PRAT range, int32_t precision);
 extern void trimit( _Inout_ PRAT *px, int32_t precision);
-extern void _dumprawrat(_In_ const wchar_t *varname, _In_ PRAT rat, std::wostream& out);
-extern void _dumprawnum(_In_ const wchar_t *varname, _In_ PNUMBER num, std::wostream& out);
+extern void _dumprawrat(_In_z_ const wchar_t *varname, _In_ PRAT rat, std::wostream& out);
+extern void _dumprawnum(_In_z_ const wchar_t *varname, _In_ PNUMBER num, std::wostream& out);

--- a/src/CalcManager/Ratpack/support.cpp
+++ b/src/CalcManager/Ratpack/support.cpp
@@ -285,7 +285,7 @@ void ChangeConstants(uint32_t radix, int32_t precision)
 //
 //----------------------------------------------------------------------------
 
-void intrat( PRAT *px, uint32_t radix, int32_t precision)
+void intrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 {
     // Only do the intrat operation if number is nonzero.
     // and only if the bottom part is not one.
@@ -317,7 +317,7 @@ void intrat( PRAT *px, uint32_t radix, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-bool rat_equ( PRAT a, PRAT b, int32_t precision)
+bool rat_equ( _In_ PRAT a, _In_ PRAT b, int32_t precision)
 
 {
     PRAT rattmp= nullptr;
@@ -340,7 +340,7 @@ bool rat_equ( PRAT a, PRAT b, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-bool rat_ge( PRAT a, PRAT b, int32_t precision)
+bool rat_ge( _In_ PRAT a, _In_ PRAT b, int32_t precision)
 
 {
     PRAT rattmp= nullptr;
@@ -366,7 +366,7 @@ bool rat_ge( PRAT a, PRAT b, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-bool rat_gt( PRAT a, PRAT b, int32_t precision)
+bool rat_gt( _In_ PRAT a, _In_ PRAT b, int32_t precision)
 
 {
     PRAT rattmp= nullptr;
@@ -391,7 +391,7 @@ bool rat_gt( PRAT a, PRAT b, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-bool rat_le( PRAT a, PRAT b, int32_t precision)
+bool rat_le( _In_ PRAT a, _In_ PRAT b, int32_t precision)
 
 {
 
@@ -418,7 +418,7 @@ bool rat_le( PRAT a, PRAT b, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-bool rat_lt( PRAT a, PRAT b, int32_t precision)
+bool rat_lt( _In_ PRAT a, _In_ PRAT b, int32_t precision)
 
 {
     PRAT rattmp= nullptr;
@@ -445,7 +445,7 @@ bool rat_lt( PRAT a, PRAT b, int32_t precision)
 //---------------------------------------------------------------------------
 
 
-bool rat_neq( PRAT a, PRAT b, int32_t precision)
+bool rat_neq( _In_ PRAT a, _In_ PRAT b, int32_t precision)
 
 {
     PRAT rattmp= nullptr;
@@ -468,7 +468,7 @@ bool rat_neq( PRAT a, PRAT b, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-void scale( PRAT *px, PRAT scalefact, uint32_t radix, int32_t precision )
+void scale( _Inout_ PRAT *px, _In_ PRAT scalefact, uint32_t radix, int32_t precision )
 {
     PRAT pret = nullptr;
     DUPRAT(pret,*px);
@@ -502,7 +502,7 @@ void scale( PRAT *px, PRAT scalefact, uint32_t radix, int32_t precision )
 //
 //---------------------------------------------------------------------------
 
-void scale2pi( PRAT *px, uint32_t radix, int32_t precision )
+void scale2pi( _Inout_ PRAT *px, uint32_t radix, int32_t precision )
 {
     PRAT pret = nullptr;
     PRAT my_two_pi = nullptr;
@@ -546,7 +546,7 @@ void scale2pi( PRAT *px, uint32_t radix, int32_t precision )
 //
 //---------------------------------------------------------------------------
 
-void inbetween( PRAT *px, PRAT range, int32_t precision)
+void inbetween( _Inout_ PRAT *px, _In_ PRAT range, int32_t precision)
 
 {
     if ( rat_gt(*px,range, precision) )
@@ -575,7 +575,7 @@ void inbetween( PRAT *px, PRAT range, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-void _dumprawrat( const wchar_t *varname, PRAT rat, wostream& out)
+void _dumprawrat( _In_z_ const wchar_t *varname, _In_ PRAT rat, wostream& out)
 
 {
     _dumprawnum(varname, rat->pp, out );
@@ -593,7 +593,7 @@ void _dumprawrat( const wchar_t *varname, PRAT rat, wostream& out)
 //
 //---------------------------------------------------------------------------
 
-void _dumprawnum(const wchar_t *varname, PNUMBER num, wostream& out)
+void _dumprawnum(_In_z_ const wchar_t *varname, _In_ PNUMBER num, wostream& out)
 
 {
     int i;
@@ -676,7 +676,7 @@ void _readconstants( void )
 //
 //---------------------------------------------------------------------------
 
-void trimit( PRAT *px, int32_t precision)
+void trimit( _Inout_ PRAT *px, int32_t precision)
 
 {
     if ( !g_ftrueinfinite )

--- a/src/CalcManager/Ratpack/trans.cpp
+++ b/src/CalcManager/Ratpack/trans.cpp
@@ -191,7 +191,7 @@ void _cosrat( PRAT *px, uint32_t radix, int32_t precision)
         }
 }
 
-void cosrat( PRAT *px, uint32_t radix, int32_t precision)
+void cosrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 {
     scale2pi(px, radix, precision);
     _cosrat(px, radix, precision);
@@ -263,7 +263,7 @@ void _tanrat( PRAT *px, uint32_t radix, int32_t precision)
 
 }
 
-void tanrat( PRAT *px, uint32_t radix, int32_t precision)
+void tanrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 {
     scale2pi(px, radix, precision);
     _tanrat(px, radix, precision);

--- a/src/CalcManager/Ratpack/transh.cpp
+++ b/src/CalcManager/Ratpack/transh.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //-----------------------------------------------------------------------------
@@ -92,7 +92,7 @@ void _sinhrat( PRAT *px, int32_t precision)
     DESTROYTAYLOR();
 }
 
-void sinhrat( PRAT *px, uint32_t radix, int32_t precision)
+void sinhrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     PRAT tmpx= nullptr;
@@ -173,7 +173,7 @@ void _coshrat( PRAT *px, uint32_t radix, int32_t precision)
     DESTROYTAYLOR();
 }
 
-void coshrat( PRAT *px, uint32_t radix, int32_t precision)
+void coshrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     PRAT tmpx= nullptr;
@@ -215,7 +215,7 @@ void coshrat( PRAT *px, uint32_t radix, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void tanhrat( PRAT *px, uint32_t radix, int32_t precision)
+void tanhrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision)
 
 {
     PRAT ptmp= nullptr;

--- a/src/CalcViewModel/CalcViewModel.vcxproj
+++ b/src/CalcViewModel/CalcViewModel.vcxproj
@@ -40,6 +40,7 @@
     <RootNamespace>CalcViewModel</RootNamespace>
     <DefaultLanguage>en-US</DefaultLanguage>
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
+    <PreferredToolArchitecture>x64</PreferredToolArchitecture>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>

--- a/src/CalcViewModel/Common/DateCalculator.cpp
+++ b/src/CalcViewModel/Common/DateCalculator.cpp
@@ -212,6 +212,7 @@ int DateCalculationEngine::GetDifferenceInDays(DateTime date1, DateTime date2)
 
 // Gets number of Calendar days in the month in which this date falls.
 // Returns true if successful, false otherwise.
+_Success_(return)
 bool DateCalculationEngine::TryGetCalendarDaysInMonth(_In_ DateTime date, _Out_ UINT& daysInMonth)
 {
     bool result = false;
@@ -230,6 +231,7 @@ bool DateCalculationEngine::TryGetCalendarDaysInMonth(_In_ DateTime date, _Out_ 
 
 // Gets number of Calendar days in the year in which this date falls.
 // Returns true if successful, false otherwise.
+_Success_(return) 
 bool DateCalculationEngine::TryGetCalendarDaysInYear(_In_ DateTime date, _Out_ UINT& daysInYear)
 {
     bool result = false;

--- a/src/CalcViewModel/Common/DateCalculator.h
+++ b/src/CalcViewModel/Common/DateCalculator.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -53,8 +53,8 @@ namespace CalculatorApp
 
                 // Private Methods
                 int GetDifferenceInDays(Windows::Foundation::DateTime date1, Windows::Foundation::DateTime date2);
-                bool TryGetCalendarDaysInMonth(_In_ Windows::Foundation::DateTime date, _Out_ UINT& daysInMonth);
-                bool TryGetCalendarDaysInYear(_In_ Windows::Foundation::DateTime date, _Out_ UINT& daysInYear);
+                _Success_(return) bool TryGetCalendarDaysInMonth(_In_ Windows::Foundation::DateTime date, _Out_ UINT& daysInMonth);
+                _Success_(return) bool TryGetCalendarDaysInYear(_In_ Windows::Foundation::DateTime date, _Out_ UINT& daysInYear);
                 Windows::Foundation::DateTime AdjustCalendarDate(Windows::Foundation::DateTime date, DateUnit dateUnit, int difference);
             };
         }

--- a/src/CalcViewModel/Common/TraceLogger.cpp
+++ b/src/CalcViewModel/Common/TraceLogger.cpp
@@ -663,7 +663,7 @@ namespace CalculatorApp
         LogTelemetryEvent(EVENT_NAME_VALID_INPUT_PASTED, fields);
     }
 
-    void TraceLogger::LogStandardException(wstring_view functionName, const exception& e) const
+    void TraceLogger::LogStandardException(wstring_view functionName, _In_ const exception& e) const
     {
         if (!GetTraceLoggingProviderEnabled()) return;
 
@@ -675,7 +675,7 @@ namespace CalculatorApp
         LogMeasureEvent(EVENT_NAME_EXCEPTION, fields);
     }
 
-    void TraceLogger::LogWinRTException(wstring_view functionName, hresult_error const& e) const
+    void TraceLogger::LogWinRTException(wstring_view functionName, _In_ hresult_error const& e) const
     {
         if (!GetTraceLoggingProviderEnabled()) return;
 
@@ -686,7 +686,7 @@ namespace CalculatorApp
         LogMeasureEvent(EVENT_NAME_EXCEPTION, fields);
     }
 
-    void TraceLogger::LogPlatformException(wstring_view functionName, Platform::Exception^ e) const
+    void TraceLogger::LogPlatformException(wstring_view functionName, _In_ Platform::Exception^ e) const
     {
         if (!GetTraceLoggingProviderEnabled()) return;
 

--- a/src/CalcViewModel/Common/Utils.cpp
+++ b/src/CalcViewModel/Common/Utils.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //
@@ -94,7 +94,7 @@ wstring Utils::RemoveUnwantedCharsFromWstring(wstring input)
 }
 
 //return wstring after removing characters specified by unwantedChars array
-wstring Utils::RemoveUnwantedCharsFromWstring(wstring input, wchar_t* unwantedChars, unsigned int size)
+wstring Utils::RemoveUnwantedCharsFromWstring(wstring input, _In_reads_(size) wchar_t* unwantedChars, unsigned int size)
 {
     for (unsigned int i = 0; i < size; ++i)
     {

--- a/src/CalcViewModel/Common/Utils.cpp
+++ b/src/CalcViewModel/Common/Utils.cpp
@@ -81,7 +81,7 @@ void Utils::RunOnUIThreadNonblocking(std::function<void()>&& function, _In_ Core
 }
 
 // returns if the last character of a wstring is the target wchar_t
-bool Utils::IsLastCharacterTarget(_In_ wstring const &input, _In_ wchar_t target)
+bool Utils::IsLastCharacterTarget(_In_ wstring const &input, wchar_t target)
 {
     return !input.empty() && input.back() == target;
 }

--- a/src/CalcViewModel/Common/Utils.h
+++ b/src/CalcViewModel/Common/Utils.h
@@ -278,8 +278,8 @@ namespace Utils
 
     void IFTPlatformException(HRESULT hr);
     Platform::String^ GetStringValue(Platform::String^ input);
-    bool IsLastCharacterTarget(std::wstring const &input, wchar_t target);
-    std::wstring RemoveUnwantedCharsFromWstring(std::wstring inputString, wchar_t* unwantedChars, unsigned int size);
+    bool IsLastCharacterTarget(_In_ std::wstring const &input, wchar_t target);
+    std::wstring RemoveUnwantedCharsFromWstring(std::wstring inputString, _In_reads_(size) wchar_t* unwantedChars, unsigned int size);
     std::wstring RemoveUnwantedCharsFromWstring(std::wstring input);
     double GetDoubleFromWstring(std::wstring input);
     int GetWindowId();

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -780,7 +780,7 @@ task<SelectedUnits> CurrencyDataLoader::GetDefaultFromToCurrency()
     co_return make_pair(fromCurrency, toCurrency);
 };
 #pragma optimize("", on)
-
+_Success_(return)
 bool CurrencyDataLoader::TryGetLastUsedCurrenciesFromLocalSettings(_Out_ wstring* const fromCurrency, _Out_ wstring* const toCurrency)
 {
     String^ fromKey = UnitConverterResourceKeys::CurrencyUnitFromKey;

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.h
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.h
@@ -102,7 +102,7 @@ namespace CalculatorApp
             void UnregisterForNetworkBehaviorChanges();
 
             concurrency::task<SelectedUnits> GetDefaultFromToCurrency();
-            bool TryGetLastUsedCurrenciesFromLocalSettings(_Out_ std::wstring* const fromCurrency, _Out_ std::wstring* const toCurrency);
+            _Success_(return) bool TryGetLastUsedCurrenciesFromLocalSettings(_Out_ std::wstring* const fromCurrency, _Out_ std::wstring* const toCurrency);
             void SaveSelectedUnitsToLocalSettings(_In_ const SelectedUnits& selectedUnits);
 
         private:

--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -549,7 +549,7 @@ void UnitConverterDataLoader::GetConversionData(_In_ unordered_map<ViewMode, uno
     }
  }
 
- wstring UnitConverterDataLoader::GetLocalizedStringName(String^ stringId)
+ wstring UnitConverterDataLoader::GetLocalizedStringName(_In_ String^ stringId)
  {
      return AppResourceProvider::GetInstance().GetResourceString(stringId)->Data();
  }

--- a/src/CalcViewModel/DateCalculatorViewModel.h
+++ b/src/CalcViewModel/DateCalculatorViewModel.h
@@ -98,7 +98,7 @@ namespace CalculatorApp
             void UpdateDisplayResult();
             void UpdateStrDateDiffResultAutomationName();
             void UpdateStrDateResultAutomationName();
-            void InitializeDateOutputFormats(Platform::String^ calendarIdentifier);
+            void InitializeDateOutputFormats(_In_ Platform::String^ calendarIdentifier);
             Platform::String^ GetDateDiffString() const;
             Platform::String^ GetDateDiffStringInDays() const;
             Platform::String^ GetLocalizedNumberString(int value) const;

--- a/src/Calculator/Common/TitleBarHelper.cpp
+++ b/src/Calculator/Common/TitleBarHelper.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include "pch.h"
@@ -14,7 +14,7 @@ using namespace Windows::ApplicationModel::Core;
 using namespace Windows::Foundation;
 using namespace Windows::UI::Xaml;
 
-unique_ptr<TitleBarHelper> TitleBarHelper::CreateTitleBarHelperIfNotDocked(FrameworkElement^ customTitleBar)
+unique_ptr<TitleBarHelper> TitleBarHelper::CreateTitleBarHelperIfNotDocked(_In_ FrameworkElement^ customTitleBar)
 {
     return (App::GetAppViewState() == ViewState::DockedView)
         ? nullptr

--- a/src/Calculator/Views/Calculator.xaml.h
+++ b/src/Calculator/Views/Calculator.xaml.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -68,7 +68,7 @@ namespace CalculatorApp
         void SetDefaultFocus();
 
     private:
-        void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void OnLoaded(_In_ Platform::Object^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs^ e);
 
         void LoadResourceStrings();
 

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -86,7 +86,7 @@ MainPage::MainPage() :
     }    
 }
 
-void MainPage::OnNavigatedTo(NavigationEventArgs^ e)
+void MainPage::OnNavigatedTo(_In_ NavigationEventArgs^ e)
 {
     if (m_model->CalculatorViewModel)
     {
@@ -409,7 +409,7 @@ void MainPage::OnNavPaneClosed(_In_ MUXC::NavigationView^ sender, _In_ Object^ a
     this->SetDefaultFocus();
 }
 
-void MainPage::OnAboutButtonClick(Object^ sender, ItemClickEventArgs^ e)
+void MainPage::OnAboutButtonClick(_In_ Object^ sender, _In_ ItemClickEventArgs^ e)
 {
     ShowAboutPage();
 }

--- a/src/Calculator/Views/TitleBar.xaml.h
+++ b/src/Calculator/Views/TitleBar.xaml.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -14,8 +14,8 @@ namespace CalculatorApp
 
         void SetTitleBar();
     private:
-        void OnLoaded(_In_ Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-        void OnUnloaded(_In_ Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void OnLoaded(_In_ Object^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs^ e);
+        void OnUnloaded(_In_ Object^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs^ e);
 
         void Initialize();
         void RegisterForLayoutChanged();


### PR DESCRIPTION
## Fixes:
- Inconsistent annotations causing warnings
- Missing annotations causing warnings about uninitialized _Out_ parameters
- Incorrect annotations in `_destroynum` and `_destroyrat` causing spurious warnings.
- Analyzer crashes on `CalcViewModel` with 32 bit toolchain.

### Description of the changes:
- I had to fix the annotations on a number of functions so that code analysis would build with a reasonable number of warnings. Most of them were just lacking the annotations on the definition, so I could've used `_Use_decl_annotations_`, but it looks more consistent this way.
- Also, analyzer on CalcViewModel uses a ton of memory, and so it won't complete without crashing when run as a 32 bit process. So I enabled the x64 build for it.

Code analysis reveals a couple codepaths where there could be nullptr dereferences. For example, this looks like a legitimate warning:
![pnumret](https://user-images.githubusercontent.com/2142308/54383584-c52b4080-4668-11e9-9fee-a10852a093ef.PNG)
...where `stripzeroesnum` immediately dereferences the pointer.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- No actual functional changes to code. None needed?

There are a whole bunch of other warnings, like uninitialized member variables and also some arithmetic overflow warnings, but it's less obvious if they're legit.
