### PR TITLE
Improve the support of Narrator with parenthesis

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -632,7 +632,7 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam)
         // Set the "(=xx" indicator.
         if (nullptr != m_pCalcDisplay)
         {
-            m_pCalcDisplay->SetParenthesisNumber(m_openParenCount >= 0 ? (unsigned int)m_openParenCount : 0);
+            m_pCalcDisplay->SetParenthesisNumber(m_openParenCount >= 0 ? static_cast<unsigned int>(m_openParenCount) : 0);
         }
 
         if (!m_bError)

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -83,7 +83,7 @@ void CCalcEngine::ClearTemporaryValues()
     m_bError = false;
 }
 
-void CCalcEngine::ProcessCommand(WPARAM wParam)
+void CCalcEngine::ProcessCommand(WPARAM wParam, bool useNarrator)
 {
     if (wParam == IDC_SET_RESULT)
     {
@@ -91,10 +91,10 @@ void CCalcEngine::ProcessCommand(WPARAM wParam)
         m_bSetCalcState = true;
     }
 
-    ProcessCommandWorker(wParam);
+    ProcessCommandWorker(wParam, useNarrator);
 }
 
-void CCalcEngine::ProcessCommandWorker(WPARAM wParam)
+void CCalcEngine::ProcessCommandWorker(WPARAM wParam, bool useNarrator)
 {
     INT            nx, ni;
 
@@ -397,7 +397,7 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam)
         cleared for CENTR */
         if (nullptr != m_pCalcDisplay)
         {
-            m_pCalcDisplay->SetParenDisplayText(L"");
+            m_pCalcDisplay->SetParenDisplayText(0, false);
             m_pCalcDisplay->SetExpressionDisplay(make_shared<CalculatorVector<pair<wstring, int>>>(), make_shared<CalculatorVector<shared_ptr<IExpressionCommand>>>());
         }
 
@@ -440,7 +440,7 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam)
             }
             // automatic closing of all the parenthesis to get a meaningful result as well as ensure data integrity
             m_nTempCom = m_nLastCom; // Put back this last saved command to the prev state so ) can be handled properly
-            ProcessCommand(IDC_CLOSEP);
+            ProcessCommand(IDC_CLOSEP, useNarrator);
             m_nLastCom = m_nTempCom; // Actually this is IDC_CLOSEP
             m_nTempCom = (INT)wParam; // put back in the state where last op seen was IDC_CLOSEP, and current op is IDC_EQU
         }
@@ -632,7 +632,7 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam)
         // Set the "(=xx" indicator.
         if (nullptr != m_pCalcDisplay)
         {
-            m_pCalcDisplay->SetParenDisplayText(m_openParenCount ? to_wstring(m_openParenCount) : L"");
+            m_pCalcDisplay->SetParenDisplayText(m_openParenCount >= 0 ? (unsigned int)m_openParenCount : 0, useNarrator);
         }
 
         if (!m_bError)

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -83,7 +83,7 @@ void CCalcEngine::ClearTemporaryValues()
     m_bError = false;
 }
 
-void CCalcEngine::ProcessCommand(WPARAM wParam, bool useNarrator)
+void CCalcEngine::ProcessCommand(WPARAM wParam)
 {
     if (wParam == IDC_SET_RESULT)
     {
@@ -91,10 +91,10 @@ void CCalcEngine::ProcessCommand(WPARAM wParam, bool useNarrator)
         m_bSetCalcState = true;
     }
 
-    ProcessCommandWorker(wParam, useNarrator);
+    ProcessCommandWorker(wParam);
 }
 
-void CCalcEngine::ProcessCommandWorker(WPARAM wParam, bool useNarrator)
+void CCalcEngine::ProcessCommandWorker(WPARAM wParam)
 {
     INT            nx, ni;
 
@@ -397,7 +397,7 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam, bool useNarrator)
         cleared for CENTR */
         if (nullptr != m_pCalcDisplay)
         {
-            m_pCalcDisplay->SetParenDisplayText(0, false);
+            m_pCalcDisplay->SetParenthesisNumber(0);
             m_pCalcDisplay->SetExpressionDisplay(make_shared<CalculatorVector<pair<wstring, int>>>(), make_shared<CalculatorVector<shared_ptr<IExpressionCommand>>>());
         }
 
@@ -440,7 +440,7 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam, bool useNarrator)
             }
             // automatic closing of all the parenthesis to get a meaningful result as well as ensure data integrity
             m_nTempCom = m_nLastCom; // Put back this last saved command to the prev state so ) can be handled properly
-            ProcessCommand(IDC_CLOSEP, useNarrator);
+            ProcessCommand(IDC_CLOSEP);
             m_nLastCom = m_nTempCom; // Actually this is IDC_CLOSEP
             m_nTempCom = (INT)wParam; // put back in the state where last op seen was IDC_CLOSEP, and current op is IDC_EQU
         }
@@ -632,7 +632,7 @@ void CCalcEngine::ProcessCommandWorker(WPARAM wParam, bool useNarrator)
         // Set the "(=xx" indicator.
         if (nullptr != m_pCalcDisplay)
         {
-            m_pCalcDisplay->SetParenDisplayText(m_openParenCount >= 0 ? (unsigned int)m_openParenCount : 0, useNarrator);
+            m_pCalcDisplay->SetParenthesisNumber(m_openParenCount >= 0 ? (unsigned int)m_openParenCount : 0);
         }
 
         if (!m_bError)

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -111,9 +111,9 @@ namespace CalculationManager
     /// Callback from the engine
     /// </summary>
     /// <param name="parenthesisCount">string containing the parenthesis count</param>
-    void CalculatorManager::SetParenDisplayText(_In_ unsigned int parenthesisCount, bool useNarrator)
+    void CalculatorManager::SetParenthesisNumber(_In_ unsigned int parenthesisCount)
     {
-        m_displayCallback->SetParenDisplayText(parenthesisCount, useNarrator);
+        m_displayCallback->SetParenthesisNumber(parenthesisCount);
     }
 
     /// <summary>
@@ -216,7 +216,7 @@ namespace CalculationManager
     /// Handle special commands such as mode change and combination of two commands.
     /// </summary>
     /// <param name="command">Enum Command</command>
-    void CalculatorManager::SendCommand(_In_ Command command, bool useNarrator)
+    void CalculatorManager::SendCommand(_In_ Command command)
     {
         // When the expression line is cleared, we save the current state, which includes,
         // primary display, memory, and degree mode
@@ -235,7 +235,7 @@ namespace CalculationManager
                 this->SetProgrammerMode();
                 break;
             default:
-                m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(command), useNarrator);
+                m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(command));
             }
 
             m_savedCommands.clear(); // Clear the previous command history
@@ -263,38 +263,38 @@ namespace CalculationManager
         switch (command)
         {
         case Command::CommandASIN:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandSIN), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandSIN));
             break;
         case Command::CommandACOS:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandCOS), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandCOS));
             break;
         case Command::CommandATAN:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandTAN), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandTAN));
             break;
         case Command::CommandPOWE:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandLN), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandLN));
             break;
         case Command::CommandASINH:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandSINH), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandSINH));
             break;
         case Command::CommandACOSH:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandCOSH), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandCOSH));
             break;
         case Command::CommandATANH:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandTANH), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandTANH));
             break;
         case Command::CommandFE:
             m_isExponentialFormat = !m_isExponentialFormat;
             [[fallthrough]];
         default:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(command), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(command));
             break;
         }
     }

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include "pch.h"
@@ -111,9 +111,9 @@ namespace CalculationManager
     /// Callback from the engine
     /// </summary>
     /// <param name="parenthesisCount">string containing the parenthesis count</param>
