### PR TITLE
Make CalculatorManager final rather than sealed

### DIFF
--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -42,7 +42,7 @@ namespace CalculationManager
         MemorizedNumberClear = 335
     };
 
-    class CalculatorManager sealed : public ICalcDisplay
+    class CalculatorManager final : public ICalcDisplay
     {
     private:
         ICalcDisplay* const m_displayCallback;


### PR DESCRIPTION
I have no idea if it is required to be `sealed`, I have seen no `^`
operator which makes me think it could be a regular C++ code, barring
the concurrency stuff.