### PR TITLE
Remove redundant if condition.

### DIFF
--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -988,7 +988,7 @@ void UnitConverterViewModel::OnPaste(String^ stringToPaste, ViewMode mode)
             }
 
             // Negate is only allowed if it's the first legal character, which is handled above.
-            if (NumbersAndOperatorsEnum::None != op && NumbersAndOperatorsEnum::Negate != op)
+            if (NumbersAndOperatorsEnum::Negate != op)
             {
                 UCM::Command cmd = CommandFromButtonId(op);
                 m_model->SendCommand(cmd);


### PR DESCRIPTION
NumbersAndOperatorsEnum::None != op check was already done in the parent "if" (line 972). Hence this redundant check can be dropped safely.