### PR TITLE
Hide the history button when in Programmer mode

### DIFF
--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -515,6 +515,7 @@
                         <Setter Target="M5.MaxWidth" Value="80"/>
                         <Setter Target="memButton.(Grid.Column)" Value="5"/>
                         <Setter Target="MemoryButton.(Grid.Column)" Value="6"/>
+                        <Setter Target="HistoryButton.Visibility" Value="Collapsed"/>
                     </VisualState.Setters>
                     <Storyboard Completed="OnStoryboardCompleted"/>
                 </VisualState>

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -415,7 +415,7 @@ void Calculator::UpdateHistoryState()
         SetChildAsHistory();
         HistoryButton->Visibility = ::Visibility::Collapsed;
 
-        if (m_IsLastFlyoutHistory)
+        if (!IsProgrammer && m_IsLastFlyoutHistory)
         {
             DockPivot->SelectedIndex = 0;
         }
@@ -522,7 +522,7 @@ void Calculator::HistoryFlyout_Closed(_In_ Object ^sender, _In_ Object ^args)
     AutomationProperties::SetName(HistoryButton, m_openHistoryFlyoutAutomationName);
     m_fIsHistoryFlyoutOpen = false;
     EnableControls(true);
-    if (HistoryButton->IsEnabled)
+    if (HistoryButton->IsEnabled && HistoryButton->Visibility == ::Visibility::Visible)
     {
         HistoryButton->Focus(::FocusState::Programmatic);
     }


### PR DESCRIPTION
## Fixes #326


### Description of the changes:
- Hide the History button when in Programmer mode via VisualState

### How changes were validated:
- Open Standard mode
- Switch to Programmer mode
- Verify that the History button isn't visible

**Bug:**
![image](https://user-images.githubusercontent.com/1226538/54543247-89d78d00-495a-11e9-8ab3-430df741caa6.png)