### PR TITLE
Update the year in the Copyright string

### DIFF
--- a/src/Calculator/AboutFlyout.xaml
+++ b/src/Calculator/AboutFlyout.xaml
@@ -38,7 +38,7 @@
                 <Paragraph>
                     <Run x:Name="AboutFlyoutVersion"/>
                     <LineBreak/>
-                    <Run x:Uid="AboutControlCopyright"/>
+                    <Run x:Name="AboutControlCopyrightRun"/>
                 </Paragraph>
             </RichTextBlock>
             <HyperlinkButton x:Name="AboutFlyoutEULA"

--- a/src/Calculator/AboutFlyout.xaml.cpp
+++ b/src/Calculator/AboutFlyout.xaml.cpp
@@ -20,7 +20,9 @@ using namespace Windows::UI::Xaml::Controls;
 using namespace Windows::UI::Xaml::Controls::Primitives;
 using namespace Windows::UI::Xaml::Data;
 
-#define BUILD_YEAR (__DATE__[7] - '0') * 1000 + (__DATE__[8] - '0') * 100 + (__DATE__[9] - '0') * 10 + (__DATE__[10] - '0')
+#ifndef BUILD_YEAR
+#define BUILD_YEAR 2019
+#endif
 
 AboutFlyout::AboutFlyout()
 {
@@ -37,7 +39,7 @@ AboutFlyout::AboutFlyout()
 
     auto copyrightText = LocalizationStringUtil::GetLocalizedString(resourceLoader.GetResourceString("AboutControlCopyright")->Data(), to_wstring(BUILD_YEAR).c_str());
     AboutControlCopyrightRun->Text = ref new String(copyrightText.c_str());
-    
+
 }
 
 void AboutFlyout::FeedbackButton_Click(_In_ Object^ sender, _In_ RoutedEventArgs^ e)

--- a/src/Calculator/AboutFlyout.xaml.cpp
+++ b/src/Calculator/AboutFlyout.xaml.cpp
@@ -8,6 +8,7 @@
 #include "CalcViewModel/Common/LocalizationStringUtil.h"
 #include "CalcViewModel/Common/TraceLogger.h"
 
+using namespace std;
 using namespace CalculatorApp;
 using namespace CalculatorApp::Common;
 using namespace Platform;
@@ -18,6 +19,8 @@ using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;
 using namespace Windows::UI::Xaml::Controls::Primitives;
 using namespace Windows::UI::Xaml::Data;
+
+#define BUILD_YEAR (__DATE__[7] - '0') * 1000 + (__DATE__[8] - '0') * 100 + (__DATE__[9] - '0') * 10 + (__DATE__[10] - '0')
 
 AboutFlyout::AboutFlyout()
 {
@@ -31,6 +34,10 @@ AboutFlyout::AboutFlyout()
     this->SetVersionString();
 
     Header->Text = resourceLoader.GetResourceString("AboutButton/Content");
+
+    auto copyrightText = LocalizationStringUtil::GetLocalizedString(resourceLoader.GetResourceString("AboutControlCopyright")->Data(), to_wstring(BUILD_YEAR).c_str());
+    AboutControlCopyrightRun->Text = ref new String(copyrightText.c_str());
+    
 }
 
 void AboutFlyout::FeedbackButton_Click(_In_ Object^ sender, _In_ RoutedEventArgs^ e)

--- a/src/Calculator/Resources/af-ZA/Resources.resw
+++ b/src/Calculator/Resources/af-ZA/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft-Privaatheidstelling</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Alle regte voorbehou.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Alle regte voorbehou.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Inligting oor</value>

--- a/src/Calculator/Resources/am-ET/Resources.resw
+++ b/src/Calculator/Resources/am-ET/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>የ Microsoft ግላዊነት መግለጫ</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. ሁሉም መብቱ የተጠበቀ።</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. ሁሉም መብቱ የተጠበቀ።</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>ስለ</value>

--- a/src/Calculator/Resources/ar-SA/Resources.resw
+++ b/src/Calculator/Resources/ar-SA/Resources.resw
@@ -2266,9 +2266,9 @@
     <value>بيان الخصوصية الخاص بشركة Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. جميع الحقوق محفوظة.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. جميع الحقوق محفوظة.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>حول</value>

--- a/src/Calculator/Resources/az-Latn-AZ/Resources.resw
+++ b/src/Calculator/Resources/az-Latn-AZ/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft Məxfilik Bildirişi</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Bütün hüquqlar qorunur.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Bütün hüquqlar qorunur.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Haqqında</value>