-    void CalculatorManager::SetParenDisplayText(const wstring& parenthesisCount)
+    void CalculatorManager::SetParenDisplayText(_In_ unsigned int parenthesisCount, bool useNarrator)
     {
-        m_displayCallback->SetParenDisplayText(parenthesisCount);
+        m_displayCallback->SetParenDisplayText(parenthesisCount, useNarrator);
     }
 
     /// <summary>
@@ -216,7 +216,7 @@ namespace CalculationManager
     /// Handle special commands such as mode change and combination of two commands.
     /// </summary>
     /// <param name="command">Enum Command</command>
-    void CalculatorManager::SendCommand(_In_ Command command)
+    void CalculatorManager::SendCommand(_In_ Command command, bool useNarrator)
     {
         // When the expression line is cleared, we save the current state, which includes,
         // primary display, memory, and degree mode
@@ -235,7 +235,7 @@ namespace CalculationManager
                 this->SetProgrammerMode();
                 break;
             default:
-                m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(command));
+                m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(command), useNarrator);
             }
 
             m_savedCommands.clear(); // Clear the previous command history
@@ -263,38 +263,38 @@ namespace CalculationManager
         switch (command)
         {
         case Command::CommandASIN:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandSIN));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandSIN), useNarrator);
             break;
         case Command::CommandACOS:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandCOS));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandCOS), useNarrator);
             break;
         case Command::CommandATAN:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandTAN));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandTAN), useNarrator);
             break;
         case Command::CommandPOWE:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandLN));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandLN), useNarrator);
             break;
         case Command::CommandASINH:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandSINH));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandSINH), useNarrator);
             break;
         case Command::CommandACOSH:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandCOSH));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandCOSH), useNarrator);
             break;
         case Command::CommandATANH:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV));
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandTANH));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandINV), useNarrator);
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(Command::CommandTANH), useNarrator);
             break;
         case Command::CommandFE:
             m_isExponentialFormat = !m_isExponentialFormat;
             [[fallthrough]];
         default:
-            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(command));
+            m_currentCalculatorEngine->ProcessCommand(static_cast<WPARAM>(command), useNarrator);
             break;
         }
     }

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -94,7 +94,7 @@ namespace CalculationManager
         void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands) override;
         void SetMemorizedNumbers(_In_ const std::vector<std::wstring>& memorizedNumbers) override;
         void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) override;
-        void SetParenDisplayText(const std::wstring& parenthesisCount) override;
+        void SetParenDisplayText(_In_ unsigned int parenthesisCount, bool useNarrator=true) override;
         void OnNoRightParenAdded() override;
         void DisplayPasteError();
         void MaxDigitsReached() override;
@@ -109,7 +109,7 @@ namespace CalculationManager
         void SetStandardMode();
         void SetScientificMode();
         void SetProgrammerMode();
-        void SendCommand(_In_ Command command);
+        void SendCommand(_In_ Command command, bool useNarrator=true);
         std::vector<unsigned char> SerializeCommands();
         void DeSerializeCommands(_In_ const std::vector<unsigned char>& serializedData);
         void SerializeMemory();

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -94,7 +94,7 @@ namespace CalculationManager
         void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands) override;
         void SetMemorizedNumbers(_In_ const std::vector<std::wstring>& memorizedNumbers) override;
         void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) override;
-        void SetParenDisplayText(_In_ unsigned int parenthesisCount, bool useNarrator=true) override;
+        void SetParenthesisNumber(_In_ unsigned int parenthesisCount) override;
         void OnNoRightParenAdded() override;
         void DisplayPasteError();
         void MaxDigitsReached() override;
@@ -109,7 +109,7 @@ namespace CalculationManager
         void SetStandardMode();
         void SetScientificMode();
         void SetProgrammerMode();
-        void SendCommand(_In_ Command command, bool useNarrator=true);
+        void SendCommand(_In_ Command command);
         std::vector<unsigned char> SerializeCommands();
         void DeSerializeCommands(_In_ const std::vector<unsigned char>& serializedData);
         void SerializeMemory();

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -52,7 +52,7 @@ namespace CalculatorUnitTests
 class CCalcEngine {
 public:
     CCalcEngine(bool fPrecedence, bool fIntegerMode, CalculationManager::IResourceProvider* const pResourceProvider, __in_opt ICalcDisplay *pCalcDisplay, __in_opt std::shared_ptr<IHistoryDisplay> pHistoryDisplay);
-    void ProcessCommand(WPARAM wID);
+    void ProcessCommand(WPARAM wID, bool useNarrator=true);
     void DisplayError (DWORD   nError);
     std::unique_ptr<CalcEngine::Rational> PersistedMemObject();
     void PersistedMemObject(CalcEngine::Rational const& memObject);
@@ -127,7 +127,7 @@ private:
     wchar_t m_groupSeparator;
 
 private:
-    void ProcessCommandWorker(WPARAM wParam);
+    void ProcessCommandWorker(WPARAM wParam, bool useNarrator = true);
     void HandleErrorCommand(WPARAM idc);
     void HandleMaxDigitsReached();
     void DisplayNum(void);

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -52,7 +52,7 @@ namespace CalculatorUnitTests
 class CCalcEngine {
 public:
     CCalcEngine(bool fPrecedence, bool fIntegerMode, CalculationManager::IResourceProvider* const pResourceProvider, __in_opt ICalcDisplay *pCalcDisplay, __in_opt std::shared_ptr<IHistoryDisplay> pHistoryDisplay);
-    void ProcessCommand(WPARAM wID, bool useNarrator=true);
+    void ProcessCommand(WPARAM wID);
     void DisplayError (DWORD   nError);
     std::unique_ptr<CalcEngine::Rational> PersistedMemObject();
     void PersistedMemObject(CalcEngine::Rational const& memObject);
@@ -127,7 +127,7 @@ private:
     wchar_t m_groupSeparator;
 
 private:
-    void ProcessCommandWorker(WPARAM wParam, bool useNarrator = true);
+    void ProcessCommandWorker(WPARAM wParam);
     void HandleErrorCommand(WPARAM idc);
     void HandleMaxDigitsReached();
     void DisplayNum(void);

--- a/src/CalcManager/Header Files/ICalcDisplay.h
+++ b/src/CalcManager/Header Files/ICalcDisplay.h
@@ -12,7 +12,7 @@ public:
     virtual void SetPrimaryDisplay(const std::wstring& pszText, bool isError) = 0;
     virtual void SetIsInError(bool isInError) = 0;
     virtual void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands) = 0;
-    virtual void SetParenDisplayText(const std::wstring& pszText) = 0;
+    virtual void SetParenDisplayText(_In_ unsigned int count, _In_  bool useNarrator) = 0;
     virtual void OnNoRightParenAdded() = 0;
     virtual void MaxDigitsReached() = 0; // not an error but still need to inform UI layer.
     virtual void BinaryOperatorReceived() = 0;

--- a/src/CalcManager/Header Files/ICalcDisplay.h
+++ b/src/CalcManager/Header Files/ICalcDisplay.h
@@ -12,7 +12,7 @@ public:
     virtual void SetPrimaryDisplay(const std::wstring& pszText, bool isError) = 0;
     virtual void SetIsInError(bool isInError) = 0;
     virtual void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands) = 0;
