### PR TITLE
UnitConverter: Automatically flip units when users set one to the same type than the other

### DIFF
--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -782,13 +782,16 @@ void UnitConverterViewModel::RefreshSupplementaryResults()
 // values are not both zero.
 void UnitConverterViewModel::AnnounceConversionResult()
 {
-    if ((m_valueFromUnlocalized != m_lastAnnouncedFrom || m_valueToUnlocalized != m_lastAnnouncedTo) && Unit1 != nullptr && Unit2 != nullptr)
+    if ((m_valueFromUnlocalized != m_lastAnnouncedFrom
+        || m_valueToUnlocalized != m_lastAnnouncedTo)
+        && m_Unit1 != nullptr
+        && m_Unit2 != nullptr)
     {
         m_lastAnnouncedFrom = m_valueFromUnlocalized;
         m_lastAnnouncedTo = m_valueToUnlocalized;
 
-        Unit ^ unitFrom = Value1Active ? Unit1 : Unit2;
-        Unit ^ unitTo = (unitFrom == Unit1) ? Unit2 : Unit1;
+        Unit^ unitFrom = Value1Active ? m_Unit1 : m_Unit2;
+        Unit^ unitTo = (unitFrom == m_Unit1) ? m_Unit2 : m_Unit1;
         m_lastAnnouncedConversionResult = GetLocalizedConversionResultStringFormat(ValueFrom, unitFrom->Name, ValueTo, unitTo->Name);
 
         Announcement = CalculatorAnnouncement::GetDisplayUpdatedAnnouncement(m_lastAnnouncedConversionResult);
@@ -959,17 +962,17 @@ String
 
 void UnitConverterViewModel::UpdateValue1AutomationName()
 {
-    if (Unit1)
+    if (m_Unit1)
     {
-        Value1AutomationName = GetLocalizedAutomationName(Value1, Unit1->AccessibleName, m_localizedValueFromFormat);
+        Value1AutomationName = GetLocalizedAutomationName(Value1, m_Unit1->AccessibleName, m_localizedValueFromFormat);
     }
 }
 
 void UnitConverterViewModel::UpdateValue2AutomationName()
 {
-    if (Unit2)
+    if (m_Unit2)
     {
-        Value2AutomationName = GetLocalizedAutomationName(Value2, Unit2->AccessibleName, m_localizedValueToFormat);
+        Value2AutomationName = GetLocalizedAutomationName(Value2, m_Unit2->AccessibleName, m_localizedValueToFormat);
     }
 }
 
@@ -989,4 +992,53 @@ String ^ SupplementaryResult::GetLocalizedAutomationName()
 {
     auto format = AppResourceProvider::GetInstance()->GetResourceString("SupplementaryUnit_AutomationName");
     return LocalizationStringUtil::GetLocalizedString(format, this->Value, this->Unit->Name);
+}
+
+Unit^ UnitConverterViewModel::Unit1::get()
+{
+    return m_Unit1;
+}
+
+void UnitConverterViewModel::Unit1::set(Unit^ value)
+{
+    if (m_Unit1 == value)
+        return;
+
+    if (value == m_Unit2 && value != nullptr && m_Unit1 != nullptr)
+    {
+        auto formerValue = m_Unit1;
+        m_Unit1 = value;
+        //Be sure m_Unit1 is set before setting Unit2
+        Unit2 = formerValue;
+    }
+    else
+    {
+        m_Unit1 = value;
+    }
+    RaisePropertyChanged(Unit1PropertyName);
+}
+
+
+Unit^ UnitConverterViewModel::Unit2::get()
+{
+    return m_Unit2;
+}
+
+void UnitConverterViewModel::Unit2::set(Unit^ value)
+{
+    if (m_Unit2 == value)
+        return;
+
+    if (value == m_Unit1 && value != nullptr && m_Unit2 != nullptr)
+    {
+        auto formerValue = m_Unit2;
+        m_Unit2 = value;
+        //Be sure m_Unit2 is set before setting Unit1
+        Unit1 = formerValue;
+    }
+    else
+    {
+        m_Unit2 = value;
+    }
+    RaisePropertyChanged(Unit2PropertyName);
 }

--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -1002,7 +1002,9 @@ Unit^ UnitConverterViewModel::Unit1::get()
 void UnitConverterViewModel::Unit1::set(Unit^ value)
 {
     if (m_Unit1 == value)
+    {
         return;
+    }
 
     if (value == m_Unit2 && value != nullptr && m_Unit1 != nullptr)
     {

--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -1029,7 +1029,9 @@ Unit^ UnitConverterViewModel::Unit2::get()
 void UnitConverterViewModel::Unit2::set(Unit^ value)
 {
     if (m_Unit2 == value)
+    {
         return;
+    }
 
     if (value == m_Unit1 && value != nullptr && m_Unit2 != nullptr)
     {

--- a/src/CalcViewModel/UnitConverterViewModel.h
+++ b/src/CalcViewModel/UnitConverterViewModel.h
@@ -336,8 +336,6 @@ namespace CalculatorApp
             std::wstring m_valueFromUnlocalized;
             std::wstring m_valueToUnlocalized;
             bool m_relocalizeStringOnSwitch;
-            // in order to save the User Preferences only if the Unit converter ViewModel is initialised for the first time
-            bool m_IsFirstTime;
             Unit^ m_Unit1;
             Unit^ m_Unit2;
 

--- a/src/CalcViewModel/UnitConverterViewModel.h
+++ b/src/CalcViewModel/UnitConverterViewModel.h
@@ -144,14 +144,12 @@ namespace CalculatorApp
 
             OBSERVABLE_PROPERTY_R(Windows::Foundation::Collections::IObservableVector<Category ^> ^, Categories);
             OBSERVABLE_PROPERTY_RW(CalculatorApp::Common::ViewMode, Mode);
-            OBSERVABLE_PROPERTY_R(Windows::Foundation::Collections::IObservableVector<Unit ^> ^, Units);
-            OBSERVABLE_PROPERTY_RW(Platform::String ^, CurrencySymbol1);
-            OBSERVABLE_PROPERTY_RW(Unit ^, Unit1);
-            OBSERVABLE_PROPERTY_RW(Platform::String ^, Value1);
-            OBSERVABLE_PROPERTY_RW(Platform::String ^, CurrencySymbol2);
-            OBSERVABLE_PROPERTY_RW(Unit ^, Unit2);
-            OBSERVABLE_PROPERTY_RW(Platform::String ^, Value2);
-            OBSERVABLE_NAMED_PROPERTY_R(Windows::Foundation::Collections::IObservableVector<SupplementaryResult ^> ^, SupplementaryResults);
+            OBSERVABLE_PROPERTY_R(Windows::Foundation::Collections::IObservableVector<Unit^>^, Units);
+            OBSERVABLE_PROPERTY_RW(Platform::String^, CurrencySymbol1);
+            OBSERVABLE_PROPERTY_RW(Platform::String^, Value1);
+            OBSERVABLE_PROPERTY_RW(Platform::String^, CurrencySymbol2);
+            OBSERVABLE_PROPERTY_RW(Platform::String^, Value2);
+            OBSERVABLE_NAMED_PROPERTY_R(Windows::Foundation::Collections::IObservableVector<SupplementaryResult^>^, SupplementaryResults);
             OBSERVABLE_PROPERTY_RW(bool, Value1Active);
             OBSERVABLE_PROPERTY_RW(bool, Value2Active);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, Value1AutomationName);
@@ -217,7 +215,19 @@ namespace CalculatorApp
 
             void AnnounceConversionResult();
 
-            internal : void ResetView();
+            property Unit^ Unit1
+            {
+                Unit^ get();
+                void set(Unit^ value);
+            }
+            property Unit^ Unit2
+            {
+                Unit^ get();
+                void set(Unit^ value);
+            }
+
+        internal:
+            void ResetView();
             void PopulateData();
             NumbersAndOperatorsEnum MapCharacterToButtonId(const wchar_t ch, bool& canSendNegate);
             void DisplayPasteError();
@@ -314,7 +324,6 @@ namespace CalculatorApp
             {
                 m_value1cp = m_value1cp == ConversionParameter::Source ? ConversionParameter::Target : ConversionParameter::Source;
             }
-
         private:
             bool m_isInputBlocked;
             Windows::System::Threading::ThreadPoolTimer ^ m_supplementaryResultsTimer;
@@ -327,6 +336,10 @@ namespace CalculatorApp
             std::wstring m_valueFromUnlocalized;
             std::wstring m_valueToUnlocalized;
             bool m_relocalizeStringOnSwitch;
+            // in order to save the User Preferences only if the Unit converter ViewModel is initialised for the first time
+            bool m_IsFirstTime;
+            Unit^ m_Unit1;
+            Unit^ m_Unit2;
 
             Platform::String ^ m_localizedValueFromFormat;
             Platform::String ^ m_localizedValueFromDecimalFormat;

--- a/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.cpp
@@ -222,10 +222,10 @@ void UnitConverterMock::SwitchActive(const std::wstring& newValue)
     m_curValue = newValue;
 }
 
-    std::wstring UnitConverterMock::SaveUserPreferences()
-    {
-        return L"TEST";
-    };
+std::wstring UnitConverterMock::SaveUserPreferences()
+{
+    return L"TEST";
+};
 
 void UnitConverterMock::RestoreUserPreferences(_In_ std::wstring_view /*userPreferences*/){};
 
@@ -284,9 +284,9 @@ for (unsigned int k = 0; k < categoryList->Size; k++)
         wstring unit1Name = vm->Unit1->Name->Data();
         for (unsigned int j = 0; j < unitList->Size; j++)
         {
-			if (i == j)
-				continue;
-			vm->Value2Active = true;
+            if (i == j)
+                continue;
+            vm->Value2Active = true;
             vm->Value1Active = false;
             vm->Unit2 = unitList->GetAt(j);
             wstring unit2Name = vm->Unit2->Name->Data();
@@ -704,46 +704,46 @@ TEST_METHOD(TestUnitChangeAfterSwitchingActiveTwiceUpdateUnitsCorrectly)
     VERIFY_IS_TRUE(UNIT6 == mock->m_curFrom);
 }
 
-        TEST_METHOD(TestUnitFlipFromToUnits)
-        {
-            shared_ptr<UnitConverterMock> mock = make_shared<UnitConverterMock>();
-            VM::UnitConverterViewModel vm(mock);
-            vm.Value2Active = true;
-            vm.Value1Active = true;
-            vm.Unit2 = vm.Units->GetAt(0);
-            VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(0));
-            vm.Unit1 = vm.Units->GetAt(2);
-            VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(2));
-            vm.Unit2 = vm.Units->GetAt(2);
-            VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(0));
-            VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(2));
-            vm.Unit1 = vm.Units->GetAt(2);
-            VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(0));
-            VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(2));
-            vm.Unit1 = vm.Units->GetAt(1);
-            VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(0));
-            VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(1));
-        }
+TEST_METHOD(TestUnitFlipFromToUnits)
+{
+    shared_ptr<UnitConverterMock> mock = make_shared<UnitConverterMock>();
+    VM::UnitConverterViewModel vm(mock);
+    vm.Value2Active = true;
+    vm.Value1Active = true;
+    vm.Unit2 = vm.Units->GetAt(0);
+    VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(0));
+    vm.Unit1 = vm.Units->GetAt(2);
+    VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(2));
+    vm.Unit2 = vm.Units->GetAt(2);
+    VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(0));
+    VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(2));
+    vm.Unit1 = vm.Units->GetAt(2);
+    VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(0));
+    VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(2));
+    vm.Unit1 = vm.Units->GetAt(1);
+    VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(0));
+    VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(1));
+}
 
