### PR TITLE
Test removal of intsafe.h include

### DIFF
--- a/src/CalcManager/pch.h
+++ b/src/CalcManager/pch.h
@@ -24,6 +24,5 @@
 #include <list>
 #include <regex>
 #include <unordered_map>
-#include <intsafe.h>
 #include <array>
 #include <ppltasks.h>

--- a/src/CalcManager/pch.h
+++ b/src/CalcManager/pch.h
@@ -26,3 +26,6 @@
 #include <unordered_map>
 #include <array>
 #include <ppltasks.h>
+
+#define LODWORD(qw) ((DWORD)(qw))
+#define HIDWORD(qw) ((DWORD)(((qw) >> 32) & 0xffffffff))


### PR DESCRIPTION
#212 should remove the need for this header, but I only realised it was still present when looking at #211. This PR is to test if it is still needed or can be dropped.