-    virtual void SetParenDisplayText(_In_ unsigned int count, _In_  bool useNarrator) = 0;
+    virtual void SetParenthesisNumber(_In_ unsigned int count) = 0;
     virtual void OnNoRightParenAdded() = 0;
     virtual void MaxDigitsReached() = 0; // not an error but still need to inform UI layer.
     virtual void BinaryOperatorReceived() = 0;

--- a/src/CalcViewModel/Common/Automation/NarratorNotifier.cpp
+++ b/src/CalcViewModel/Common/Automation/NarratorNotifier.cpp
@@ -6,7 +6,7 @@
 #include "pch.h"
 #include "NarratorNotifier.h"
 #include "NarratorAnnouncementHostFactory.h"
-#include <iostream>
+
 using namespace CalculatorApp::Common::Automation;
 using namespace Platform;
 using namespace Windows::UI::Xaml;
@@ -26,7 +26,6 @@ void NarratorNotifier::Announce(NarratorAnnouncement^ announcement)
         && m_announcementHost != nullptr)
     {
         m_announcementHost->Announce(announcement);
-        OutputDebugString(announcement->Announcement->Data());
     }
 }
 

--- a/src/CalcViewModel/Common/Automation/NarratorNotifier.cpp
+++ b/src/CalcViewModel/Common/Automation/NarratorNotifier.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 // Implementation of the NarratorNotifier class.
@@ -6,7 +6,7 @@
 #include "pch.h"
 #include "NarratorNotifier.h"
 #include "NarratorAnnouncementHostFactory.h"
-
+#include <iostream>
 using namespace CalculatorApp::Common::Automation;
 using namespace Platform;
 using namespace Windows::UI::Xaml;
@@ -26,6 +26,7 @@ void NarratorNotifier::Announce(NarratorAnnouncement^ announcement)
         && m_announcementHost != nullptr)
     {
         m_announcementHost->Announce(announcement);
+        OutputDebugString(announcement->Announcement->Data());
     }
 }
 

--- a/src/CalcViewModel/Common/CalculatorDisplay.cpp
+++ b/src/CalcViewModel/Common/CalculatorDisplay.cpp
@@ -36,13 +36,13 @@ void CalculatorDisplay::SetPrimaryDisplay(_In_ const wstring& displayStringValue
     }
 }
 
-void CalculatorDisplay::SetParenDisplayText(_In_ const std::wstring& parenthesisCount)
+void CalculatorDisplay::SetParenDisplayText(_In_ unsigned int parenthesisCount, _In_ bool useNarrator)
 {
     if (m_callbackReference != nullptr)
     {
         if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
-            calcVM->SetParenthesisCount(parenthesisCount);
+            calcVM->SetParenthesisCount(parenthesisCount, useNarrator);
         }
     }
 }

--- a/src/CalcViewModel/Common/CalculatorDisplay.cpp
+++ b/src/CalcViewModel/Common/CalculatorDisplay.cpp
@@ -36,13 +36,13 @@ void CalculatorDisplay::SetPrimaryDisplay(_In_ const wstring& displayStringValue
     }
 }
 
-void CalculatorDisplay::SetParenDisplayText(_In_ unsigned int parenthesisCount, _In_ bool useNarrator)
+void CalculatorDisplay::SetParenthesisNumber(_In_ unsigned int parenthesisCount)
 {
     if (m_callbackReference != nullptr)
     {
         if (auto calcVM = m_callbackReference.Resolve<ViewModel::StandardCalculatorViewModel>())
         {
-            calcVM->SetParenthesisCount(parenthesisCount, useNarrator);
+            calcVM->SetParenthesisCount(parenthesisCount);
         }
     }
 }

--- a/src/CalcViewModel/Common/CalculatorDisplay.h
+++ b/src/CalcViewModel/Common/CalculatorDisplay.h
@@ -21,7 +21,7 @@ namespace CalculatorApp
         void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands) override;
         void SetMemorizedNumbers(_In_ const std::vector<std::wstring>& memorizedNumbers) override;
         void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) override;
-        void SetParenDisplayText(_In_ unsigned int parenthesisCount, _In_ bool useNarrator=true) override;
+        void SetParenthesisNumber(_In_ unsigned int parenthesisCount) override;
         void OnNoRightParenAdded() override;
         void MaxDigitsReached() override;
         void BinaryOperatorReceived() override;

--- a/src/CalcViewModel/Common/CalculatorDisplay.h
+++ b/src/CalcViewModel/Common/CalculatorDisplay.h
@@ -21,7 +21,7 @@ namespace CalculatorApp
         void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands) override;
         void SetMemorizedNumbers(_In_ const std::vector<std::wstring>& memorizedNumbers) override;
         void OnHistoryItemAdded(_In_ unsigned int addedItemIndex) override;
-        void SetParenDisplayText(_In_ const std::wstring& parenthesisCount) override;
+        void SetParenDisplayText(_In_ unsigned int parenthesisCount, _In_ bool useNarrator=true) override;
         void OnNoRightParenAdded() override;
         void MaxDigitsReached() override;
         void BinaryOperatorReceived() override;

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1416,26 +1416,26 @@ void StandardCalculatorViewModel::SaveEditedCommand(_In_ unsigned int tokenPosit
             case static_cast<int>(Command::CommandASIN) :
                 updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandSIN), true, angleType);
                 break;