-        TEST_METHOD(TestCategoryChangeAfterSwitchingActiveTwiceUpdatesDisplayCorrectly)
-        {
-            shared_ptr<UnitConverterMock> mock = make_shared<UnitConverterMock>();
-            VM::UnitConverterViewModel vm(mock);
-            const WCHAR * vFrom = L"1", *vTo = L"234";
-            vm.UpdateDisplay(vFrom, vTo);
-            vm.Value2Active = true;
-            vm.Value1Active = true;
-            vm.CurrentCategory = vm.Categories->GetAt(2);
-            VERIFY_IS_TRUE(UNIT9 == vm.Unit1->GetModelUnit());
-            VERIFY_IS_TRUE(UNIT7 == vm.Unit2->GetModelUnit());
-            VERIFY_IS_TRUE(UNIT9 == mock->m_curFrom);
-            VERIFY_IS_TRUE(UNIT7 == mock->m_curTo);
-            VERIFY_ARE_EQUAL((UINT)2, mock->m_switchActiveCallCount);
-            const wchar_t * newvFrom = L"5", *newvTo = L"7";
-            vm.UpdateDisplay(newvFrom, newvTo);
-            VERIFY_IS_TRUE(vm.Value1 == AddUnicodeLTRMarkers(newvFrom));
-            VERIFY_IS_TRUE(vm.Value2 == AddUnicodeLTRMarkers(newvTo));
-        }
+TEST_METHOD(TestCategoryChangeAfterSwitchingActiveTwiceUpdatesDisplayCorrectly)
+{
+    shared_ptr<UnitConverterMock> mock = make_shared<UnitConverterMock>();
+    VM::UnitConverterViewModel vm(mock);
+    const WCHAR *vFrom = L"1", *vTo = L"234";
+    vm.UpdateDisplay(vFrom, vTo);
+    vm.Value2Active = true;
+    vm.Value1Active = true;
+    vm.CurrentCategory = vm.Categories->GetAt(2);
+    VERIFY_IS_TRUE(UNIT9 == vm.Unit1->GetModelUnit());
+    VERIFY_IS_TRUE(UNIT7 == vm.Unit2->GetModelUnit());
+    VERIFY_IS_TRUE(UNIT9 == mock->m_curFrom);
+    VERIFY_IS_TRUE(UNIT7 == mock->m_curTo);
+    VERIFY_ARE_EQUAL((UINT)2, mock->m_switchActiveCallCount);
+    const wchar_t *newvFrom = L"5", *newvTo = L"7";
+    vm.UpdateDisplay(newvFrom, newvTo);
+    VERIFY_IS_TRUE(vm.Value1 == AddUnicodeLTRMarkers(newvFrom));
+    VERIFY_IS_TRUE(vm.Value2 == AddUnicodeLTRMarkers(newvTo));
+}
 
 // There is a 100 ms fudge time for the time based tests below
 

