### PR TITLE
Disable use of min/max macros defined by Windows headers.

### DIFF
--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -1271,7 +1271,7 @@ PNUMBER RatToNumber(_In_ PRAT prat, uint32_t radix, int32_t precision)
     // Convert p and q of rational form from internal base to requested base.
     // Scale by largest power of BASEX possible.
     long scaleby = min(temprat->pp->exp, temprat->pq->exp);
-    scaleby = max(scaleby, 0);
+    scaleby = max(scaleby, 0l);
 
     temprat->pp->exp -= scaleby;
     temprat->pq->exp -= scaleby;

--- a/src/CalcManager/Ratpack/logic.cpp
+++ b/src/CalcManager/Ratpack/logic.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //---------------------------------------------------------------------------
@@ -16,7 +16,7 @@
 #include "pch.h"
 #include "ratpak.h"
 
-
+using namespace std;
 
 void lshrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
 

--- a/src/CalcManager/Ratpack/ratpak.h
+++ b/src/CalcManager/Ratpack/ratpak.h
@@ -225,7 +225,7 @@ memmove( (x)->pp->mant, &((x)->pp->mant[trim]), sizeof(MANTTYPE)*((x)->pp->cdigi
                 (x)->pp->cdigit -= trim; \
                 (x)->pp->exp += trim; \
                 } \
-            trim = min((x)->pp->exp,(x)->pq->exp);\
+            trim = std::min((x)->pp->exp,(x)->pq->exp);\
             (x)->pp->exp -= trim;\
             (x)->pq->exp -= trim;\
             }

--- a/src/CalcManager/pch.h
+++ b/src/CalcManager/pch.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -6,6 +6,10 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+
+// Windows headers define min/max macros.
+// Disable it for project code.
+#define NOMINMAX
 
 #include <assert.h>
 #include <windows.h>

--- a/src/CalcViewModel/pch.h
+++ b/src/CalcViewModel/pch.h
@@ -10,6 +10,10 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 
+// Windows headers define min/max macros.
+// Disable it for project code.
+#define NOMINMAX
+
 #include <windows.h>
 
 #include <collection.h>

--- a/src/Calculator/Controls/CalculationResult.cpp
+++ b/src/Calculator/Controls/CalculationResult.cpp
@@ -207,7 +207,7 @@ void CalculationResult::UpdateTextState()
     {
         double widthDiff = abs(m_textBlock->ActualWidth - containerSize);
         double fontSizeChange = INCREMENTOFFSET;
-         
+
         if (widthDiff > WIDTHCUTOFF)
         {
             fontSizeChange = min<double>(max<double>(floor(WIDTHTOFONTSCALAR * widthDiff) - WIDTHTOFONTOFFSET, INCREMENTOFFSET), MAXFONTINCREMENT);

--- a/src/Calculator/Controls/CalculationResult.cpp
+++ b/src/Calculator/Controls/CalculationResult.cpp
@@ -207,10 +207,10 @@ void CalculationResult::UpdateTextState()
     {
         double widthDiff = abs(m_textBlock->ActualWidth - containerSize);
         double fontSizeChange = INCREMENTOFFSET;
-
+         
         if (widthDiff > WIDTHCUTOFF)
         {
-            fontSizeChange = min(max(floor(WIDTHTOFONTSCALAR * widthDiff) - WIDTHTOFONTOFFSET, INCREMENTOFFSET), MAXFONTINCREMENT);
+            fontSizeChange = min<double>(max<double>(floor(WIDTHTOFONTSCALAR * widthDiff) - WIDTHTOFONTOFFSET, INCREMENTOFFSET), MAXFONTINCREMENT);
         }
         if (m_textBlock->ActualWidth < containerSize && abs(m_textBlock->FontSize - m_startingFontSize) > FONTTOLERANCE && !m_haveCalculatedMax)
         {

--- a/src/Calculator/pch.h
+++ b/src/Calculator/pch.h
@@ -8,6 +8,10 @@
 
 #pragma once
 
+// Windows headers define min/max macros.
+// Disable it for project code.
+#define NOMINMAX
+
 #include <collection.h>
 #include <unordered_map>
 #include <map>

--- a/src/CalculatorUnitTests/pch.h
+++ b/src/CalculatorUnitTests/pch.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //
@@ -11,6 +11,10 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
+
+// Windows headers define min/max macros.
+// Disable it for project code.
+#define NOMINMAX
 
 #define UNIT_TESTS
 


### PR DESCRIPTION
## Fixes #362.


### Description of the changes:
- Disable Windows-provided min/max macros using the `NOMINMAX` flag.  Add the flag to each project's pch to disable the macros across the solution.

### How changes were validated:
- Project builds.
- Unit tests pass.
- Smoke tests.