-                case static_cast<int>(Command::CommandACOS) :
-                    updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandCOS), true, angleType);
-                    break;
-                    case static_cast<int>(Command::CommandATAN) :
-                        updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandTAN), true, angleType);
-                        break;
-                        case static_cast<int>(Command::CommandASINH) :
-                            updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandSINH), true, angleType);
-                            break;
-                            case static_cast<int>(Command::CommandACOSH) :
-                                updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandCOSH), true, angleType);
-                                break;
-                                case static_cast<int>(Command::CommandATANH) :
-                                    updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandTANH), true, angleType);
-                                    break;
-                                    case static_cast<int>(Command::CommandPOWE) :
-                                        updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandLN), true, angleType);
-                                        break;
-                                    default:
-                                        updatedToken = CCalcEngine::OpCodeToUnaryString(nOpCode, false, angleType);
+            case static_cast<int>(Command::CommandACOS) :
+                updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandCOS), true, angleType);
+                break;
+            case static_cast<int>(Command::CommandATAN) :
+                updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandTAN), true, angleType);
+                break;
+            case static_cast<int>(Command::CommandASINH) :
+                updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandSINH), true, angleType);
+                break;
+            case static_cast<int>(Command::CommandACOSH) :
+                updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandCOSH), true, angleType);
+                break;
+            case static_cast<int>(Command::CommandATANH) :
+                updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandTANH), true, angleType);
+                break;
+            case static_cast<int>(Command::CommandPOWE) :
+                updatedToken = CCalcEngine::OpCodeToUnaryString(static_cast<int>(Command::CommandLN), true, angleType);
+                break;
+            default:
+                updatedToken = CCalcEngine::OpCodeToUnaryString(nOpCode, false, angleType);
         }
         if ((token.first.length() > 0) && (token.first[token.first.length() - 1] == L'('))
         {

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -217,7 +217,9 @@ void StandardCalculatorViewModel::DisplayPasteError()
 void StandardCalculatorViewModel::SetParenthesisCount(_In_ unsigned int parenthesisCount)
 {
     if (m_OpenParenthesisCount == parenthesisCount)
+    {
         return;
+    }
 
     OpenParenthesisCount = parenthesisCount;
     if (IsProgrammer || IsScientific)

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -75,12 +75,12 @@ namespace CalculatorApp
             OBSERVABLE_PROPERTY_RW(bool, IsDwordEnabled);
             OBSERVABLE_PROPERTY_RW(bool, IsWordEnabled);
             OBSERVABLE_PROPERTY_RW(bool, IsByteEnabled);
-            OBSERVABLE_NAMED_PROPERTY_RW(Platform::String^, OpenParenthesisCount);
             OBSERVABLE_PROPERTY_RW(int, CurrentRadixType);
             OBSERVABLE_PROPERTY_RW(bool, AreTokensUpdated);
             OBSERVABLE_PROPERTY_RW(bool, AreHistoryShortcutsEnabled);
             OBSERVABLE_PROPERTY_RW(bool, AreProgrammerRadixOperatorsEnabled);
             OBSERVABLE_PROPERTY_RW(CalculatorApp::Common::Automation::NarratorAnnouncement^, Announcement);
+            OBSERVABLE_PROPERTY_R(unsigned int, OpenParenthesisCount);
 
             COMMAND_FOR_METHOD(CopyCommand, StandardCalculatorViewModel::OnCopyCommand);
             COMMAND_FOR_METHOD(PasteCommand, StandardCalculatorViewModel::OnPasteCommand);
@@ -255,14 +255,6 @@ namespace CalculatorApp
                 void set(bool value) { m_completeTextSelection = value; }
             }
 
-            property Platform::String^ LeftParenthesisAutomationName
-            {
-                Platform::String^ get()
-                {
-                    return GetLeftParenthesisAutomationName();
-                }
-            }
-
         internal:
             void OnPaste(Platform::String^ pastedString, CalculatorApp::Common::ViewMode mode);
             void OnCopyCommand(Platform::Object^ parameter);
@@ -283,7 +275,7 @@ namespace CalculatorApp
             void SetTokens(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens);
             void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands);
             void SetHistoryExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector <std::shared_ptr<IExpressionCommand>>> const &commands);
-            void SetParenthesisCount(_In_ unsigned int parenthesisCount, _In_ bool useNarrator=true);
+            void SetParenthesisCount(_In_ unsigned int parenthesisCount);
             void SetOpenParenthesisCountNarratorAnnouncement();
             void OnNoRightParenAdded();
             void SetNoParenAddedNarratorAnnouncement();
@@ -352,10 +344,8 @@ namespace CalculatorApp
             bool m_operandUpdated;
             bool m_completeTextSelection;
             bool m_isLastOperationHistoryLoad;
-            unsigned int m_parenthesisCount;
             Platform::String^ m_selectedExpressionLastData;
             Common::DisplayExpressionToken^ m_selectedExpressionToken;
-            Platform::String^ m_leftParenthesisAutomationFormat;
 
             Platform::String^ LocalizeDisplayValue(_In_ std::wstring const &displayValue, _In_ bool isError);
             Platform::String^ CalculateNarratorDisplayValue(_In_ std::wstring const &displayValue, _In_ Platform::String^ localizedDisplayValue, _In_ bool isError);
@@ -365,7 +355,6 @@ namespace CalculatorApp
 
             CalculationManager::Command ConvertToOperatorsEnum(NumbersAndOperatorsEnum operation);
             void DisableButtons(CalculationManager::CommandType selectedExpressionCommandType);
-            Platform::String^ GetLeftParenthesisAutomationName();
 
             Platform::String^ m_feedbackForButtonPress;
             void OnButtonPressed(Platform::Object^ parameter);

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -283,7 +283,7 @@ namespace CalculatorApp
             void SetTokens(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens);
             void SetExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector<std::shared_ptr<IExpressionCommand>>> const &commands);
             void SetHistoryExpressionDisplay(_Inout_ std::shared_ptr<CalculatorVector<std::pair<std::wstring, int>>> const &tokens, _Inout_ std::shared_ptr<CalculatorVector <std::shared_ptr<IExpressionCommand>>> const &commands);
-            void SetParenthesisCount(_In_ const std::wstring& parenthesisCount);
+            void SetParenthesisCount(_In_ unsigned int parenthesisCount, _In_ bool useNarrator=true);
             void SetOpenParenthesisCountNarratorAnnouncement();
             void OnNoRightParenAdded();
             void SetNoParenAddedNarratorAnnouncement();
@@ -352,6 +352,7 @@ namespace CalculatorApp
             bool m_operandUpdated;
             bool m_completeTextSelection;
             bool m_isLastOperationHistoryLoad;
+            unsigned int m_parenthesisCount;
             Platform::String^ m_selectedExpressionLastData;
             Common::DisplayExpressionToken^ m_selectedExpressionToken;
             Platform::String^ m_leftParenthesisAutomationFormat;

--- a/src/Calculator/Resources/am-ET/Resources.resw
+++ b/src/Calculator/Resources/am-ET/Resources.resw
@@ -901,10 +901,7 @@
     <value>የግራ ቅንፍ</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>የግራ ቅንፍ፣ የክፍት ቅንፍ ቁጥር %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>የቀኝ ቅንፍ</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ar-SA/Resources.resw
+++ b/src/Calculator/Resources/ar-SA/Resources.resw
@@ -901,10 +901,7 @@
     <value>أقواس يسرى</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>القوس الأيسر، عدد الأقواس المفتوحة %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>أقواس يمنى</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/az-Latn-AZ/Resources.resw
+++ b/src/Calculator/Resources/az-Latn-AZ/Resources.resw
@@ -901,10 +901,7 @@
     <value>Sol mötərizə</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Sol mötərizə, açıq mötərizənin sayı %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sağ mötərizə</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/be-BY/Resources.resw
+++ b/src/Calculator/Resources/be-BY/Resources.resw
@@ -901,10 +901,7 @@
     <value>Левая дужка</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Левая дужка, пачатак адліку дужак (%1)</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Правая дужка</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/bg-BG/Resources.resw
+++ b/src/Calculator/Resources/bg-BG/Resources.resw
@@ -901,10 +901,7 @@
     <value>Лява скоба</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Лява скоба, брой на отваряща скоба %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Дясна скоба</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ca-ES/Resources.resw