--- a/src/Calculator/Resources/be-BY/Resources.resw
+++ b/src/Calculator/Resources/be-BY/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Заява аб канфідэнцыйнасці Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© Microsoft, 2018. Усе правы абароненыя.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© Microsoft, %1. Усе правы абароненыя.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Інфармацыя</value>

--- a/src/Calculator/Resources/bg-BG/Resources.resw
+++ b/src/Calculator/Resources/bg-BG/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Декларация за поверителност на Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Всички права запазени.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Всички права запазени.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Относно</value>

--- a/src/Calculator/Resources/bn-BD/Resources.resw
+++ b/src/Calculator/Resources/bn-BD/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft গোপনীয়তার বিবৃতি</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. সর্বস্বত্ব সংরক্ষিত।</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. সর্বস্বত্ব সংরক্ষিত।</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>বিষয়ক</value>

--- a/src/Calculator/Resources/ca-ES/Resources.resw
+++ b/src/Calculator/Resources/ca-ES/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Declaració de privadesa de Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Tots els drets reservats.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Tots els drets reservats.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Sobre</value>

--- a/src/Calculator/Resources/cs-CZ/Resources.resw
+++ b/src/Calculator/Resources/cs-CZ/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Prohlášení společnosti Microsoft o zásadách ochrany osobních údajů</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Všechna práva vyhrazena.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Všechna práva vyhrazena.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>O aplikaci</value>

--- a/src/Calculator/Resources/da-DK/Resources.resw
+++ b/src/Calculator/Resources/da-DK/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Microsofts erklæring om beskyttelse af personlige oplysninger</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Alle rettigheder forbeholdes.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Alle rettigheder forbeholdes.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Om</value>

--- a/src/Calculator/Resources/de-DE/Resources.resw
+++ b/src/Calculator/Resources/de-DE/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Datenschutzbestimmungen von Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Alle Rechte vorbehalten.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Alle Rechte vorbehalten.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Info</value>

--- a/src/Calculator/Resources/el-GR/Resources.resw
+++ b/src/Calculator/Resources/el-GR/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Δήλωση προστασίας προσωπικών δεδομένων της Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Με επιφύλαξη κάθε νόμιμου δικαιώματος.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Με επιφύλαξη κάθε νόμιμου δικαιώματος.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Πληροφορίες</value>

--- a/src/Calculator/Resources/en-GB/Resources.resw
+++ b/src/Calculator/Resources/en-GB/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Microsoft Privacy Statement</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. All rights reserved.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. All rights reserved.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>About</value>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -2709,9 +2709,9 @@
     <value>Microsoft Privacy Statement</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. All rights reserved.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. All rights reserved.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>About</value>

--- a/src/Calculator/Resources/es-ES/Resources.resw
+++ b/src/Calculator/Resources/es-ES/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Declaración de privacidad de Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Todos los derechos reservados.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Todos los derechos reservados.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Acerca de</value>

--- a/src/Calculator/Resources/es-MX/Resources.resw
+++ b/src/Calculator/Resources/es-MX/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Declaración de privacidad de Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Todos los derechos reservados.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Todos los derechos reservados.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Acerca de</value>

--- a/src/Calculator/Resources/et-EE/Resources.resw
+++ b/src/Calculator/Resources/et-EE/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsofti privaatsusavaldus</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Kõik õigused on reserveeritud.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Kõik õigused on reserveeritud.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Teave</value>

--- a/src/Calculator/Resources/eu-ES/Resources.resw
+++ b/src/Calculator/Resources/eu-ES/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft Pribatutasun-adierazpena</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Eskubide guztiak erreserbatuta.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Eskubide guztiak erreserbatuta.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Honi buruz</value>

--- a/src/Calculator/Resources/fa-IR/Resources.resw
+++ b/src/Calculator/Resources/fa-IR/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>بیانیه حریم خصوصی Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. کلیه حقوق محفوظ است.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. کلیه حقوق محفوظ است.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>درباره</value>

--- a/src/Calculator/Resources/fi-FI/Resources.resw
+++ b/src/Calculator/Resources/fi-FI/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoftin tietosuojatiedot</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Kaikki oikeudet pidätetään.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Kaikki oikeudet pidätetään.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Tietoja</value>

--- a/src/Calculator/Resources/fil-PH/Resources.resw
+++ b/src/Calculator/Resources/fil-PH/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Pahayag ng Pagiging Pribado ng Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Nakalaan ang lahat ng karapatan.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Nakalaan ang lahat ng karapatan.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Tungkol Dito</value>

--- a/src/Calculator/Resources/fr-CA/Resources.resw
+++ b/src/Calculator/Resources/fr-CA/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Énoncé de confidentialité Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Tous droits réservés.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>%1 Microsoft. Tous droits réservés.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>À propos de</value>

