### PR TITLE
Perform clang-format on Azure

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -18,6 +18,10 @@ jobs:
   parameters:
     platform: x64
 
+- template: ./templates/clang-format.yaml
+  parameters:
+    platform: x64
+
 - template: ./templates/build-app-public.yaml
   parameters:
     platform: x86

--- a/build/pipelines/templates/clang-format.yaml
+++ b/build/pipelines/templates/clang-format.yaml
@@ -1,0 +1,37 @@
+# Job for running clang-format on sources.
+
+parameters:
+  platform: ''
+  condition: ''
+
+jobs:
+- job: Format${{ parameters.platform }}
+  displayName: clang-format
+  pool:
+    vmImage: 'Ubuntu-16.04'
+
+  steps:
+  - script: |
+      # Download a recent, static build of clang-format. Be quiet, but don't hide errors.
+      wget --no-verbose https://github.com/angular/clang-format/raw/master/bin/linux_x64/clang-format
+      chmod a+x clang-format
+      # Make sure it identifies itself
+      ./clang-format --version
+      # Parse full lines
+      export IFS=$'\n'
+      # For each file in repository with name ending with ".cpp" ...
+      for file in $(git ls-files | grep \\.cpp$); do
+          # ... print its name, in case clang-format throws some errors ...
+          echo Formatting "$file"
+          # ... and format it in place, so git can pick it up.
+          ./clang-format -style=file -i "$file"
+      done
+      # Just some visual separation
+      echo -e "\\n\\n\\n\\tChecking diff...\\n\\n\\n"
+      # Set error mode. Makes bash bail on first non-zero exit code
+      set -e
+      # Print diff, if any and report with exit code.
+      git diff --exit-code
+      # When no diff present, provide status.
+      echo -e "\\tStyle is fine"
+    displayName: 'clang-format'


### PR DESCRIPTION
## Fixes (part of) #202.

#236 discusses the contents of `.clang-format`, this PR makes CI capable of enforcing it.

A problem I ran into was `clang-format` mistaking some of the sources for Objective-C, due to non-C++ constructs like https://github.com/Microsoft/calculator/blob/f6a6aae6e6ce1c485b4b4b02413259649cf2b58f/src/Calculator/Converters/BitFlipAutomationNameConverter.h#L13
I have no idea what that is, so I took the easy way out and only apply formatting files which name ends with `.cpp`.

I provided comments in the script itself, but the gist of it is:
* Using Hosted Ubuntu 16.04
* Downloads static build of `clang-format` from https://github.com/angular/clang-format/blob/master/bin/linux_x64/clang-format, a long standing repo with occasional updates to the tool
* Performs `clang-format` on the sources (files ending with `.cpp`)
* Reports the diff, if any, and
  - Fails the build, if diff present
  - Reports success otherwise.

You can see a failing build here: https://dev.azure.com/ms/calculator/_build/results?buildId=8367

And a passing one (with sources formatted) here: https://dev.azure.com/ms/calculator/_build/results?buildId=8372, as per #406 

This PR does not include `.clang-format`, I hope @seyfer will update https://github.com/Microsoft/calculator/pull/236 and it will get merged.