+++ b/src/Calculator/Resources/ca-ES/Resources.resw
@@ -901,10 +901,7 @@
     <value>Parèntesi d'obertura</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Parèntesi d'obertura, recompte de parèntesis d'obertura %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Parèntesi de tancament</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/cs-CZ/Resources.resw
+++ b/src/Calculator/Resources/cs-CZ/Resources.resw
@@ -901,10 +901,7 @@
     <value>Levá závorka</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Levá závorka, počet otevřených závorek %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Pravá závorka</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/da-DK/Resources.resw
+++ b/src/Calculator/Resources/da-DK/Resources.resw
@@ -901,10 +901,7 @@
     <value>Venstreparentes</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Venstre parentes, åben parentes antal %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Højreparentes</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/de-DE/Resources.resw
+++ b/src/Calculator/Resources/de-DE/Resources.resw
@@ -901,10 +901,7 @@
     <value>Öffnende Klammer</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Runde Klammer links, Anzahl der öffnenden Klammern: %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Schließende Klammer</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/el-GR/Resources.resw
+++ b/src/Calculator/Resources/el-GR/Resources.resw
@@ -901,10 +901,7 @@
     <value>Αριστερή παρένθεση</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Αριστερή παρένθεση, πλήθος ανοιχτών παρενθέσεων %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Δεξιά παρένθεση</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/en-GB/Resources.resw
+++ b/src/Calculator/Resources/en-GB/Resources.resw
@@ -901,10 +901,7 @@
     <value>Left parenthesis</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Left parenthesis, open parenthesis count %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Right parenthesis</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/es-ES/Resources.resw
+++ b/src/Calculator/Resources/es-ES/Resources.resw
@@ -901,10 +901,7 @@
     <value>Paréntesis de apertura</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Paréntesis de apertura, número de paréntesis abiertos %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Paréntesis de cierre</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/es-MX/Resources.resw
+++ b/src/Calculator/Resources/es-MX/Resources.resw
@@ -901,10 +901,7 @@
     <value>Paréntesis de apertura</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Abrir paréntesis, recuento de paréntesis abiertos %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Paréntesis de cierre</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/et-EE/Resources.resw
+++ b/src/Calculator/Resources/et-EE/Resources.resw
@@ -901,10 +901,7 @@
     <value>Vasaksulg</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Vasaksulg, avavate sulgude arv %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Paremsulg</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/eu-ES/Resources.resw
+++ b/src/Calculator/Resources/eu-ES/Resources.resw
@@ -901,10 +901,7 @@
     <value>Ezkerreko parentesia</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Ezkerreko parentesia, ireki %1. parentesia</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Eskuineko parentesia</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fa-IR/Resources.resw
+++ b/src/Calculator/Resources/fa-IR/Resources.resw
@@ -901,10 +901,7 @@
     <value>پرانتز سمت چپ</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>پرانتز چپ، تعداد پرانتزهای باز %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>پرانتز سمت راست</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fi-FI/Resources.resw
+++ b/src/Calculator/Resources/fi-FI/Resources.resw
@@ -901,10 +901,7 @@
     <value>Vasen sulje</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Vasen sulje, avaavien sulkeiden määrä %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Oikea sulje</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fil-PH/Resources.resw
+++ b/src/Calculator/Resources/fil-PH/Resources.resw
@@ -901,10 +901,7 @@
     <value>Kaliwang parenthesis</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Bilang ng kaliwang panaklong, pambukas na panaklong %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Kanang parenthesis</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fr-CA/Resources.resw
+++ b/src/Calculator/Resources/fr-CA/Resources.resw
@@ -901,10 +901,7 @@
     <value>Parenthèse gauche</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>%1 parenthèses gauches ouvrantes</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Parenthèse droite</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fr-FR/Resources.resw
+++ b/src/Calculator/Resources/fr-FR/Resources.resw
@@ -901,10 +901,7 @@
     <value>Parenthèse gauche</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Parenthèse gauche, nombre de parenthèses ouvertes %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Parenthèse droite</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/gl-ES/Resources.resw
+++ b/src/Calculator/Resources/gl-ES/Resources.resw
@@ -901,10 +901,7 @@
     <value>Paréntese esquerda</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Paréntese de apertura, total de parénteses abertos %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Paréntese dereita</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/he-IL/Resources.resw
+++ b/src/Calculator/Resources/he-IL/Resources.resw
@@ -901,10 +901,7 @@
     <value>סוגר שמאלי</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>סוגריים ימניים, פתח ספירת סוגריים %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>סוגר ימני</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/hi-IN/Resources.resw
+++ b/src/Calculator/Resources/hi-IN/Resources.resw
@@ -901,10 +901,7 @@
     <value>बायाँ कोष्ठक</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>बायाँ कोष्ठक, खुले कोष्ठक की संख्या %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>दायाँ कोष्ठक</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/hr-HR/Resources.resw
+++ b/src/Calculator/Resources/hr-HR/Resources.resw
@@ -901,10 +901,7 @@
     <value>Lijeva zagrada</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Lijeva zagrada, broj otvorenih zagrada %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Desna zagrada</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/hu-HU/Resources.resw
+++ b/src/Calculator/Resources/hu-HU/Resources.resw
@@ -901,10 +901,7 @@
     <value>Nyitó zárójel</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Bal oldali vagy nyitó zárójelek száma: %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Berekesztő zárójel</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/id-ID/Resources.resw
+++ b/src/Calculator/Resources/id-ID/Resources.resw
@@ -901,10 +901,7 @@
     <value>Tanda kurung tutup</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Tanda kurung kiri, tanda kurung terbuka berjumlah %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Tanda kurung buka</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/is-IS/Resources.resw
+++ b/src/Calculator/Resources/is-IS/Resources.resw
@@ -901,10 +901,7 @@
     <value>Vinstri svigi</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Vinstri svigi, opnir svigar telja %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Hægri svigi</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/it-IT/Resources.resw
+++ b/src/Calculator/Resources/it-IT/Resources.resw
@@ -901,10 +901,7 @@
     <value>Parentesi sinistra</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Conteggio parentesi sinistra, parentesi aperta %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Parentesi destra</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ja-JP/Resources.resw
+++ b/src/Calculator/Resources/ja-JP/Resources.resw
@@ -901,10 +901,7 @@
     <value>始め丸かっこ</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>左かっこ、開きかっこの数 %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>終わり丸かっこ</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/kk-KZ/Resources.resw
+++ b/src/Calculator/Resources/kk-KZ/Resources.resw
@@ -901,10 +901,7 @@
     <value>Сол жақ жақша</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Сол жақ жақша, ашық жақша саны: %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Оң жақ жақша</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/km-KH/Resources.resw
+++ b/src/Calculator/Resources/km-KH/Resources.resw
@@ -901,10 +901,7 @@
     <value>វង់ក្រចកឆ្វេង</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>វង់​ក្រចក​ឆ្វេង បើក​ការ​រាប់​វង់​ក្រចក %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>វង់ក្រចកស្តាំ</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/kn-IN/Resources.resw
+++ b/src/Calculator/Resources/kn-IN/Resources.resw
@@ -901,10 +901,7 @@
     <value>ಎಡ ಆವರಣ ಚಿಹ್ನೆ</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>ಎಡ ಆವರಣ, ಬಲ ಆವರಣ ಎಣಿಕೆ %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>ಬಲ ಆವರಣ ಚಿಹ್ನೆ</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ko-KR/Resources.resw
