### PR TITLE
Accept plus/minus sign before a parenthesis in ClipboardManager

### DIFF
--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -44,8 +44,8 @@ static const array<wregex, 1> standardModePatterns =
 };
 static const array<wregex, 2> scientificModePatterns =
 {
-    wregex(c_wspcLParens + c_signedDecFloat + c_wspcRParens),
-    wregex(c_wspcLParens + c_signedDecFloat + L"[e]([+]|[-])+\\d+" + c_wspcRParens)
+    wregex(L"[-+]?" + c_wspcLParens + c_signedDecFloat + c_wspcRParens),
+    wregex(L"[-+]?" + c_wspcLParens + c_signedDecFloat + L"[e]([+]|[-])+\\d+" + c_wspcRParens)
 };
 static const array<array<wregex, 5>, 4> programmerModePatterns =
 { {

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -44,8 +44,8 @@ static const array<wregex, 1> standardModePatterns =
 };
 static const array<wregex, 2> scientificModePatterns =
 {
-    wregex(L"[-+]?" + c_wspcLParens + c_signedDecFloat + c_wspcRParens),
-    wregex(L"[-+]?" + c_wspcLParens + c_signedDecFloat + L"[e]([+]|[-])+\\d+" + c_wspcRParens)
+    wregex(c_wspc + L"[-+]?" + c_wspcLParens + c_signedDecFloat + c_wspcRParens),
+    wregex(c_wspc + L"[-+]?" + c_wspcLParens + c_signedDecFloat + L"[e]([+]|[-])+\\d+" + c_wspcRParens)
 };
 static const array<array<wregex, 5>, 4> programmerModePatterns =
 { {

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -26,6 +26,7 @@ constexpr wstring_view c_validCharacterSet{ L"0123456789()+-*/.abcdefABCDEF" };
 // [\s\x85] means white-space characters
 static const wstring c_wspc = L"[\\s\\x85]*";
 static const wstring c_wspcLParens = c_wspc + L"[(]*" + c_wspc;
+static const wstring c_wspcLParenSigned = c_wspc + L"([-+]?[(])*" + c_wspc;
 static const wstring c_wspcRParens = c_wspc + L"[)]*" + c_wspc;
 static const wstring c_signedDecFloat = L"[-+]?\\d*(\\d|[.])\\d*";
 
@@ -44,8 +45,8 @@ static const array<wregex, 1> standardModePatterns =
 };
 static const array<wregex, 2> scientificModePatterns =
 {
-    wregex(c_wspc + L"[-+]?" + c_wspcLParens + c_signedDecFloat + c_wspcRParens),
-    wregex(c_wspc + L"[-+]?" + c_wspcLParens + c_signedDecFloat + L"[e]([+]|[-])+\\d+" + c_wspcRParens)
+    wregex(L"(" + c_wspc + L"[-+]?)|(" + c_wspcLParenSigned + L")" + c_signedDecFloat + c_wspcRParens),
+    wregex(L"(" + c_wspc + L"[-+]?)|(" + c_wspcLParenSigned + L")" + c_signedDecFloat + L"[e]([+]|[-])+\\d+" + c_wspcRParens)
 };
 static const array<array<wregex, 5>, 4> programmerModePatterns =
 { {
@@ -402,7 +403,7 @@ pair<size_t, uint64_t> CopyPasteManager::GetMaxOperandLengthAndValue(ViewMode mo
 
 wstring CopyPasteManager::SanitizeOperand(const wstring& operand)
 {
-    wchar_t unWantedChars[] = { L'\'', L'_', L'`', L'(', L')', L'-' };
+    wchar_t unWantedChars[] = { L'\'', L'_', L'`', L'(', L')', L'-', L'+' };
 
     return Utils::RemoveUnwantedCharsFromWstring(operand, unWantedChars, static_cast<int>(size(unWantedChars)));
 }

--- a/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
+++ b/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
@@ -184,7 +184,11 @@ namespace CalculatorUnitTests
         {
             VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"((1234"), L"1234");
             VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"1234))"), L"1234");
+            VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"1234))"), L"1234");
             VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"-1234"), L"1234");
+            VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"+1234"), L"1234");
+            VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"-(1234)"), L"1234");
+            VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"+(1234)"), L"1234");
             VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"12-34"), L"1234");
             VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"((((1234))))"), L"1234");
             VERIFY_ARE_EQUAL(m_CopyPasteManager.SanitizeOperand(L"1'2'3'4"), L"1234");
@@ -488,7 +492,7 @@ namespace CalculatorUnitTests
 
     void CopyPasteManagerTest::ValidateScientificPasteExpressionTest()
     {
-        String^ positiveInput[] = { L"123", L"+123", L"-133", L"123+456", L"12345e+023", L"1,234", L"1.23", L"-.123", L".1234", L"012.012", L"123+-234", L"123*-345", L"123*4*-3", L"123*+4*-3", L"1 2 3", L"\n\r1,234\n", L"\f\n1+2\t\r\v\x85", L"\n 1+\n2 ", L"1\"2", L"1.2e+023", L"12345e-23", L"(123)+(456)", L"12345678912345678123456789012345", L"(123)+(456)=", L"2+2=   " };
+        String^ positiveInput[] = { L"123", L"+123", L"-133", L"123+456", L"12345e+023", L"1,234", L"1.23", L"-.123", L".1234", L"012.012", L"123+-234", L"123*-345", L"123*4*-3", L"123*+4*-3", L"1 2 3", L"\n\r1,234\n", L"\f\n1+2\t\r\v\x85", L"\n 1+\n2 ", L"1\"2", L"1.2e+023", L"12345e-23", L"(123)+(456)", L"12345678912345678123456789012345", L"(123)+(456)=", L"2+2=   ", "-(43)", "+(41213)", "-(432+3232)" , "-(+(-3213)+(-2312))", "-(-(432+3232))" };
         String^ negativeInput[] = { L"1.2e23"/*unsigned exponent*/, L"abcdef", L"xyz", L"ABab", L"e+234", L"123456789123456781234567890123456"/*boundary condition: greater than 32 digits*/, L"SIN(2)", L"2+2==", L"2=+2" };
 
         ASSERT_POSITIVE_TESTCASES(ValidateScientificPasteExpression, positiveInput);


### PR DESCRIPTION
## Fixes #343 


### Description of the changes:
- Modify scientificModePatterns regexes to support minus sign before parenthesis.

### How changes were validated:
- Manually