### PR TITLE
Minor corrections to the german locale.

### DIFF
--- a/src/Calculator/Resources/de-DE/Resources.resw
+++ b/src/Calculator/Resources/de-DE/Resources.resw
@@ -422,7 +422,7 @@
     <comment>This is the automation name and label for the memory button when the memory flyout is open.</comment>
   </data>
   <data name="MemoryButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Arbeitsspeicher</value>
+    <value>Speicher</value>
     <comment>This is the tool tip automation name for the memory button.</comment>
   </data>
   <data name="HistoryButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -442,7 +442,7 @@
     <comment>This is the tool tip automation name for the Clear Memory (MC) button.</comment>
   </data>
   <data name="MemoryLabel.Text" xml:space="preserve">
-    <value>Arbeitsspeicher</value>
+    <value>Speicher</value>
     <comment>The text that shows as the header for the memory list</comment>
   </data>
   <data name="MemoryPivotItem.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
@@ -550,7 +550,7 @@
     <comment>Screen reader prompt for the history flyout</comment>
   </data>
   <data name="MemoryPane" xml:space="preserve">
-    <value>Arbeitsspeicher</value>
+    <value>Speicher</value>
     <comment>Screen reader prompt for the memory flyout</comment>
   </data>
   <data name="Format_HexButtonValue" xml:space="preserve">
@@ -594,7 +594,7 @@
     <comment>Screen reader prompt for the Calculator Memory button</comment>
   </data>
   <data name="memButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Gespeicherten Wert speichern (STRG+M)</value>
+    <value>Angezeigten Wert speichern (STRG+M)</value>
     <comment>This is the tool tip automation name for the Memory Store (MS) button.</comment>
   </data>
   <data name="ClearMemoryButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
@@ -918,7 +918,7 @@
     <comment>Screen reader prompt for the Calculator cos button  on the scientific operator keypad</comment>
   </data>
   <data name="tanButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Tagens</value>
+    <value>Tangens</value>
     <comment>Screen reader prompt for the Calculator tan button  on the scientific operator keypad</comment>
   </data>
   <data name="sinhButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
@@ -1030,11 +1030,11 @@
     <comment>This is the Deg button's Rad mode automation name on the scientific operator keypad. Should read as "Radians toggle button".</comment>
   </data>
   <data name="FlyoutNav.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Modus-Dropdownfeld</value>
+    <value>Modus-Auswahlfeld</value>
     <comment>Screen reader prompt for the Mode dropdown field in Snapped and Portrait modes.</comment>
   </data>
   <data name="Categories.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Kategorie-Dropdownfeld</value>
+    <value>Kategorie-Auswahlfeld</value>
     <comment>Screen reader prompt for the Categories dropdown field.</comment>
   </data>
   <data name="Format_ValueFrom" xml:space="preserve">
@@ -1150,7 +1150,7 @@
     <comment>A measurement unit for volume. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitAbbreviation_Liter" xml:space="preserve">
-    <value>L</value>
+    <value>l</value>
     <comment>An abbreviation for a measurement unit of volume</comment>
   </data>
   <data name="UnitName_Milliliter" xml:space="preserve">
@@ -1158,7 +1158,7 @@
     <comment>A measurement unit for volume. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitAbbreviation_Milliliter" xml:space="preserve">
-    <value>mL</value>
+    <value>ml</value>
     <comment>An abbreviation for a measurement unit of volume</comment>
   </data>
   <data name="UnitName_PintUK" xml:space="preserve">
@@ -1494,7 +1494,7 @@
     <comment>An abbreviation for a measurement unit of power</comment>
   </data>
   <data name="UnitAbbreviation_Week" xml:space="preserve">
-    <value>wo</value>
+    <value>w</value>
     <comment>An abbreviation for a measurement unit of time</comment>
   </data>
   <data name="UnitAbbreviation_Yard" xml:space="preserve">
@@ -1594,7 +1594,7 @@
     <comment>An abbreviation for a measurement unit of data</comment>
   </data>
   <data name="UnitName_Acre" xml:space="preserve">
-    <value>Morgen</value>
+    <value>Acre</value>
     <comment>A measurement unit for area. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Bit" xml:space="preserve">
@@ -1866,7 +1866,7 @@
     <comment>A measurement unit for time. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitAbbreviation_Carat" xml:space="preserve">
-    <value>cd</value>
+    <value>Kt</value>
     <comment>An abbreviation for a measurement unit of weight</comment>
   </data>
   <data name="UnitAbbreviation_Degree" xml:space="preserve">
@@ -2186,11 +2186,11 @@
     <comment>An Olympic-sized swimming pool, used as a comparison measurement unit for volume. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Hand" xml:space="preserve">
-    <value>Hand</value>
+    <value>Hände</value>
     <comment>A human hand, used as a comparison measurement unit for length or area. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitAbbreviation_Hand" xml:space="preserve">
-    <value>Hand</value>
+    <value>Hände</value>
     <comment>A human hand, used as a comparison measurement unit for length or area. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Paper" xml:space="preserve">


### PR DESCRIPTION
## Fixes #.
Minor corrections to the german locale.

### Description of the changes:
Strings in Resources.resw for de-DE edited. Despriction of the changes: 'Arbeitsspeicher' --> 'Speicher', there is just the memory. A split in memory and random access memory (Arbeitsspeicher) is confusing. 'Gespeicherten Wert speichern' --> 'Angezeigten Wert speichern', there is no memory saved till i hit the set (MS) button. 'Tagens' in line 918 --> 'Tangens', just a spelling mistake. 'Modus-Dropdownfeld' and 'Kategorie-Dropdownfeld' --> '-Auswahlfeld', 'Auswahl' is more common than Dropdown. 'L' --> 'l', cause the official abbreviation for liter (ISO, IEC) is l. Also edited this for milliliter. 'wo' --> 'w', with respect to ISO8601. Line 1597 changed to 'Acre' insted of 'Morgen'. 'cd' --> 'Kt' as common abbreviation for Carat. 'Hand' --> 'Hände', because there are just the plural forms used.

### How changes were validated:
Official reference work like Duden and my native language experience.