+++ b/src/Calculator/Resources/ko-KR/Resources.resw
@@ -901,10 +901,7 @@
     <value>여는 괄호</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>왼쪽 괄호 또는 여는 괄호 수 %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>닫는 괄호</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/lo-LA/Resources.resw
+++ b/src/Calculator/Resources/lo-LA/Resources.resw
@@ -901,10 +901,7 @@
     <value>ວົງເລັບຊ້າຍ</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>&lt;mrk mtype="seg" mid="55"&gt;ວົງເລັບຊ້າຍ, ເປີດຍອດລວມວົງເລັບ %1&lt;/mrk&gt;</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>ວົງເລັບຂວາ</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/lt-LT/Resources.resw
+++ b/src/Calculator/Resources/lt-LT/Resources.resw
@@ -901,10 +901,7 @@
     <value>Kairysis lenktinis skliaustas</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Kairysis skliaustas, atidarančio skliausto skaičius %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Dešinysis lenktinis skliaustas</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/lv-LV/Resources.resw
+++ b/src/Calculator/Resources/lv-LV/Resources.resw
@@ -901,10 +901,7 @@
     <value>Kreisās puses apaļā iekava</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Kreisā iekava, atvērto iekavu skaits: %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Labās puses apaļā iekava</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/mk-MK/Resources.resw
+++ b/src/Calculator/Resources/mk-MK/Resources.resw
@@ -901,10 +901,7 @@
     <value>Лева заграда</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Лева заграда, отворена заграда пресметува %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Десна заграда</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ml-IN/Resources.resw
+++ b/src/Calculator/Resources/ml-IN/Resources.resw
@@ -901,10 +901,7 @@
     <value>ഇടത് ആവരണചിഹ്നം</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>ഇടത് പാരന്തെസിസ്, പാരന്തെസിസ് കൗണ്ട് %1 തുറക്കുക</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>വലത് ബ്രാക്കറ്റ്</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ms-MY/Resources.resw
+++ b/src/Calculator/Resources/ms-MY/Resources.resw
@@ -901,10 +901,7 @@
     <value>Tanda kurungan kiri</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Tanda kurung kiri, buka kiraan tanda kurung %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Tanda kurungan kanan</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/nb-NO/Resources.resw
+++ b/src/Calculator/Resources/nb-NO/Resources.resw
@@ -901,10 +901,7 @@
     <value>Venstreparentes</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Venstreparentes, åpen parentes teller %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Høyreparentes</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/nl-NL/Resources.resw
+++ b/src/Calculator/Resources/nl-NL/Resources.resw
@@ -901,10 +901,7 @@
     <value>Haakje openen</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Haakje openen, aantal haakjes openen %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Haakje sluiten</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/pl-PL/Resources.resw
+++ b/src/Calculator/Resources/pl-PL/Resources.resw
@@ -901,10 +901,7 @@
     <value>Lewy nawias</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Lewy nawias, liczba otwartych nawiasów: %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Prawy nawias</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/pt-BR/Resources.resw
+++ b/src/Calculator/Resources/pt-BR/Resources.resw
@@ -901,10 +901,7 @@
     <value>Parêntese esquerdo</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Parêntese esquerdo, contagem de parêntese de abertura %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Parêntese direito</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/pt-PT/Resources.resw
+++ b/src/Calculator/Resources/pt-PT/Resources.resw
@@ -901,10 +901,7 @@
     <value>Parêntese à esquerda</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Parêntese à esquerda, abrir contagem de parênteses %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Parêntese à direita</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ro-RO/Resources.resw
+++ b/src/Calculator/Resources/ro-RO/Resources.resw
@@ -901,10 +901,7 @@
     <value>Paranteză stânga</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Contor paranteze stânga, paranteze deschise %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Paranteză dreapta</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ru-RU/Resources.resw
+++ b/src/Calculator/Resources/ru-RU/Resources.resw
@@ -901,10 +901,7 @@
     <value>Открывающая круглая скобка</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Левая круглая скобка, количество открывающих круглых скобок — %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Закрывающая круглая скобка</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sk-SK/Resources.resw
+++ b/src/Calculator/Resources/sk-SK/Resources.resw
@@ -901,10 +901,7 @@
     <value>Ľavá zátvorka</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Ľavá zátvorka, počet ľavých zátvoriek je %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Pravá zátvorka</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sl-SI/Resources.resw
+++ b/src/Calculator/Resources/sl-SI/Resources.resw
@@ -901,10 +901,7 @@
     <value>Levi oklepaj</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Levi oklepaj, število oklepajev %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Desni oklepaj</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sq-AL/Resources.resw
+++ b/src/Calculator/Resources/sq-AL/Resources.resw
@@ -901,10 +901,7 @@
     <value>Kllapa e majtë</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Kllapa e majtë, numri i kllapave hapëse %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Kllapa e djathtë</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sr-Latn-RS/Resources.resw
+++ b/src/Calculator/Resources/sr-Latn-RS/Resources.resw
@@ -901,10 +901,7 @@
     <value>Leva zagrada</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Otvorena zagrada, broj otvorenih zagrada %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Desna zagrada</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sv-SE/Resources.resw
+++ b/src/Calculator/Resources/sv-SE/Resources.resw
@@ -901,10 +901,7 @@
     <value>Vänster parentes</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Vänster parentes, antal inledande parenteser är %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Höger parentes</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sw-KE/Resources.resw
+++ b/src/Calculator/Resources/sw-KE/Resources.resw
@@ -901,10 +901,7 @@
     <value>Mabano ya kushoto</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Mabano ya kushoto, fungua idadi ya mabano %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Mabano ya kulia</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ta-IN/Resources.resw
+++ b/src/Calculator/Resources/ta-IN/Resources.resw
@@ -901,10 +901,7 @@
     <value>இடது அடைப்புக்குறி</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>இடது அடைப்புக்குறி, திறப்பு அடைப்புக்குறி கணக்கு %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>வலது அடைப்புக்குறி</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/te-IN/Resources.resw
+++ b/src/Calculator/Resources/te-IN/Resources.resw
@@ -901,10 +901,7 @@
     <value>ఎడమ కుండలీకరణం</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>ఎడమ కుండలీకరణం, కుండలీకరణ గణనను %1 తెరవు</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>కుడి కుండలీకరణం</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/th-TH/Resources.resw
+++ b/src/Calculator/Resources/th-TH/Resources.resw
@@ -901,10 +901,7 @@
     <value>วงเล็บเปิด</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>วงเล็บเปิด จำนวนวงเล็บเปิด %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>วงเล็บปิด</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/tr-TR/Resources.resw
+++ b/src/Calculator/Resources/tr-TR/Resources.resw
@@ -901,10 +901,7 @@
     <value>Sol parantez</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Sol parantez, parantez sayımını aç %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sağ parantez</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/uk-UA/Resources.resw
+++ b/src/Calculator/Resources/uk-UA/Resources.resw
@@ -901,10 +901,7 @@
     <value>Ліва кругла дужка</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Ліва кругла дужка, кількість відкривних круглих дужок – %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Права кругла дужка</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/Calculator/Resources/uz-Latn-UZ/Resources.resw