--- a/src/Calculator/Resources/fr-FR/Resources.resw
+++ b/src/Calculator/Resources/fr-FR/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Déclaration de confidentialité Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Tous droits réservés.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Tous droits réservés.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>À propos de</value>

--- a/src/Calculator/Resources/gl-ES/Resources.resw
+++ b/src/Calculator/Resources/gl-ES/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Declaración de privacidade de Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Todos os dereitos reservados.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Todos os dereitos reservados.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Acerca de</value>

--- a/src/Calculator/Resources/he-IL/Resources.resw
+++ b/src/Calculator/Resources/he-IL/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>הצהרת הפרטיות של Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>‎© 2018 Microsoft. כל הזכויות שמורות.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>‎© %1 Microsoft. כל הזכויות שמורות.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>אודות</value>

--- a/src/Calculator/Resources/hi-IN/Resources.resw
+++ b/src/Calculator/Resources/hi-IN/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft गोपनीयता कथन</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. सर्वाधिकार सुरक्षित.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. सर्वाधिकार सुरक्षित.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>के बारे में</value>

--- a/src/Calculator/Resources/hr-HR/Resources.resw
+++ b/src/Calculator/Resources/hr-HR/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoftova izjava o zaštiti privatnosti</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
+  <data name="AboutControlCopyright" xml:space="preserve">
     <value>© 2018. Microsoft. Sva prava pridržana.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>O programu</value>

--- a/src/Calculator/Resources/hu-HU/Resources.resw
+++ b/src/Calculator/Resources/hu-HU/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>A Microsoft adatvédelmi nyilatkozata</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Minden jog fenntartva.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Minden jog fenntartva.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Névjegy</value>

--- a/src/Calculator/Resources/id-ID/Resources.resw
+++ b/src/Calculator/Resources/id-ID/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Pernyataan Privasi Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Hak cipta dilindungi undang-undang.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Hak cipta dilindungi undang-undang.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Tentang</value>

--- a/src/Calculator/Resources/is-IS/Resources.resw
+++ b/src/Calculator/Resources/is-IS/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Yfirlýsing Microsoft um persónuvernd</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Allur réttur áskilinn.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Allur réttur áskilinn.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Um</value>

--- a/src/Calculator/Resources/it-IT/Resources.resw
+++ b/src/Calculator/Resources/it-IT/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Informativa sulla privacy di Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Tutti i diritti sono riservati.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Tutti i diritti sono riservati.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Informazioni</value>

--- a/src/Calculator/Resources/ja-JP/Resources.resw
+++ b/src/Calculator/Resources/ja-JP/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Microsoft のプライバシーに関する声明</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. All rights reserved.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. All rights reserved.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>バージョン情報</value>

--- a/src/Calculator/Resources/kk-KZ/Resources.resw
+++ b/src/Calculator/Resources/kk-KZ/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft құпиялылық туралы мәлімдемесі</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Барлық құқықтар қорғалған.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Барлық құқықтар қорғалған.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Бағдарлама туралы</value>

--- a/src/Calculator/Resources/km-KH/Resources.resw
+++ b/src/Calculator/Resources/km-KH/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>ព័ត៌មាន​ឯកត្តជន Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. រក្សាសិទ្ធិគ្រប់បែបយ៉ាង។</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. រក្សាសិទ្ធិគ្រប់បែបយ៉ាង។</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>អំពី</value>

--- a/src/Calculator/Resources/kn-IN/Resources.resw
+++ b/src/Calculator/Resources/kn-IN/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft ಗೌಪ್ಯತೆ ಹೇಳಿಕೆ</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. ಎಲ್ಲ ಹಕ್ಕುಗಳನ್ನು ಕಾಯ್ದಿರಿಸಲಾಗಿದೆ.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. ಎಲ್ಲ ಹಕ್ಕುಗಳನ್ನು ಕಾಯ್ದಿರಿಸಲಾಗಿದೆ.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>ಕುರಿತು</value>

--- a/src/Calculator/Resources/ko-KR/Resources.resw
+++ b/src/Calculator/Resources/ko-KR/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft 개인정보취급방침</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. All rights reserved.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. All rights reserved.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>정보</value>

--- a/src/Calculator/Resources/lo-LA/Resources.resw
+++ b/src/Calculator/Resources/lo-LA/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>ຄໍາຖະແຫຼງຄວາມເປັນສ່ວນຕົວຂອງ Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. ສະຫງວນລິຂະສິດ.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. ສະຫງວນລິຂະສິດ.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>ກ່ຽວກັບ</value>