--- a/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.cpp
@@ -284,7 +284,9 @@ for (unsigned int k = 0; k < categoryList->Size; k++)
         wstring unit1Name = vm->Unit1->Name->Data();
         for (unsigned int j = 0; j < unitList->Size; j++)
         {
-            vm->Value2Active = true;
+			if (i == j)
+				continue;
+			vm->Value2Active = true;
             vm->Value1Active = false;
             vm->Unit2 = unitList->GetAt(j);
             wstring unit2Name = vm->Unit2->Name->Data();
@@ -702,25 +704,46 @@ TEST_METHOD(TestUnitChangeAfterSwitchingActiveTwiceUpdateUnitsCorrectly)
     VERIFY_IS_TRUE(UNIT6 == mock->m_curFrom);
 }
 
-TEST_METHOD(TestCategoryChangeAfterSwitchingActiveTwiceUpdatesDisplayCorrectly)
-{
-    shared_ptr<UnitConverterMock> mock = make_shared<UnitConverterMock>();
-    VM::UnitConverterViewModel vm(mock);
-    const WCHAR *vFrom = L"1", *vTo = L"234";
-    vm.UpdateDisplay(vFrom, vTo);
-    vm.Value2Active = true;
-    vm.Value1Active = true;
-    vm.CurrentCategory = vm.Categories->GetAt(2);
-    VERIFY_IS_TRUE(UNIT9 == vm.Unit1->GetModelUnit());
-    VERIFY_IS_TRUE(UNIT7 == vm.Unit2->GetModelUnit());
-    VERIFY_IS_TRUE(UNIT9 == mock->m_curFrom);
-    VERIFY_IS_TRUE(UNIT7 == mock->m_curTo);
-    VERIFY_ARE_EQUAL((UINT)2, mock->m_switchActiveCallCount);
-    const wchar_t *newvFrom = L"5", *newvTo = L"7";
-    vm.UpdateDisplay(newvFrom, newvTo);
-    VERIFY_IS_TRUE(vm.Value1 == AddUnicodeLTRMarkers(newvFrom));
-    VERIFY_IS_TRUE(vm.Value2 == AddUnicodeLTRMarkers(newvTo));
-}
+        TEST_METHOD(TestUnitFlipFromToUnits)
+        {
+            shared_ptr<UnitConverterMock> mock = make_shared<UnitConverterMock>();
+            VM::UnitConverterViewModel vm(mock);
+            vm.Value2Active = true;
+            vm.Value1Active = true;
+            vm.Unit2 = vm.Units->GetAt(0);
+            VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(0));
+            vm.Unit1 = vm.Units->GetAt(2);
+            VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(2));
+            vm.Unit2 = vm.Units->GetAt(2);
+            VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(0));
+            VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(2));
+            vm.Unit1 = vm.Units->GetAt(2);
+            VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(0));
+            VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(2));
+            vm.Unit1 = vm.Units->GetAt(1);
+            VERIFY_IS_TRUE(vm.Unit2 == vm.Units->GetAt(0));
+            VERIFY_IS_TRUE(vm.Unit1 == vm.Units->GetAt(1));
+        }
+
+        TEST_METHOD(TestCategoryChangeAfterSwitchingActiveTwiceUpdatesDisplayCorrectly)
+        {
+            shared_ptr<UnitConverterMock> mock = make_shared<UnitConverterMock>();
+            VM::UnitConverterViewModel vm(mock);
+            const WCHAR * vFrom = L"1", *vTo = L"234";
+            vm.UpdateDisplay(vFrom, vTo);
+            vm.Value2Active = true;
+            vm.Value1Active = true;
+            vm.CurrentCategory = vm.Categories->GetAt(2);
+            VERIFY_IS_TRUE(UNIT9 == vm.Unit1->GetModelUnit());
+            VERIFY_IS_TRUE(UNIT7 == vm.Unit2->GetModelUnit());
+            VERIFY_IS_TRUE(UNIT9 == mock->m_curFrom);
+            VERIFY_IS_TRUE(UNIT7 == mock->m_curTo);
+            VERIFY_ARE_EQUAL((UINT)2, mock->m_switchActiveCallCount);
+            const wchar_t * newvFrom = L"5", *newvTo = L"7";
+            vm.UpdateDisplay(newvFrom, newvTo);
+            VERIFY_IS_TRUE(vm.Value1 == AddUnicodeLTRMarkers(newvFrom));
+            VERIFY_IS_TRUE(vm.Value2 == AddUnicodeLTRMarkers(newvTo));
+        }
 
 // There is a 100 ms fudge time for the time based tests below
 
@@ -798,7 +821,7 @@ TEST_METHOD(TestUnitChangeImmediatelyUpdatesSupplementaryResults)
     WaitForSingleObjectEx(GetCurrentThread(), 1100, FALSE);
     VERIFY_ARE_EQUAL((UINT)3, vm.SupplementaryResults->Size); // Verify we're in the state we expect as a pre condition
 
-    vm.Unit1 = vm.Units->GetAt(2);
+    vm.Unit1 = vm.Units->GetAt(1);
     VERIFY_ARE_EQUAL((UINT)0, vm.SupplementaryResults->Size);
 
     // Reset and try with other unit


### PR DESCRIPTION
## Fixes #266


### Description of the changes:
- replace `OBSERVABLE_PROPERTY_RW` for Unit1 and Unit2 by custom code.
- verify if the new value of `Unit1` is equals to the current value of `Unit2`, if it's the case, set `Unit2` to the former value of `Unit1`. 
- add unit tests (and adapt existing ones)
- [NIT optimization] replace `Unit1` and `Unit2` by `m_Unit1` and `m_Unit2` when possible

### How changes were validated:
- Manually tested + unit tests