@@ -901,10 +901,7 @@
     <value>Chap qavs</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Chap qavs, ochiq qavslar soni - %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>O‘ng qavs</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/vi-VN/Resources.resw
+++ b/src/Calculator/Resources/vi-VN/Resources.resw
@@ -901,10 +901,7 @@
     <value>Dấu ngoặc đơn trái</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>Ngoặc trái, tính ngoặc mở %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Dấu ngoặc đơn phải</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/zh-CN/Resources.resw
+++ b/src/Calculator/Resources/zh-CN/Resources.resw
@@ -901,10 +901,7 @@
     <value>左括号</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>左括号，左开式括号计数 %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>右括号</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/zh-TW/Resources.resw
+++ b/src/Calculator/Resources/zh-TW/Resources.resw
@@ -901,10 +901,7 @@
     <value>左括弧</value>
     <comment>Screen reader prompt for the Calculator "(" button on the scientific operator keypad</comment>
   </data>
-  <data name="Format_OpenParenthesisAutomationNamePrefix" xml:space="preserve">
-    <value>左括弧，左括弧計數 %1</value>
-    <comment>{Locked="%1"} Screen reader prompt for the Calculator "(" button on the scientific operator keypad. %1 is the localized count of open parenthesis, e.g. "2".</comment>
-  </data>
+  
   <data name="closeParenthesisButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>右括弧</value>
     <comment>Screen reader prompt for the Calculator ")" button on the scientific operator keypad</comment>

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
@@ -409,10 +409,10 @@
                                    Style="{StaticResource ParenthesisCalcButtonStyle}"
                                    FontSize="18"
                                    AutomationProperties.AutomationId="openParenthesisButton"
-                                   AutomationProperties.Name="{Binding LeftParenthesisAutomationName}"
                                    ButtonId="OpenParenthesis"
                                    Content="("
-                                   Tag="{x:Bind Model.OpenParenthesisCount, Mode=OneWay}"/>
+                                   GotFocus="OpenParenthesisButton_GotFocus"
+                                   Tag="{x:Bind ParenthesisCountToString(Model.OpenParenthesisCount), Mode=OneWay}"/>
         <controls:CalculatorButton x:Name="closeParenthesisButton"
                                    x:Uid="closeParenthesisButton"
                                    Grid.Row="5"

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
@@ -35,12 +35,10 @@ CalculatorProgrammerRadixOperators::CalculatorProgrammerRadixOperators() :
 void CalculatorProgrammerRadixOperators::OnLoaded(Object^, RoutedEventArgs^)
 {
     m_progModeRadixChangeToken = Model->ProgModeRadixChange += ref new ProgModeRadixChangeHandler(this, &CalculatorProgrammerRadixOperators::ProgModeRadixChange);
-    m_propertyChangedToken = Model->PropertyChanged += ref new PropertyChangedEventHandler(this, &CalculatorProgrammerRadixOperators::OnViewModelPropertyChanged);
 }
 void CalculatorProgrammerRadixOperators::OnUnloaded(Object^, RoutedEventArgs^)
 {
     Model->ProgModeRadixChange -= m_progModeRadixChangeToken;
-    Model->PropertyChanged -=  m_propertyChangedToken;
 }
 
 void CalculatorProgrammerRadixOperators::Shift_Clicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
@@ -97,13 +95,5 @@ void CalculatorProgrammerRadixOperators::IsErrorVisualState::set(bool value)
         String^ newState = m_isErrorVisualState ? L"ErrorLayout" : L"NoErrorLayout";
         VisualStateManager::GoToState(this, newState, false);
         NumberPad->IsErrorVisualState = m_isErrorVisualState;
-    }
-}
-
-void CalculatorProgrammerRadixOperators::OnViewModelPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e)
-{
-    if (e->PropertyName == StandardCalculatorViewModel::OpenParenthesisCountPropertyName && closeParenthesisButton->FocusState != ::FocusState::Unfocused)
-    {
-        Model->SetOpenParenthesisCountNarratorAnnouncement();
     }
 }

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
@@ -12,8 +12,8 @@
 #include "Converters/BooleanToVisibilityConverter.h"
 #include "Views/NumberPad.xaml.h"
 
+using namespace std;
 using namespace CalculatorApp;
-
 using namespace CalculatorApp::ViewModel;
 using namespace Platform;
 using namespace Windows::UI::Xaml;
@@ -96,4 +96,14 @@ void CalculatorProgrammerRadixOperators::IsErrorVisualState::set(bool value)
         VisualStateManager::GoToState(this, newState, false);
         NumberPad->IsErrorVisualState = m_isErrorVisualState;
     }
+}
+
+String^ CalculatorProgrammerRadixOperators::ParenthesisCountToString(unsigned int count) {
+    return count == 0 ? ref new String(L"") : ref new String(to_wstring(count).data());
+}
+
+
+void CalculatorProgrammerRadixOperators::CalculatorProgrammerRadixOperators::OpenParenthesisButton_GotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+    Model->SetOpenParenthesisCountNarratorAnnouncement();
 }

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
@@ -99,11 +99,11 @@ void CalculatorProgrammerRadixOperators::IsErrorVisualState::set(bool value)
 }
 
 String^ CalculatorProgrammerRadixOperators::ParenthesisCountToString(unsigned int count) {
-    return count == 0 ? ref new String(L"") : ref new String(to_wstring(count).data());
+    return (count == 0) ? ref new String() : ref new String(to_wstring(count).data());
 }
 
 
-void CalculatorProgrammerRadixOperators::CalculatorProgrammerRadixOperators::OpenParenthesisButton_GotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void CalculatorProgrammerRadixOperators::CalculatorProgrammerRadixOperators::OpenParenthesisButton_GotFocus(Object^ sender, RoutedEventArgs^ e)
 {
     Model->SetOpenParenthesisCountNarratorAnnouncement();
 }

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
@@ -26,6 +26,7 @@ namespace CalculatorApp
             bool get();
             void set(bool value);
         }
+        Platform::String^ ParenthesisCountToString(unsigned int count);
 
         DEPENDENCY_PROPERTY_OWNER(CalculatorProgrammerRadixOperators);
 
@@ -38,5 +39,6 @@ namespace CalculatorApp
 
         bool m_isErrorVisualState;
         Windows::Foundation::EventRegistrationToken m_progModeRadixChangeToken;
+        void OpenParenthesisButton_GotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
     };
 }

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
@@ -35,10 +35,8 @@ namespace CalculatorApp
         void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void ProgModeRadixChange();
-        void OnViewModelPropertyChanged(Platform::Object^ sender, Windows::UI::Xaml::Data::PropertyChangedEventArgs ^ e);
 
         bool m_isErrorVisualState;
         Windows::Foundation::EventRegistrationToken m_progModeRadixChangeToken;
-        Windows::Foundation::EventRegistrationToken m_propertyChangedToken;
     };
 }

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -11,8 +11,6 @@
              x:Name="ControlRoot"
              d:DesignHeight="400"
              d:DesignWidth="315"
