### PR TITLE
Fix compilation issues due to unsigned/signed warnings treated as errors in x86

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -36,7 +36,7 @@ namespace {
         static BYTE    rgbPrec[] = { 0,0,  IDC_OR,0, IDC_XOR,0,  IDC_AND,1,
             IDC_ADD,2, IDC_SUB,2,    IDC_RSHF,3, IDC_LSHF,3,
             IDC_MOD,3, IDC_DIV,3, IDC_MUL,3,  IDC_PWR,4,   IDC_ROOT, 4 };
-        int iPrec;
+        unsigned int iPrec;
 
         iPrec = 0;
         while ((iPrec < size(rgbPrec)) && (nopCode != rgbPrec[iPrec]))
@@ -947,7 +947,7 @@ wstring_view CCalcEngine::OpCodeToUnaryString(int nOpCode, bool fInv, ANGLE_TYPE
     // Try to lookup the ID in the UFNE table
     int ids = 0;
     int iufne = nOpCode - IDC_UNARYFIRST;
-    if (iufne >= 0 && iufne < size(rgUfne))
+    if (iufne >= 0 && (size_t)iufne < size(rgUfne))
     {
         if (fInv)
         {

--- a/src/CalcManager/CEngine/sciset.cpp
+++ b/src/CalcManager/CEngine/sciset.cpp
@@ -56,7 +56,7 @@ LONG CCalcEngine::DwWordBitWidthFromeNumWidth(NUM_WIDTH /*numwidth*/)
     static constexpr int nBitMax[] = { 64, 32, 16, 8 };
     LONG wmax = nBitMax[0];
 
-    if (m_numwidth >= 0 && m_numwidth < size(nBitMax))
+    if (m_numwidth >= 0 && (size_t)m_numwidth < size(nBitMax))
     {
         wmax = nBitMax[m_numwidth];
     }
@@ -69,7 +69,7 @@ uint32_t CCalcEngine::NRadixFromRadixType(RADIX_TYPE radixtype)
     uint32_t radix = 10;
 
     // convert special bases into symbolic values
-    if (radixtype >= 0 && radixtype < size(rgnRadish))
+    if (radixtype >= 0 && (size_t)radixtype < size(rgnRadish))
     {
         radix = rgnRadish[radixtype];
     }

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1648,7 +1648,7 @@ bool StandardCalculatorViewModel::IsOpnd(int nOpCode)
         Command::CommandPNT
     };
 
-    for (int i = 0; i < size(opnd); i++)
+    for (unsigned int i = 0; i < size(opnd); i++)
     {
         if (nOpCode == static_cast<int>(opnd[i]))
         {
@@ -1679,7 +1679,7 @@ bool StandardCalculatorViewModel::IsUnaryOp(int nOpCode)
         Command::CommandCUB
     };
 
-    for (int i = 0; i < size(unaryOp); i++)
+    for (unsigned int i = 0; i < size(unaryOp); i++)
     {
         if (nOpCode == static_cast<int>(unaryOp[i]))
         {
@@ -1706,7 +1706,7 @@ bool StandardCalculatorViewModel::IsTrigOp(int nOpCode)
         Command::CommandATAN
     };
 
-    for (int i = 0; i < size(trigOp); i++)
+    for (unsigned int i = 0; i < size(trigOp); i++)
     {
         if (nOpCode == static_cast<int>(trigOp[i]))
         {
@@ -1729,7 +1729,7 @@ bool StandardCalculatorViewModel::IsBinOp(int nOpCode)
         Command::CommandPWR
     };
 
-    for (int i = 0; i < size(binOp); i++)
+    for (unsigned int i = 0; i < size(binOp); i++)
     {
         if (nOpCode == static_cast<int>(binOp[i]))
         {
@@ -1763,7 +1763,7 @@ bool StandardCalculatorViewModel::IsRecoverableCommand(int nOpCode)
         Command::CommandF
     };
 
-    for (int i = 0; i < size(recoverableCommands); i++)
+    for (unsigned int i = 0; i < size(recoverableCommands); i++)
     {
         if (nOpCode == static_cast<int>(recoverableCommands[i]))
         {


### PR DESCRIPTION
## Fixes #316

It was no more possible to compile the project in x86 due to unsigned/signed warnings. 

### Description of the changes:
- make sure comparisons with size(...) are made with unsigned numbers.

### How changes were validated:
- Project compiled with all architectures.