--- a/src/Calculator/Resources/lt-LT/Resources.resw
+++ b/src/Calculator/Resources/lt-LT/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>„Microsoft“ privatumo patvirtinimas</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© „Microsoft“, 2018 m. Visos teisės ginamos.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© „Microsoft“, %1 m. Visos teisės ginamos.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Apie</value>

--- a/src/Calculator/Resources/lv-LV/Resources.resw
+++ b/src/Calculator/Resources/lv-LV/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft paziņojums par konfidencialitāti</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Visas tiesības paturētas.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Visas tiesības paturētas.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Par</value>

--- a/src/Calculator/Resources/mk-MK/Resources.resw
+++ b/src/Calculator/Resources/mk-MK/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Изјава на Microsoft за заштита на личните податоци</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft Corporation. Сите права се задржани.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft Corporation. Сите права се задржани.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>За</value>

--- a/src/Calculator/Resources/ml-IN/Resources.resw
+++ b/src/Calculator/Resources/ml-IN/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft സ്വകാര്യതാ പ്രസ്താവന</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. എല്ലാ അവകാശങ്ങളും സംവരണം ചെയ്തിരിക്കുന്നു.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. എല്ലാ അവകാശങ്ങളും സംവരണം ചെയ്തിരിക്കുന്നു.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>വിവരം</value>

--- a/src/Calculator/Resources/ms-MY/Resources.resw
+++ b/src/Calculator/Resources/ms-MY/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Pernyataan Privasi Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Hak cipta terpelihara.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Hak cipta terpelihara.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Perihal</value>

--- a/src/Calculator/Resources/nb-NO/Resources.resw
+++ b/src/Calculator/Resources/nb-NO/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsofts personvernerklæring</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Med enerett.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Med enerett.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Om</value>

--- a/src/Calculator/Resources/nl-NL/Resources.resw
+++ b/src/Calculator/Resources/nl-NL/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Privacyverklaring van Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Alle rechten voorbehouden.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Alle rechten voorbehouden.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Info over</value>

--- a/src/Calculator/Resources/pl-PL/Resources.resw
+++ b/src/Calculator/Resources/pl-PL/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Zasady zachowania poufności informacji firmy Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Wszelkie prawa zastrzeżone.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Wszelkie prawa zastrzeżone.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Informacje</value>

--- a/src/Calculator/Resources/pt-BR/Resources.resw
+++ b/src/Calculator/Resources/pt-BR/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Política de Privacidade da Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Todos os direitos reservados.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Todos os direitos reservados.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Sobre</value>

--- a/src/Calculator/Resources/pt-PT/Resources.resw
+++ b/src/Calculator/Resources/pt-PT/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Declaração de Privacidade da Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Todos os direitos reservados.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Todos os direitos reservados.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Acerca de</value>

--- a/src/Calculator/Resources/ro-RO/Resources.resw
+++ b/src/Calculator/Resources/ro-RO/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Angajamentul de respectare a confidențialității Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Toate drepturile rezervate.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Toate drepturile rezervate.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Despre</value>

--- a/src/Calculator/Resources/ru-RU/Resources.resw
+++ b/src/Calculator/Resources/ru-RU/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Заявление о конфиденциальности Майкрософт</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© Корпорация Майкрософт (Microsoft Corporation), 2018. Все права защищены.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© Корпорация Майкрософт (Microsoft Corporation), %1. Все права защищены.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>О программе</value>

--- a/src/Calculator/Resources/sk-SK/Resources.resw
+++ b/src/Calculator/Resources/sk-SK/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Prehlásenie spoločnosti Microsoft o ochrane osobných údajov</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Všetky práva vyhradené.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Všetky práva vyhradené.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Informácie</value>

--- a/src/Calculator/Resources/sl-SI/Resources.resw
+++ b/src/Calculator/Resources/sl-SI/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoftova izjava o zasebnosti</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Vse pravice pridržane.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Vse pravice pridržane.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Vizitka</value>

--- a/src/Calculator/Resources/sq-AL/Resources.resw
+++ b/src/Calculator/Resources/sq-AL/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Deklarata e privatësisë e Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Të gjitha të drejtat të rezervuara.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Të gjitha të drejtat të rezervuara.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Rreth</value>

--- a/src/Calculator/Resources/sr-Latn-RS/Resources.resw
+++ b/src/Calculator/Resources/sr-Latn-RS/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft izjava o privatnosti</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Sva prava zadržana.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Sva prava zadržana.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Osnovni podaci o</value>

