### PR TITLE
Fix order of initialization list in CalculatorManager ctor

### DIFF
--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -24,15 +24,15 @@ namespace CalculationManager
 {
     CalculatorManager::CalculatorManager(_In_ ICalcDisplay* displayCallback, _In_ IResourceProvider* resourceProvider) :
         m_displayCallback(displayCallback),
+        m_currentCalculatorEngine(nullptr),
         m_resourceProvider(resourceProvider),
+        m_inHistoryItemLoadMode(false),
+        m_persistedPrimaryValue(),
+        m_isExponentialFormat(false),
         m_currentDegreeMode(Command::CommandNULL),
         m_savedDegreeMode(Command::CommandDEG),
-        m_isExponentialFormat(false),
-        m_persistedPrimaryValue(),
-        m_currentCalculatorEngine(nullptr),
         m_pStdHistory(new CalculatorHistory(MAX_HISTORY_ITEMS)),
-        m_pSciHistory(new CalculatorHistory(MAX_HISTORY_ITEMS)),
-        m_inHistoryItemLoadMode(false)
+        m_pSciHistory(new CalculatorHistory(MAX_HISTORY_ITEMS))
     {
         CCalcEngine::InitialOneTimeOnlySetup(*m_resourceProvider);
     }

--- a/src/CalcManager/ExpressionCommand.cpp
+++ b/src/CalcManager/ExpressionCommand.cpp
@@ -98,8 +98,8 @@ void CBinaryCommand::Accept(_In_ ISerializeCommandVisitor &commandVisitor)
 COpndCommand::COpndCommand(shared_ptr<CalculatorVector<int>> const &commands, bool fNegative, bool fDecimal, bool fSciFmt) :
     m_commands(commands),
     m_fNegative(fNegative),
-    m_fDecimal(fDecimal),
     m_fSciFmt(fSciFmt),
+    m_fDecimal(fDecimal),
     m_fInitialized(false),
     m_value{}
 {}


### PR DESCRIPTION
This ensures the initialization order matches the layout of member
fields in class declaration

This will conflict with https://github.com/Microsoft/calculator/pull/330, but I will rebase the loser