### PR TITLE
Fix padding of unit converter when the locale displays currency symbols on the left

### DIFF
--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -459,8 +459,8 @@
                 <VisualState x:Name="CurrencySymbolLeftState"/>
                 <VisualState x:Name="CurrencySymbolRightState">
                     <VisualState.Setters>
-                        <Setter Target="Value1Container.Padding" Value="0,0,12,0"/>
-                        <Setter Target="Value2Container.Padding" Value="0,0,12,0"/>
+                        <Setter Target="CurrencySymbol1Block.Padding" Value="0,0,12,0"/>
+                        <Setter Target="CurrencySymbol2Block.Padding" Value="0,0,12,0"/>
                         <Setter Target="CurrencySymbol1Block.(Grid.Column)" Value="2"/>
                         <Setter Target="CurrencySymbol2Block.(Grid.Column)" Value="2"/>
                     </VisualState.Setters>
@@ -492,7 +492,6 @@
         <Grid x:Name="Value1Container"
               Grid.Row="1"
               Grid.Column="1"
-              Padding="12,0,0,0"
               HorizontalAlignment="Left"
               Style="{ThemeResource ValueContainerStyle}"
               FlowDirection="{x:Bind LayoutDirection}"
@@ -504,6 +503,7 @@
             </Grid.ColumnDefinitions>
             <TextBlock x:Name="CurrencySymbol1Block"
                        Grid.Column="0"
+                       Padding="12,0,0,0"
                        Style="{ThemeResource CurrencySymbolMediumStyle}"
                        AutomationProperties.AccessibilityView="Raw"
                        Text="{x:Bind Model.CurrencySymbol1, Mode=OneWay}"
@@ -544,7 +544,6 @@
         <Grid x:Name="Value2Container"
               Grid.Row="3"
               Grid.Column="1"
-              Padding="12,0,0,0"
               HorizontalAlignment="Left"
               Style="{ThemeResource ValueContainerStyle}"
               FlowDirection="{x:Bind LayoutDirection}"
@@ -556,6 +555,7 @@
             </Grid.ColumnDefinitions>
             <TextBlock x:Name="CurrencySymbol2Block"
                        Grid.Column="0"
+                       Padding="12,0,0,0"
                        Style="{ThemeResource CurrencySymbolMediumStyle}"
                        AutomationProperties.AccessibilityView="Raw"
                        Text="{x:Bind Model.CurrencySymbol2, Mode=OneWay}"


### PR DESCRIPTION
## Fixes #372

UnitConverter.xaml didn't align controls correctly when the PC was set with a locale displaying currency symbols on the left. The bug was only visible with unit conversion, not with currency conversion.

### Change
- Modify how we manage the padding of Value1Container and Value2Container

### How changes were validated:
- manually, in FR (currency symbols displayed on the right), in EN (currency symbols displayed on the left) 
- in currency converter mode and in unit converter mode
- portrait and landscape.
