### PR TITLE
Updates to copypastemanager

### DIFF
--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -418,8 +418,7 @@ bool CopyPasteManager::TryOperandToULL(const wstring& operand, int numberBase, u
         return false;
     }
 
-    // Default to base10
-    int intBase = 10;
+    int intBase;
     switch (numberBase)
     {
     case HexBase:
@@ -431,7 +430,8 @@ bool CopyPasteManager::TryOperandToULL(const wstring& operand, int numberBase, u
     case BinBase:
         intBase = 2;
         break;
-    case DecBase: // Unneeded as the default is already 10?
+    default:
+    case DecBase:
         intBase = 10;
         break;
     }

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -429,7 +429,7 @@ bool CopyPasteManager::TryOperandToULL(const wstring& operand, int numberBase, u
     case BinBase:
         intBase = 2;
         break;
-    case DecBase:
+    case DecBase: // Unneeded as the default is already 10?
         intBase = 10;
         break;
     }
@@ -445,6 +445,10 @@ bool CopyPasteManager::TryOperandToULL(const wstring& operand, int numberBase, u
         // Do nothing
     }
     catch (out_of_range)
+    {
+        // Do nothing
+    }
+    catch(...)
     {
         // Do nothing
     }
@@ -472,13 +476,13 @@ size_t CopyPasteManager::OperandLength(wstring operand, ViewMode mode, CategoryG
 
 size_t CopyPasteManager::StandardScientificOperandLength(wstring operand)
 {
+    // Loop until a decimal is found or if the end is reached
     bool hasDecimal = false;
-    for (size_t i = 0; i < operand.length(); i++)
+    for (size_t i = 0; i < operand.length() && !hasDecimal; i++)
     {
         if (operand[i] == L'.')
         {
             hasDecimal = true;
-            break;
         }
     }
 

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -340,14 +340,16 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
 
 pair<size_t, uint64_t> CopyPasteManager::GetMaxOperandLengthAndValue(ViewMode mode, CategoryGroupType modeType, int programmerNumberBase, int bitLengthType)
 {
+    constexpr size_t defaultMaxOperandLength = 0;
+    constexpr uint64_t defaultMaxValue = 0;
     
     if (mode == ViewMode::Standard)
     {
-        return make_pair(MaxStandardOperandLength, 0);
+        return make_pair(MaxStandardOperandLength, defaultMaxValue);
     }
     else if (mode == ViewMode::Scientific)
     {
-        return make_pair(MaxScientificOperandLength, 0);
+        return make_pair(MaxScientificOperandLength, defaultMaxValue);
     }
     else if (mode == ViewMode::Programmer)
     {
@@ -394,10 +396,10 @@ pair<size_t, uint64_t> CopyPasteManager::GetMaxOperandLengthAndValue(ViewMode mo
     }
     else if (modeType == CategoryGroupType::Converter)
     {
-        return make_pair(MaxConverterInputLength, 0);
+        return make_pair(MaxConverterInputLength, defaultMaxValue);
     }
 
-    return make_pair(0, 0);
+    return make_pair(defaultMaxOperandLength, defaultMaxValue);
 }
 
 wstring CopyPasteManager::SanitizeOperand(const wstring& operand)

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -15,8 +15,6 @@ using namespace Windows::Foundation;
 using namespace Windows::System;
 using namespace Windows::ApplicationModel::DataTransfer;
 
-unsigned long long maxOperandNumber;
-
 String^ CopyPasteManager::supportedFormats[] =
 {
     StandardDataFormats::Text

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -106,19 +106,16 @@ task<String^> CopyPasteManager::GetStringToPaste(ViewMode mode, CategoryGroupTyp
 
 int CopyPasteManager::ClipboardTextFormat()
 {
-    int result = -1;
-
-    auto dataPackageView = Clipboard::GetContent();
+    const auto dataPackageView = Clipboard::GetContent();
 
     for (int i = 0; i < RTL_NUMBER_OF(supportedFormats); i++)
     {
         if (dataPackageView->Contains(supportedFormats[i]))
         {
-            result = i;
-            break;
+            return i;
         }
     }
-    return result;
+    return -1;
 }
 
 String^ CopyPasteManager::ValidatePasteExpression(String^ pastedText, ViewMode mode, int programmerNumberBase, int bitLengthType)
@@ -394,7 +391,7 @@ pair<size_t, uint64_t> CopyPasteManager::GetMaxOperandLengthAndValue(ViewMode mo
 
         unsigned int signBit = (programmerNumberBase == DecBase) ? 1 : 0;
 
-        maxLength = (size_t)ceil((bitLength - signBit) / bitsPerDigit);
+        maxLength = static_cast<size_t>(ceil((bitLength - signBit) / bitsPerDigit));
         maxValue = UINT64_MAX >> (MaxProgrammerBitLength - (bitLength - signBit));
     }
     else if (modeType == CategoryGroupType::Converter)
@@ -459,21 +456,20 @@ bool CopyPasteManager::TryOperandToULL(const wstring& operand, int numberBase, u
 
 size_t CopyPasteManager::OperandLength(wstring operand, ViewMode mode, CategoryGroupType modeType, int programmerNumberBase)
 {
-    size_t len = 0;
     if (mode == ViewMode::Standard || mode == ViewMode::Scientific)
     {
-        len = StandardScientificOperandLength(operand);
+        return StandardScientificOperandLength(operand);
     }
     else if (mode == ViewMode::Programmer)
     {
-        len = ProgrammerOperandLength(operand, programmerNumberBase);
+        return ProgrammerOperandLength(operand, programmerNumberBase);
     }
     else if (modeType == CategoryGroupType::Converter)
     {
-        len = operand.length();
+        return operand.length();
     }
 
-    return len;
+    return 0;
 }
 
 size_t CopyPasteManager::StandardScientificOperandLength(wstring operand)
@@ -484,6 +480,7 @@ size_t CopyPasteManager::StandardScientificOperandLength(wstring operand)
         if (operand[i] == L'.')
         {
             hasDecimal = true;
+            break;
         }
     }
 
@@ -541,7 +538,7 @@ size_t CopyPasteManager::ProgrammerOperandLength(const wstring& operand, int num
 
     // Detect if there is a suffix and subtract its length
     // Check suffixes first to allow e.g. "0b" to result in length 1 (value 0), rather than length 0 (no value).
-    for (const wstring& suffix : suffixes)
+    for (const auto& suffix : suffixes)
     {
         if (len < suffix.length())
         {
@@ -556,7 +553,7 @@ size_t CopyPasteManager::ProgrammerOperandLength(const wstring& operand, int num
     }
 
     // Detect if there is a prefix and subtract its length
-    for (const wstring& prefix : prefixes)
+    for (const auto& prefix : prefixes)
     {
         if (len < prefix.length())
         {

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -459,34 +459,27 @@ bool CopyPasteManager::TryOperandToULL(const wstring& operand, int numberBase, u
 }
 
 size_t CopyPasteManager::OperandLength(wstring operand, ViewMode mode, CategoryGroupType modeType, int programmerNumberBase)
-{
-    if (mode == ViewMode::Standard || mode == ViewMode::Scientific)
-    {
-        return StandardScientificOperandLength(operand);
-    }
-    else if (mode == ViewMode::Programmer)
-    {
-        return ProgrammerOperandLength(operand, programmerNumberBase);
-    }
-    else if (modeType == CategoryGroupType::Converter)
-    {
+{      
+    if(modeType == CategoryGroupType::Converter) {
         return operand.length();
     }
 
-    return 0;
+    switch(mode) {
+        case ViewMode::Standard:
+        case ViewMode::Scientific:
+            return StandardScientificOperandLength(operand);
+
+        case ViewMode::Programmer:
+            return ProgrammerOperandLength(operand, programmerNumberBase);
+
+        default:
+            return 0;
+    }
 }
 
 size_t CopyPasteManager::StandardScientificOperandLength(wstring operand)
-{
-    // Loop until a decimal is found or if the end is reached
-    bool hasDecimal = false;
-    for (size_t i = 0; i < operand.length() && !hasDecimal; i++)
-    {
-        if (operand[i] == L'.')
-        {
-            hasDecimal = true;
-        }
-    }
+{   
+    const bool hasDecimal = operand.find('.') != std::wstring::npos;
 
     if (hasDecimal)
     {

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -23,20 +23,23 @@ String^ CopyPasteManager::supportedFormats[] =
 };
 
 constexpr wstring_view c_validCharacterSet{ L"0123456789()+-*/.abcdefABCDEF" };
+
+// The below values can not be "constexpr"-ed,
+// as both wstring_view and wchar[] can not be concatenated
 // [\s\x85] means white-space characters
 static const wstring c_wspc = L"[\\s\\x85]*";
-static const wstring c_wspcLParens = c_wspc + L"[(]*" + c_wspc;
-static const wstring c_wspcLParenSigned = c_wspc + L"([-+]?[(])*" + c_wspc;
-static const wstring c_wspcRParens = c_wspc + L"[)]*" + c_wspc;
-static const wstring c_signedDecFloat = L"[-+]?\\d*(\\d|[.])\\d*";
+static const auto c_wspcLParens = c_wspc + L"[(]*" + c_wspc;
+static const auto c_wspcLParenSigned = c_wspc + L"([-+]?[(])*" + c_wspc;
+static const auto c_wspcRParens = c_wspc + L"[)]*" + c_wspc;
+static const auto c_signedDecFloat = L"[-+]?\\d*(\\d|[.])\\d*";
 
 // Programmer Mode Integer patterns
 // Support digit separators ` (WinDbg/MASM), ' (C++), and _ (C# and other languages)
-static const wstring c_hexProgrammerChars = L"([a-f]|[A-F]|\\d)+((_|'|`)([a-f]|[A-F]|\\d)+)*";
-static const wstring c_decProgrammerChars = L"\\d+((_|'|`)\\d+)*";
-static const wstring c_octProgrammerChars = L"[0-7]+((_|'|`)[0-7]+)*";
-static const wstring c_binProgrammerChars = L"[0-1]+((_|'|`)[0-1]+)*";
-static const wstring c_uIntSuffixes = L"[uU]?[lL]{0,2}";
+static constexpr auto c_hexProgrammerChars = L"([a-f]|[A-F]|\\d)+((_|'|`)([a-f]|[A-F]|\\d)+)*";
+static constexpr auto c_decProgrammerChars = L"\\d+((_|'|`)\\d+)*";
+static constexpr auto c_octProgrammerChars = L"[0-7]+((_|'|`)[0-7]+)*";
+static constexpr auto c_binProgrammerChars = L"[0-1]+((_|'|`)[0-1]+)*";
+static constexpr auto c_uIntSuffixes = L"[uU]?[lL]{0,2}";
 
 // RegEx Patterns used by various modes
 static const array<wregex, 1> standardModePatterns =
@@ -271,6 +274,7 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
     bool expMatched = true;
     vector<wregex> patterns{};
 
+    // Could this be auto?
     pair<size_t, uint64_t> operandLimits = GetMaxOperandLengthAndValue(mode, modeType, programmerNumberBase, bitLengthType);
     size_t maxOperandLength = operandLimits.first;
     uint64_t maxOperandValue = operandLimits.second;
@@ -292,11 +296,11 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
         patterns.assign(unitConverterPatterns.begin(), unitConverterPatterns.end());
     }
 
-    for (const wstring& operand : operands)
+    for (const auto& operand : operands)
     {
         // Each operand only needs to match one of the available patterns.
         bool operandMatched = false;
-        for (const wregex& pattern : patterns)
+        for (const auto& pattern : patterns)
         {
             operandMatched = operandMatched || regex_match(operand, pattern);
         }
@@ -305,7 +309,7 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
         {
             // Remove characters that are valid in the expression but we do not want to include in length calculations
             // or which will break conversion from string-to-ULL.
-            wstring operandValue = SanitizeOperand(operand);
+            const wstring operandValue = SanitizeOperand(operand);
 
             // If an operand exceeds the maximum length allowed, break and return.
             if (OperandLength(operandValue, mode, modeType, programmerNumberBase) > maxOperandLength)

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -477,9 +477,9 @@ size_t CopyPasteManager::OperandLength(wstring operand, ViewMode mode, CategoryG
     }
 }
 
-size_t CopyPasteManager::StandardScientificOperandLength(wstring operand)
+size_t CopyPasteManager::StandardScientificOperandLength(const wstring& operand)
 {   
-    const bool hasDecimal = operand.find('.') != std::wstring::npos;
+    const bool hasDecimal = operand.find('.') != wstring::npos;
 
     if (hasDecimal)
     {

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -20,7 +20,7 @@ String^ CopyPasteManager::supportedFormats[] =
     StandardDataFormats::Text
 };
 
-constexpr wstring_view c_validCharacterSet{ L"0123456789()+-*/.abcdefABCDEF" };
+static constexpr wstring_view c_validCharacterSet{ L"0123456789()+-*/.abcdefABCDEF" };
 
 // The below values can not be "constexpr"-ed,
 // as both wstring_view and wchar[] can not be concatenated
@@ -269,10 +269,7 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
     bool expMatched = true;
     vector<wregex> patterns{};
 
-    // Could this be auto?
-    pair<size_t, uint64_t> operandLimits = GetMaxOperandLengthAndValue(mode, modeType, programmerNumberBase, bitLengthType);
-    size_t maxOperandLength = operandLimits.first;
-    uint64_t maxOperandValue = operandLimits.second;
+    const auto [maxOperandLength, maxOperandValue] = GetMaxOperandLengthAndValue(mode, modeType, programmerNumberBase, bitLengthType);
 
     if (mode == ViewMode::Standard)
     {
@@ -442,15 +439,11 @@ bool CopyPasteManager::TryOperandToULL(const wstring& operand, int numberBase, u
         result = stoull(operand, &size, intBase);
         return true;
     }
-    catch (invalid_argument)
+    catch (const invalid_argument&)
     {
         // Do nothing
     }
-    catch (out_of_range)
-    {
-        // Do nothing
-    }
-    catch(...)
+    catch (const out_of_range&)
     {
         // Do nothing
     }

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -340,16 +340,14 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
 
 pair<size_t, uint64_t> CopyPasteManager::GetMaxOperandLengthAndValue(ViewMode mode, CategoryGroupType modeType, int programmerNumberBase, int bitLengthType)
 {
-    size_t maxLength = 0;
-    uint64_t maxValue = 0;
-
+    
     if (mode == ViewMode::Standard)
     {
-        maxLength = MaxStandardOperandLength;
+        return make_pair(MaxStandardOperandLength, 0);
     }
     else if (mode == ViewMode::Scientific)
     {
-        maxLength = MaxScientificOperandLength;
+        return make_pair(MaxScientificOperandLength, 0);
     }
     else if (mode == ViewMode::Programmer)
     {
@@ -389,15 +387,17 @@ pair<size_t, uint64_t> CopyPasteManager::GetMaxOperandLengthAndValue(ViewMode mo
 
         unsigned int signBit = (programmerNumberBase == DecBase) ? 1 : 0;
 
-        maxLength = static_cast<size_t>(ceil((bitLength - signBit) / bitsPerDigit));
-        maxValue = UINT64_MAX >> (MaxProgrammerBitLength - (bitLength - signBit));
+        const auto maxLength = static_cast<size_t>(ceil((bitLength - signBit) / bitsPerDigit));
+        const uint64_t maxValue = UINT64_MAX >> (MaxProgrammerBitLength - (bitLength - signBit));
+
+        return make_pair(maxLength, maxValue);
     }
     else if (modeType == CategoryGroupType::Converter)
     {
-        maxLength = MaxConverterInputLength;
+        return make_pair(MaxConverterInputLength, 0);
     }
 
-    return make_pair(maxLength, maxValue);
+    return make_pair(0, 0);
 }
 
 wstring CopyPasteManager::SanitizeOperand(const wstring& operand)

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -26,18 +26,18 @@ constexpr wstring_view c_validCharacterSet{ L"0123456789()+-*/.abcdefABCDEF" };
 // as both wstring_view and wchar[] can not be concatenated
 // [\s\x85] means white-space characters
 static const wstring c_wspc = L"[\\s\\x85]*";
-static const auto c_wspcLParens = c_wspc + L"[(]*" + c_wspc;
-static const auto c_wspcLParenSigned = c_wspc + L"([-+]?[(])*" + c_wspc;
-static const auto c_wspcRParens = c_wspc + L"[)]*" + c_wspc;
-static const auto c_signedDecFloat = L"[-+]?\\d*(\\d|[.])\\d*";
+static const wstring c_wspcLParens = c_wspc + L"[(]*" + c_wspc;
+static const wstring c_wspcLParenSigned = c_wspc + L"([-+]?[(])*" + c_wspc;
+static const wstring c_wspcRParens = c_wspc + L"[)]*" + c_wspc;
+static const wstring c_signedDecFloat = L"[-+]?\\d*(\\d|[.])\\d*";
 
 // Programmer Mode Integer patterns
 // Support digit separators ` (WinDbg/MASM), ' (C++), and _ (C# and other languages)
-static constexpr auto c_hexProgrammerChars = L"([a-f]|[A-F]|\\d)+((_|'|`)([a-f]|[A-F]|\\d)+)*";
-static constexpr auto c_decProgrammerChars = L"\\d+((_|'|`)\\d+)*";
-static constexpr auto c_octProgrammerChars = L"[0-7]+((_|'|`)[0-7]+)*";
-static constexpr auto c_binProgrammerChars = L"[0-1]+((_|'|`)[0-1]+)*";
-static constexpr auto c_uIntSuffixes = L"[uU]?[lL]{0,2}";
+static const wstring c_hexProgrammerChars = L"([a-f]|[A-F]|\\d)+((_|'|`)([a-f]|[A-F]|\\d)+)*";
+static const wstring c_decProgrammerChars = L"\\d+((_|'|`)\\d+)*";
+static const wstring c_octProgrammerChars = L"[0-7]+((_|'|`)[0-7]+)*";
+static const wstring c_binProgrammerChars = L"[0-1]+((_|'|`)[0-1]+)*";
+static const wstring c_uIntSuffixes = L"[uU]?[lL]{0,2}";
 
 // RegEx Patterns used by various modes
 static const array<wregex, 1> standardModePatterns =

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -451,7 +451,7 @@ bool CopyPasteManager::TryOperandToULL(const wstring& operand, int numberBase, u
     return false;
 }
 
-size_t CopyPasteManager::OperandLength(wstring operand, ViewMode mode, CategoryGroupType modeType, int programmerNumberBase)
+size_t CopyPasteManager::OperandLength(const wstring& operand, ViewMode mode, CategoryGroupType modeType, int programmerNumberBase)
 {      
     if (modeType == CategoryGroupType::Converter) {
         return operand.length();

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -266,11 +266,8 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
         return false;
     }
 
-    bool expMatched = true;
     vector<wregex> patterns{};
-
-    const auto [maxOperandLength, maxOperandValue] = GetMaxOperandLengthAndValue(mode, modeType, programmerNumberBase, bitLengthType);
-
+    
     if (mode == ViewMode::Standard)
     {
         patterns.assign(standardModePatterns.begin(), standardModePatterns.end());
@@ -287,6 +284,9 @@ bool CopyPasteManager::ExpressionRegExMatch(vector<wstring> operands, ViewMode m
     {
         patterns.assign(unitConverterPatterns.begin(), unitConverterPatterns.end());
     }
+
+    const auto [maxOperandLength, maxOperandValue] = GetMaxOperandLengthAndValue(mode, modeType, programmerNumberBase, bitLengthType);
+    bool expMatched = true;
 
     for (const auto& operand : operands)
     {
@@ -494,8 +494,7 @@ size_t CopyPasteManager::StandardScientificOperandLength(const wstring& operand)
 
 size_t CopyPasteManager::ProgrammerOperandLength(const wstring& operand, int numberBase)
 {
-    size_t len = operand.length();
-
+   
     vector<wstring> prefixes{};
     vector<wstring> suffixes{};
     switch (numberBase)
@@ -525,6 +524,8 @@ size_t CopyPasteManager::ProgrammerOperandLength(const wstring& operand, int num
 
     wstring operandUpper = operand;
     transform(operandUpper.begin(), operandUpper.end(), operandUpper.begin(), towupper);
+
+    size_t len = operand.length();
 
     // Detect if there is a suffix and subtract its length
     // Check suffixes first to allow e.g. "0b" to result in length 1 (value 0), rather than length 0 (no value).

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -453,7 +453,7 @@ bool CopyPasteManager::TryOperandToULL(const wstring& operand, int numberBase, u
 
 size_t CopyPasteManager::OperandLength(wstring operand, ViewMode mode, CategoryGroupType modeType, int programmerNumberBase)
 {      
-    if(modeType == CategoryGroupType::Converter) {
+    if (modeType == CategoryGroupType::Converter) {
         return operand.length();
     }
 
@@ -516,7 +516,7 @@ size_t CopyPasteManager::ProgrammerOperandLength(const wstring& operand, int num
         break;
     default:
         // No defined prefixes/suffixes
-        break;
+      return 0;
     }
 
     // UInt suffixes are common across all modes

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -13,7 +13,6 @@ namespace CalculatorUnitTests
 
 namespace CalculatorApp
 {
-    // TODO: Could be made into an enum : unsigned ?
     constexpr auto QwordType = 1;
     constexpr auto DwordType = 2;
     constexpr auto WordType = 3;

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -27,7 +27,7 @@ namespace CalculatorApp
     public:
         static void CopyToClipboard(Platform::String^ stringToCopy);
         static concurrency::task<Platform::String^> GetStringToPaste(CalculatorApp::Common::ViewMode mode, CalculatorApp::Common::CategoryGroupType modeType, int programmerNumberBase = -1, int bitLengthType = -1);
-        inline static bool HasStringToPaste()
+        static bool HasStringToPaste()
         {
             return ClipboardTextFormat() >= 0;
         }

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -13,14 +13,14 @@ namespace CalculatorUnitTests
 
 namespace CalculatorApp
 {
-    constexpr auto QwordType = 1;
-    constexpr auto DwordType = 2;
-    constexpr auto WordType = 3;
-    constexpr auto ByteType = 4;
-    constexpr auto HexBase = 5;
-    constexpr auto DecBase = 6;
-    constexpr auto OctBase = 7;
-    constexpr auto BinBase = 8;
+    inline constexpr auto QwordType = 1;
+    inline constexpr auto DwordType = 2;
+    inline constexpr auto WordType = 3;
+    inline constexpr auto ByteType = 4;
+    inline constexpr auto HexBase = 5;
+    inline constexpr auto DecBase = 6;
+    inline constexpr auto OctBase = 7;
+    inline constexpr auto BinBase = 8;
 
     class CopyPasteManager
     {
@@ -32,7 +32,7 @@ namespace CalculatorApp
             return ClipboardTextFormat() >= 0;
         }
 
-        static constexpr auto PasteErrorString = L"NoOp";
+        inline static constexpr auto PasteErrorString = L"NoOp";
 
     private:
         static int ClipboardTextFormat();

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -27,7 +27,7 @@ namespace CalculatorApp
     public:
         static void CopyToClipboard(Platform::String^ stringToCopy);
         static concurrency::task<Platform::String^> GetStringToPaste(CalculatorApp::Common::ViewMode mode, CalculatorApp::Common::CategoryGroupType modeType, int programmerNumberBase = -1, int bitLengthType = -1);
-        static bool HasStringToPaste()
+        inline static bool HasStringToPaste()
         {
             return ClipboardTextFormat() >= 0;
         }

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -13,15 +13,15 @@ namespace CalculatorUnitTests
 
 namespace CalculatorApp
 {
-
-#define QwordType 1
-#define DwordType 2
-#define WordType 3
-#define ByteType 4
-#define HexBase 5
-#define DecBase 6
-#define OctBase 7
-#define BinBase 8
+    // TODO: Could be made into an enum : unsigned ?
+    constexpr auto QwordType = 1;
+    constexpr auto DwordType = 2;
+    constexpr auto WordType = 3;
+    constexpr auto ByteType = 4;
+    constexpr auto HexBase = 5;
+    constexpr auto DecBase = 6;
+    constexpr auto OctBase = 7;
+    constexpr auto BinBase = 8;
 
     class CopyPasteManager
     {

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -54,7 +54,7 @@ namespace CalculatorApp
         static std::pair<size_t, uint64_t> GetMaxOperandLengthAndValue(CalculatorApp::Common::ViewMode mode, CalculatorApp::Common::CategoryGroupType modeType, int programmerNumberBase = -1, int bitLengthType = -1);
         static std::wstring SanitizeOperand(const std::wstring& operand);
         static bool TryOperandToULL(const std::wstring& operand, int numberBase, unsigned long long int& result);
-        static size_t OperandLength(std::wstring operand, CalculatorApp::Common::ViewMode mode, CalculatorApp::Common::CategoryGroupType modeType, int programmerNumberBase = -1);
+        static size_t OperandLength(const std::wstring& operand, CalculatorApp::Common::ViewMode mode, CalculatorApp::Common::CategoryGroupType modeType, int programmerNumberBase = -1);
         static size_t StandardScientificOperandLength(const std::wstring& operand);
         static size_t ProgrammerOperandLength(const std::wstring& operand, int numberBase);
         static std::wstring RemoveUnwantedCharsFromWstring(const std::wstring& input);

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -56,7 +56,7 @@ namespace CalculatorApp
         static std::wstring SanitizeOperand(const std::wstring& operand);
         static bool TryOperandToULL(const std::wstring& operand, int numberBase, unsigned long long int& result);
         static size_t OperandLength(std::wstring operand, CalculatorApp::Common::ViewMode mode, CalculatorApp::Common::CategoryGroupType modeType, int programmerNumberBase = -1);
-        static size_t StandardScientificOperandLength(std::wstring operand);
+        static size_t StandardScientificOperandLength(const std::wstring& operand);
         static size_t ProgrammerOperandLength(const std::wstring& operand, int numberBase);
         static std::wstring RemoveUnwantedCharsFromWstring(const std::wstring& input);
 

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -32,7 +32,7 @@ namespace CalculatorApp
             return ClipboardTextFormat() >= 0;
         }
 
-        inline static constexpr auto PasteErrorString = L"NoOp";
+        static constexpr auto PasteErrorString = L"NoOp";
 
     private:
         static int ClipboardTextFormat();


### PR DESCRIPTION
## Fixes #55 and #64 

### Description of the changes:
- Added `constexpr` to formerly `static const` or `#define` variables
- Applied C++ Core Guideline NR.2 
- Added `auto` and `const` in appropriate places

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Used the provided unit tests