-             Loaded="OnLoaded"
-             Unloaded="OnUnloaded"
              mc:Ignorable="d">
     <UserControl.Resources>
         <converters:BooleanNegationConverter x:Key="BooleanNegationConverter"/>

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -727,10 +727,10 @@
                                    Style="{StaticResource ParenthesisCalcButtonStyle}"
                                    FontSize="19"
                                    AutomationProperties.AutomationId="openParenthesisButton"
-                                   AutomationProperties.Name="{Binding LeftParenthesisAutomationName}"
                                    ButtonId="OpenParenthesis"
                                    Content="("
-                                   Tag="{x:Bind Model.OpenParenthesisCount, Mode=OneWay}"/>
+                                   GotFocus="OpenParenthesisButton_GotFocus"
+                                   Tag="{x:Bind ParenthesisCountToString(Model.OpenParenthesisCount), Mode=OneWay}"/>
         <controls:CalculatorButton x:Name="closeParenthesisButton"
                                    x:Uid="closeParenthesisButton"
                                    Grid.Row="8"

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
@@ -38,15 +38,6 @@ CalculatorScientificOperators::CalculatorScientificOperators()
     Common::KeyboardShortcutManager::ShiftButtonChecked(false);
 }
 
-void CalculatorScientificOperators::OnLoaded(Object^, RoutedEventArgs^)
-{
-    m_propertyChangedToken = Model->PropertyChanged += ref new PropertyChangedEventHandler(this, &CalculatorScientificOperators::OnViewModelPropertyChanged);
-}
-void CalculatorScientificOperators::OnUnloaded(Object^, RoutedEventArgs^)
-{
-    Model->PropertyChanged -= m_propertyChangedToken;
-}
-
 void CalculatorScientificOperators::ShortLayout_Completed(_In_ Platform::Object^ /*sender*/, _In_ Platform::Object^ /*e*/)
 {
     IsWideLayout = false;
@@ -107,10 +98,3 @@ void CalculatorScientificOperators::SetOperatorRowVisibility()
     InvRow2->Visibility = invRowVis;
 }
 
-void CalculatorScientificOperators::OnViewModelPropertyChanged(Object^ sender, PropertyChangedEventArgs^ e)
-{
-    if (e->PropertyName == StandardCalculatorViewModel::OpenParenthesisCountPropertyName && closeParenthesisButton->FocusState != ::FocusState::Unfocused)
-    {
-        Model->SetOpenParenthesisCountNarratorAnnouncement();
-    }
-}

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
@@ -99,11 +99,11 @@ void CalculatorScientificOperators::SetOperatorRowVisibility()
     InvRow2->Visibility = invRowVis;
 }
 
-void CalculatorScientificOperators::OpenParenthesisButton_GotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+void CalculatorScientificOperators::OpenParenthesisButton_GotFocus(Object^ sender, RoutedEventArgs^ e)
 {
     Model->SetOpenParenthesisCountNarratorAnnouncement();
 }
 
 String^ CalculatorScientificOperators::ParenthesisCountToString(unsigned int count) {
-    return count == 0 ? ref new String(L"") : ref new String(to_wstring(count).data());
+    return (count == 0) ? ref new String() : ref new String(to_wstring(count).data());
 }

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
@@ -16,6 +16,7 @@ using namespace CalculatorApp;
 using namespace CalculatorApp::Common;
 using namespace CalculatorApp::ViewModel;
 
+using namespace std;
 using namespace Platform;
 using namespace Windows::Foundation;
 using namespace Windows::Foundation::Collections;
@@ -98,3 +99,11 @@ void CalculatorScientificOperators::SetOperatorRowVisibility()
     InvRow2->Visibility = invRowVis;
 }
 
+void CalculatorScientificOperators::OpenParenthesisButton_GotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e)
+{
+    Model->SetOpenParenthesisCountNarratorAnnouncement();
+}
+
+String^ CalculatorScientificOperators::ParenthesisCountToString(unsigned int count) {
+    return count == 0 ? ref new String(L"") : ref new String(to_wstring(count).data());
+}

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.h
@@ -41,10 +41,5 @@ namespace CalculatorApp
         void shiftButton_Check(_In_ Platform::Object^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs^ e);
         void shiftButton_IsEnabledChanged(_In_ Platform::Object^ sender, _In_ Windows::UI::Xaml::DependencyPropertyChangedEventArgs^ e);
         void SetOperatorRowVisibility();
-        void OnViewModelPropertyChanged(Platform::Object^ sender, Windows::UI::Xaml::Data::PropertyChangedEventArgs ^ e);
-        void OnLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-        void OnUnloaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-
-        Windows::Foundation::EventRegistrationToken m_propertyChangedToken;
     };
 }

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.h
@@ -33,7 +33,8 @@ namespace CalculatorApp
         DEPENDENCY_PROPERTY_WITH_DEFAULT(bool, IsWideLayout, false);
 
         bool IsShiftEnabled(bool isWideLayout, bool isErrorState) { return !(isWideLayout || isErrorState); }
-
+        void OpenParenthesisButton_GotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        Platform::String^ ParenthesisCountToString(unsigned int count);
     private:
         void ShortLayout_Completed(_In_ Platform::Object^ sender, _In_ Platform::Object^ e);
         void WideLayout_Completed(_In_ Platform::Object^ sender, _In_ Platform::Object^ e);

--- a/src/Calculator/pch.h
+++ b/src/Calculator/pch.h
@@ -19,6 +19,7 @@
 #include <locale>
 #include <sal.h>
 #include <sstream>
+#include <string>
 #include <concrt.h>
 #include <regex>
 

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -57,7 +57,7 @@ namespace CalculatorManagerTest
             m_memorizedNumberStrings = numbers;
         }
 
-        void SetParenDisplayText(const std::wstring& parenthesisCount) override
+        void SetParenDisplayText(unsigned int parenthesisCount, bool /*useNarrator*/) override
         {
             m_parenDisplay = parenthesisCount;
         }
@@ -115,7 +115,7 @@ namespace CalculatorManagerTest
     private:
         wstring m_primaryDisplay;
         wstring m_expression;
-        wstring m_parenDisplay;
+        unsigned int m_parenDisplay;
         bool m_isError;
         vector<wstring> m_memorizedNumberStrings;
         int m_maxDigitsCalledCount;

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -57,7 +57,7 @@ namespace CalculatorManagerTest
             m_memorizedNumberStrings = numbers;
         }
 
-        void SetParenDisplayText(unsigned int parenthesisCount, bool /*useNarrator*/) override
+        void SetParenthesisNumber(unsigned int parenthesisCount) override
         {
             m_parenDisplay = parenthesisCount;
         }


### PR DESCRIPTION
## Fixes #367


### Description of the changes:
- Modify how the opening parenthesis button manages the Narrator to only convey the name of the `(` or `)` button when they get the focus
- Narrator will now say how many parenthesis are still open when users type '(' or ')'
- Modify and simplify how the right parenthesis button supports Narrator, we should limit registrations to `ViewModel::PropertyChanged` when possible, ideally, for performance reasons, we should only use bindings or specialized events. 
- Remove `Format_OpenParenthesisAutomationNamePrefix` to unify the behavior with the right parenthesis button and not repeat the name of the button each time the user clicks on it.

### How changes were validated:
- tested manually

