### PR TITLE
Build: disable component governance task in internal localization build

### DIFF
--- a/build/pipelines/azure-pipelines.loc.yaml
+++ b/build/pipelines/azure-pipelines.loc.yaml
@@ -20,6 +20,8 @@ jobs:
     - ClientAlias -equals PKGESUTILAPPS
   workspace:
     clean: outputs
+  variables:
+    skipComponentGovernanceDetection: true
   steps:
   - checkout: self
     clean: true


### PR DESCRIPTION
Internally, a "component detection" task is automatically injected into builds to make sure we're not using any components with known security vulnerabilities. Because this task runs during the main app builds, it doesn't also need to run in the pipeline which hands off strings to the localization system.