### PR TITLE
Remove unused member field from CalculatorHistory

### DIFF
--- a/src/CalcManager/CalculatorHistory.cpp
+++ b/src/CalcManager/CalculatorHistory.cpp
@@ -7,8 +7,7 @@
 using namespace std;
 using namespace CalculationManager;
 
-CalculatorHistory::CalculatorHistory(CALCULATOR_MODE eMode, size_t maxSize) :
-    m_mode(eMode),
+CalculatorHistory::CalculatorHistory(size_t maxSize) :
     m_maxHistorySize(maxSize)
 {}
 

--- a/src/CalcManager/CalculatorHistory.h
+++ b/src/CalcManager/CalculatorHistory.h
@@ -31,7 +31,7 @@ namespace CalculationManager
     {
 
     public:
-        CalculatorHistory(CALCULATOR_MODE eMode, const size_t maxSize);
+        CalculatorHistory(const size_t maxSize);
         unsigned int AddToHistory(_In_ std::shared_ptr<CalculatorVector <std::pair<std::wstring, int>>> const &spTokens, _In_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &spCommands, std::wstring_view result);
         std::vector<std::shared_ptr<HISTORYITEM>> const& GetHistory();
         std::shared_ptr<HISTORYITEM> const& GetHistoryItem(unsigned int uIdx);
@@ -43,7 +43,6 @@ namespace CalculationManager
 
     private:
         std::vector<std::shared_ptr<HISTORYITEM>> m_historyItems;
-        CALCULATOR_MODE m_mode;
         const size_t m_maxHistorySize;
     };
 }

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -30,8 +30,8 @@ namespace CalculationManager
         m_isExponentialFormat(false),
         m_persistedPrimaryValue(),
         m_currentCalculatorEngine(nullptr),
-        m_pStdHistory(new CalculatorHistory(CM_STD, MAX_HISTORY_ITEMS)),
-        m_pSciHistory(new CalculatorHistory(CM_SCI, MAX_HISTORY_ITEMS)),
+        m_pStdHistory(new CalculatorHistory(MAX_HISTORY_ITEMS)),
+        m_pSciHistory(new CalculatorHistory(MAX_HISTORY_ITEMS)),
         m_inHistoryItemLoadMode(false)
     {
         CCalcEngine::InitialOneTimeOnlySetup(*m_resourceProvider);

--- a/src/CalculatorUnitTests/CalcEngineTests.cpp
+++ b/src/CalculatorUnitTests/CalcEngineTests.cpp
@@ -20,7 +20,7 @@ namespace CalculatorUnitTests
         TEST_METHOD_INITIALIZE(CommonSetup)
         {
             m_resourceProvider = make_shared<EngineResourceProvider>();
-            m_history = make_shared<CalculatorHistory>(CM_STD, MAX_HISTORY_SIZE);
+            m_history = make_shared<CalculatorHistory>(MAX_HISTORY_SIZE);
             CCalcEngine::InitialOneTimeOnlySetup(*(m_resourceProvider.get()));
             m_calcEngine = make_unique<CCalcEngine>(false /* Respect Order of Operations */, false /* Set to Integer Mode */, m_resourceProvider.get(), nullptr, m_history);
         }


### PR DESCRIPTION
`m_mode` field was assigned to, but never read from.