--- a/src/Calculator/Resources/sv-SE/Resources.resw
+++ b/src/Calculator/Resources/sv-SE/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsofts sekretesspolicy</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Med ensamrätt.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Med ensamrätt.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Om</value>

--- a/src/Calculator/Resources/sw-KE/Resources.resw
+++ b/src/Calculator/Resources/sw-KE/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Taarifa ya Faragha ya Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Haki zote zimehifadhiwa.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Haki zote zimehifadhiwa.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Kuhusu</value>

--- a/src/Calculator/Resources/ta-IN/Resources.resw
+++ b/src/Calculator/Resources/ta-IN/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft தனியுரிமை அறிக்கை</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. அனைத்து உரிமைகளும் பாதுகாக்கப்பட்டவை.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. அனைத்து உரிமைகளும் பாதுகாக்கப்பட்டவை.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>இது பற்றி</value>

--- a/src/Calculator/Resources/te-IN/Resources.resw
+++ b/src/Calculator/Resources/te-IN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Microsoft గోప్యతా ప్రకటన</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. అన్ని హక్కులు ప్రత్యేకించినవి.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. అన్ని హక్కులు ప్రత్యేకించినవి.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>గురించి</value>

--- a/src/Calculator/Resources/th-TH/Resources.resw
+++ b/src/Calculator/Resources/th-TH/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>คำชี้แจงสิทธิ์ส่วนบุคคลของ Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. All rights reserved.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. All rights reserved.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>เกี่ยวกับ</value>

--- a/src/Calculator/Resources/tr-TR/Resources.resw
+++ b/src/Calculator/Resources/tr-TR/Resources.resw
@@ -2266,9 +2266,9 @@
     <value>Microsoft Gizlilik Bildirimi</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Tüm hakları saklıdır.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Tüm hakları saklıdır.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Hakkında</value>

--- a/src/Calculator/Resources/uk-UA/Resources.resw
+++ b/src/Calculator/Resources/uk-UA/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Декларація корпорації Майкрософт про конфіденційність</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© Корпорація Майкрософт (Microsoft Corporation), 2018. Усі права захищено.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© Корпорація Майкрософт (Microsoft Corporation), %1. Усі права захищено.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Про програму</value>

--- a/src/Calculator/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/Calculator/Resources/uz-Latn-UZ/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft Maxfiylik bayonnomasi</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Barcha huquqlar himoyalangan.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Barcha huquqlar himoyalangan.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Haqida</value>

--- a/src/Calculator/Resources/vi-VN/Resources.resw
+++ b/src/Calculator/Resources/vi-VN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Điều khoản về Quyền riêng tư của Microsoft</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. Bảo lưu mọi quyền.</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. Bảo lưu mọi quyền.</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>Giới thiệu</value>

--- a/src/Calculator/Resources/zh-CN/Resources.resw
+++ b/src/Calculator/Resources/zh-CN/Resources.resw
@@ -2265,9 +2265,9 @@
     <value>Microsoft 隐私声明</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft。保留所有权利。</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft。保留所有权利。</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>关于</value>

--- a/src/Calculator/Resources/zh-TW/Resources.resw
+++ b/src/Calculator/Resources/zh-TW/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2265,9 +2265,9 @@
     <value>Microsoft 隱私權聲明</value>
     <comment>Displayed on a link to the Microsoft Privacy Statement on the About panel</comment>
   </data>
-  <data name="AboutControlCopyright.Text" xml:space="preserve">
-    <value>© 2018 Microsoft. 著作權所有，並保留一切權利。</value>
-    <comment>Copyright statement, displayed on the About panel</comment>
+  <data name="AboutControlCopyright" xml:space="preserve">
+    <value>© %1 Microsoft. 著作權所有，並保留一切權利。</value>
+    <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>關於</value>

--- a/src/Calculator/pch.h
+++ b/src/Calculator/pch.h
@@ -21,6 +21,7 @@
 #include <sstream>
 #include <concrt.h>
 #include <regex>
+#include <string>
 
 // C++\WinRT Headers
 #include "winrt/base.h"
@@ -44,5 +45,3 @@ namespace CustomPeers = CalculatorApp::Common::Automation;
 
 // Project Headers
 #include "App.xaml.h"
-
-#include <string>

--- a/src/Calculator/pch.h
+++ b/src/Calculator/pch.h
@@ -44,3 +44,5 @@ namespace CustomPeers = CalculatorApp::Common::Automation;
 
 // Project Headers
 #include "App.xaml.h"
+
+#include <string>


### PR DESCRIPTION
## Fixes #319

Templatize the copyright string and use a preprocessor definition to set the year, so the build server will be able to update it.

### How changes were validated:
- tested with English and French and with different dates.