### PR TITLE
[Build] Don't run component governance detection in postbuild steps

### DIFF
--- a/build/pipelines/templates/package-appxbundle.yaml
+++ b/build/pipelines/templates/package-appxbundle.yaml
@@ -20,6 +20,8 @@ jobs:
     vmImage: vs2017-win2016
   workspace:
     clean: outputs
+  variables:
+    skipComponentGovernanceDetection: true
   steps:
   - checkout: self
     clean: true

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -17,6 +17,8 @@ jobs:
     name: Package ES Lab E
   workspace:
     clean: outputs
+  variables:
+    skipComponentGovernanceDetection: true
   steps:
   - checkout: self
     clean: true

--- a/build/pipelines/templates/run-unit-tests.yaml
+++ b/build/pipelines/templates/run-unit-tests.yaml
@@ -14,6 +14,8 @@ jobs:
     name: Essential Experiences Interactive
   workspace:
     clean: outputs
+  variables:
+    skipComponentGovernanceDetection: true
   steps:
   - checkout: none
 


### PR DESCRIPTION
See also #353.

In the internal build environment, there's an auto-injected component governance task which needs to run once during the build. This task doesn't need to run during the unit test, package, and internal release jobs.