### PR TITLE
Use operator""sv to ensure string_view are initialized correctly

### DIFF
--- a/src/CalcManager/CEngine/calc.cpp
+++ b/src/CalcManager/CEngine/calc.cpp
@@ -19,8 +19,8 @@ static constexpr long DEFAULT_RADIX = 10;
 
 static constexpr wchar_t DEFAULT_DEC_SEPARATOR = L'.';
 static constexpr wchar_t DEFAULT_GRP_SEPARATOR = L',';
-static constexpr wstring_view DEFAULT_GRP_STR = L"3;0";
-static constexpr wstring_view DEFAULT_NUMBER_STR = L"0";
+static constexpr wstring_view DEFAULT_GRP_STR = L"3;0"sv;
+static constexpr wstring_view DEFAULT_NUMBER_STR = L"0"sv;
 
 // Read strings for keys, errors, trig types, etc.
 // These will be copied from the resources to local memory.

--- a/src/CalcManager/CEngine/scidisp.cpp
+++ b/src/CalcManager/CEngine/scidisp.cpp
@@ -20,8 +20,8 @@ using namespace CalcEngine;
 
 constexpr int MAX_EXPONENT = 4;
 constexpr uint32_t MAX_GROUPING_SIZE = 16;
-constexpr wstring_view c_decPreSepStr = L"[+-]?(\\d*)[";
-constexpr wstring_view c_decPostSepStr = L"]?(\\d*)(?:e[+-]?(\\d*))?$";
+constexpr wstring_view c_decPreSepStr = L"[+-]?(\\d*)["sv;
+constexpr wstring_view c_decPostSepStr = L"]?(\\d*)(?:e[+-]?(\\d*))?$"sv;
 
 
 /****************************************************************************\


### PR DESCRIPTION
Addresses following warning raised by clang:
```
src/CalcManager/CEngine/scidisp.cpp:23:24: error: constexpr variable 'c_decPreSepStr' must be initialized by a constant expression
constexpr wstring_view c_decPreSepStr = L"[+-]?(\\d*)[";
                       ^                ~~~~~~~~~~~~~~~
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/bits/char_traits.h:431:11: note: non-constexpr function 'wcslen' cannot be used in a constant expression
          return wcslen(__s);
                 ^
/usr/bin/../lib64/gcc/x86_64-pc-linux-gnu/8.2.1/../../../../include/c++/8.2.1/string_view:100:39: note: in call to 'length(&L"[+-]?(\\d*)["[0])'
      : _M_len{__str == nullptr ? 0 : traits_type::length(__str)},
                                      ^
```

### Description of the changes:
- Addresses a warning raised by clang. I'm not 100% positive it's not a bug in the STL implementation used by my compiler, but doesn't cause other issues.