### PR TITLE
Modify how modulo is calculated in Normal and Scientific mode.

### DIFF
--- a/src/CalcManager/CEngine/Rational.cpp
+++ b/src/CalcManager/CEngine/Rational.cpp
@@ -189,7 +189,7 @@ namespace CalcEngine
 
         try
         {
-            modrat(&lhsRat, rhsRat);
+            remrat(&lhsRat, rhsRat);
             destroyrat(rhsRat);
         }
         catch (uint32_t error)

--- a/src/CalcManager/CEngine/Rational.cpp
+++ b/src/CalcManager/CEngine/Rational.cpp
@@ -186,7 +186,8 @@ namespace CalcEngine
     /// Calculate the remainder after division, the sign of a result will match the sign of the current object.
     /// </summary>
     /// <remarks>
-    /// This function has the same behavior as the standard C/C++ operator '%', to calculate the modulus after division instead, use <see cref="Rational::operator%"/> instead.
+    /// This function has the same behavior as the standard C/C++ operator '%'
+    /// to calculate the modulus after division instead, use <see cref="RationalMath::Mod"/> instead.
     /// </remarks>
     Rational& Rational::operator%=(Rational const& rhs)
     {

--- a/src/CalcManager/CEngine/Rational.cpp
+++ b/src/CalcManager/CEngine/Rational.cpp
@@ -183,10 +183,10 @@ namespace CalcEngine
     }
 
     /// <summary>
-    /// Calculate the remainder after division, the sign of the result will match the sign of the current object.
+    /// Calculate the remainder after division, the sign of a result will match the sign of the current object.
     /// </summary>
     /// <remarks>
-    /// This function has the same behavior than the standard C/C++ operator '%', to calculate the modulus after division instead, use <see cref="Rational::operator%"/> instead.
+    /// This function has the same behavior as the standard C/C++ operator '%', to calculate the modulus after division instead, use <see cref="Rational::operator%"/> instead.
     /// </remarks>
     Rational& Rational::operator%=(Rational const& rhs)
     {
@@ -349,10 +349,10 @@ namespace CalcEngine
     }
 
     /// <summary>
-    /// Calculate the remainder after division, the sign of the result will match the sign of a.
+    /// Calculate the remainder after division, the sign of a result will match the sign of lhs.
     /// </summary>
     /// <remarks>
-    /// This function has the same behavior than the standard C/C++ operator '%', to calculate the modulus after division instead, use <see cref="Rational::operator%"/> instead.
+    /// This function has the same behavior as the standard C/C++ operator '%', to calculate the modulus after division instead, use <see cref="Rational::operator%"/> instead.
     /// </remarks>
     Rational operator%(Rational lhs, Rational const& rhs)
     {

--- a/src/CalcManager/CEngine/Rational.cpp
+++ b/src/CalcManager/CEngine/Rational.cpp
@@ -182,6 +182,12 @@ namespace CalcEngine
         return *this;
     }
 
+    /// <summary>
+    /// Calculate the remainder after division, the sign of the result will match the sign of the current object.
+    /// </summary>
+    /// <remarks>
+    /// This function has the same behavior than the standard C/C++ operator '%', to calculate the modulus after division instead, use <see cref="Rational::operator%"/> instead.
+    /// </remarks>
     Rational& Rational::operator%=(Rational const& rhs)
     {
         PRAT lhsRat = this->ToPRAT();
@@ -342,6 +348,12 @@ namespace CalcEngine
         return lhs;
     }
 
+    /// <summary>
+    /// Calculate the remainder after division, the sign of the result will match the sign of a.
+    /// </summary>
+    /// <remarks>
+    /// This function has the same behavior than the standard C/C++ operator '%', to calculate the modulus after division instead, use <see cref="Rational::operator%"/> instead.
+    /// </remarks>
     Rational operator%(Rational lhs, Rational const& rhs)
     {
         lhs %= rhs;

--- a/src/CalcManager/CEngine/RationalMath.cpp
+++ b/src/CalcManager/CEngine/RationalMath.cpp
@@ -387,3 +387,26 @@ Rational RationalMath::ATanh(Rational const& rat)
 
     return result;
 }
+
+
+Rational RationalMath::Mod(Rational const& base, Rational const& n)
+{
+    PRAT prat = base.ToPRAT();
+    PRAT pn = n.ToPRAT();
+
+    try
+    {
+        modrat(&prat, pn);
+        destroyrat(pn);
+    }
+    catch (uint32_t error)
+    {
+        destroyrat(prat);
+        destroyrat(pn);
+        throw(error);
+    }
+
+    auto res = Rational{ prat };
+    destroyrat(prat);
+    return res;
+}

--- a/src/CalcManager/CEngine/RationalMath.cpp
+++ b/src/CalcManager/CEngine/RationalMath.cpp
@@ -388,11 +388,16 @@ Rational RationalMath::ATanh(Rational const& rat)
     return result;
 }
 
-
-Rational RationalMath::Mod(Rational const& base, Rational const& n)
+/// <summary>
+/// Calculate the modulus after division, the sign of the result will match the sign of b.
+/// </summary>
+/// <remarks>
+/// When one of the operand is negative, the result will differ from the C/C++ operator '%', use <see cref="Rational::operator%"/> instead to calculate the remainder after division.
+/// </remarks>
+Rational RationalMath::Mod(Rational const& a, Rational const& b)
 {
-    PRAT prat = base.ToPRAT();
-    PRAT pn = n.ToPRAT();
+    PRAT prat = a.ToPRAT();
+    PRAT pn = b.ToPRAT();
 
     try
     {

--- a/src/CalcManager/CEngine/RationalMath.cpp
+++ b/src/CalcManager/CEngine/RationalMath.cpp
@@ -392,7 +392,9 @@ Rational RationalMath::ATanh(Rational const& rat)
 /// Calculate the modulus after division, the sign of the result will match the sign of b.
 /// </summary>
 /// <remarks>
-/// When one of the operand is negative, the result will differ from the C/C++ operator '%', use <see cref="Rational::operator%"/> instead to calculate the remainder after division.
+/// When one of the operand is negative
+/// the result will differ from the C/C++ operator '%'
+/// use <see cref="Rational::operator%"/> instead to calculate the remainder after division.
 /// </remarks>
 Rational RationalMath::Mod(Rational const& a, Rational const& b)
 {

--- a/src/CalcManager/CEngine/scioper.cpp
+++ b/src/CalcManager/CEngine/scioper.cpp
@@ -112,8 +112,17 @@ CalcEngine::Rational CCalcEngine::DoOperation(int operation, CalcEngine::Rationa
             }
             else
             {
-                iFinalSign = iNumeratorSign;
-                result %= temp;
+                if (m_fIntegerMode)
+                {
+                    // Programmer mode
+                    iFinalSign = iNumeratorSign;
+                    result %= temp;
+                }
+                else
+                {
+                    iFinalSign = iDenominatorSign;
+                    result = Mod(result, temp);
+                }
             }
 
             if (m_fIntegerMode && iFinalSign == -1)

--- a/src/CalcManager/CEngine/scioper.cpp
+++ b/src/CalcManager/CEngine/scioper.cpp
@@ -114,12 +114,13 @@ CalcEngine::Rational CCalcEngine::DoOperation(int operation, CalcEngine::Rationa
             {
                 if (m_fIntegerMode)
                 {
-                    // Programmer mode
+                    // Programmer mode, use remrat (remainder after division)
                     iFinalSign = iNumeratorSign;
                     result %= temp;
                 }
                 else
                 {
+                    //other modes, use modrat (modulus after division)
                     iFinalSign = iDenominatorSign;
                     result = Mod(result, temp);
                 }

--- a/src/CalcManager/CEngine/scioper.cpp
+++ b/src/CalcManager/CEngine/scioper.cpp
@@ -78,7 +78,7 @@ CalcEngine::Rational CCalcEngine::DoOperation(int operation, CalcEngine::Rationa
         case IDC_DIV:
         case IDC_MOD:
         {
-            int iNumeratorSign = 1, iDenominatorSign = 1, iFinalSign = 1;
+            int iNumeratorSign = 1, iDenominatorSign = 1;
             auto temp = result;
             result = rhs;
 
@@ -107,30 +107,30 @@ CalcEngine::Rational CCalcEngine::DoOperation(int operation, CalcEngine::Rationa
 
             if (operation == IDC_DIV)
             {
-                iFinalSign = iNumeratorSign * iDenominatorSign;
                 result /= temp;
+                if (m_fIntegerMode && (iNumeratorSign * iDenominatorSign) == -1)
+                {
+                    result = -(Integer(result));
+                }
             }
             else
             {
                 if (m_fIntegerMode)
                 {
                     // Programmer mode, use remrat (remainder after division)
-                    iFinalSign = iNumeratorSign;
                     result %= temp;
+
+                    if (iNumeratorSign == -1)
+                    {
+                        result = -(Integer(result));
+                    }
                 }
                 else
                 {
                     //other modes, use modrat (modulus after division)
-                    iFinalSign = iDenominatorSign;
                     result = Mod(result, temp);
                 }
             }
-
-            if (m_fIntegerMode && iFinalSign == -1)
-            {
-                result = -(Integer(result));
-            }
-
             break;
         }
 

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -45,7 +45,7 @@ namespace CalculationManager
     class IResourceProvider;
 }
 
-namespace CalculatorUnitTests
+namespace CalculatorEngineTests
 {
     class CalcEngineTests;
 }
@@ -159,5 +159,5 @@ private:
     static void ChangeBaseConstants(uint32_t radix, int maxIntDigits, int32_t precision);
     void BaseOrPrecisionChanged();
 
-    friend class CalculatorUnitTests::CalcEngineTests;
+    friend class CalculatorEngineTests::CalcEngineTests;
 };

--- a/src/CalcManager/Header Files/RationalMath.h
+++ b/src/CalcManager/Header Files/RationalMath.h
@@ -13,6 +13,7 @@ namespace CalcEngine::RationalMath
     Rational Pow(Rational const& base, Rational const& pow);
     Rational Root(Rational const& base, Rational const& root);
     Rational Fact(Rational const& rat);
+    Rational Mod(Rational const& base, Rational const& n);
 
     Rational Exp(Rational const& rat);
     Rational Log(Rational const& rat);

--- a/src/CalcManager/Header Files/RationalMath.h
+++ b/src/CalcManager/Header Files/RationalMath.h
@@ -13,7 +13,7 @@ namespace CalcEngine::RationalMath
     Rational Pow(Rational const& base, Rational const& pow);
     Rational Root(Rational const& base, Rational const& root);
     Rational Fact(Rational const& rat);
-    Rational Mod(Rational const& base, Rational const& n);
+    Rational Mod(Rational const& a, Rational const& b);
 
     Rational Exp(Rational const& rat);
     Rational Log(Rational const& rat);

--- a/src/CalcManager/Ratpack/exp.cpp
+++ b/src/CalcManager/Ratpack/exp.cpp
@@ -408,7 +408,7 @@ void powratNumeratorDenominator(PRAT *px, PRAT y, uint32_t radix, int32_t precis
 //---------------------------------------------------------------------------
 void powratcomp(PRAT *px, PRAT y, uint32_t radix, int32_t precision)
 {
-    int32_t sign = ((*px)->pp->sign * (*px)->pq->sign);
+    int32_t sign = SIGN(*px);
 
     // Take the absolute value
     (*px)->pp->sign = 1;

--- a/src/CalcManager/Ratpack/fact.cpp
+++ b/src/CalcManager/Ratpack/fact.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //-----------------------------------------------------------------------------
@@ -216,7 +216,7 @@ void factrat( PRAT *px, uint32_t radix, int32_t precision)
 
     // Check for negative integers and throw an error.
     if ( ( zerrat(frac) || ( LOGRATRADIX(frac) <= -precision) ) &&
-        ( (*px)->pp->sign * (*px)->pq->sign == -1 ) )
+        ( SIGN(*px) == -1 ) )
         {
         throw CALC_E_DOMAIN;
         }

--- a/src/CalcManager/Ratpack/itrans.cpp
+++ b/src/CalcManager/Ratpack/itrans.cpp
@@ -92,11 +92,9 @@ void asinanglerat( _Inout_ PRAT *pa, ANGLE_TYPE angletype, uint32_t radix, int32
 void asinrat( PRAT *px, uint32_t radix, int32_t precision)
 
 {
-    int32_t sgn;
     PRAT pret= nullptr;
     PRAT phack= nullptr;
-
-    sgn = SIGN(*px);
+    int32_t sgn = SIGN(*px);
 
     (*px)->pp->sign = 1;
     (*px)->pq->sign = 1;
@@ -204,9 +202,7 @@ void _acosrat( PRAT *px, int32_t precision)
 void acosrat( PRAT *px, uint32_t radix, int32_t precision)
 
 {
-    int32_t sgn;
-
-    sgn = SIGN(*px);
+    int32_t sgn = SIGN(*px);
 
     (*px)->pp->sign = 1;
     (*px)->pq->sign = 1;
@@ -291,10 +287,8 @@ void _atanrat( PRAT *px, int32_t precision)
 void atanrat( PRAT *px, uint32_t radix, int32_t precision)
 
 {
-    int32_t sgn;
     PRAT tmpx= nullptr;
-
-    sgn = SIGN(*px);
+    int32_t sgn = SIGN(*px);
 
     (*px)->pp->sign = 1;
     (*px)->pq->sign = 1;

--- a/src/CalcManager/Ratpack/itrans.cpp
+++ b/src/CalcManager/Ratpack/itrans.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //-----------------------------------------------------------------------------
@@ -96,7 +96,7 @@ void asinrat( PRAT *px, uint32_t radix, int32_t precision)
     PRAT pret= nullptr;
     PRAT phack= nullptr;
 
-    sgn = (*px)->pp->sign* (*px)->pq->sign;
+    sgn = SIGN(*px);
 
     (*px)->pp->sign = 1;
     (*px)->pq->sign = 1;
@@ -206,7 +206,7 @@ void acosrat( PRAT *px, uint32_t radix, int32_t precision)
 {
     int32_t sgn;
 
-    sgn = (*px)->pp->sign*(*px)->pq->sign;
+    sgn = SIGN(*px);
 
     (*px)->pp->sign = 1;
     (*px)->pq->sign = 1;
@@ -294,7 +294,7 @@ void atanrat( PRAT *px, uint32_t radix, int32_t precision)
     int32_t sgn;
     PRAT tmpx= nullptr;
 
-    sgn = (*px)->pp->sign * (*px)->pq->sign;
+    sgn = SIGN(*px);
 
     (*px)->pp->sign = 1;
     (*px)->pq->sign = 1;

--- a/src/CalcManager/Ratpack/logic.cpp
+++ b/src/CalcManager/Ratpack/logic.cpp
@@ -18,54 +18,54 @@
 
 using namespace std;
 
-void lshrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void lshrat(PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
 
 {
-    PRAT pwr= nullptr;
+    PRAT pwr = nullptr;
     int32_t intb;
 
     intrat(pa, radix, precision);
-    if ( !zernum( (*pa)->pp ) )
-        {
+    if (!zernum((*pa)->pp))
+    {
         // If input is zero we're done.
-        if ( rat_gt( b, rat_max_exp, precision) )
-            {
+        if (rat_gt(b, rat_max_exp, precision))
+        {
             // Don't attempt lsh of anything big
-            throw( CALC_E_DOMAIN );
-            }
+            throw(CALC_E_DOMAIN);
+        }
         intb = rattoi32(b, radix, precision);
-        DUPRAT(pwr,rat_two);
+        DUPRAT(pwr, rat_two);
         ratpowi32(&pwr, intb, precision);
         mulrat(pa, pwr, precision);
         destroyrat(pwr);
-        }
+    }
 }
 
-void rshrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void rshrat(PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
 
 {
-    PRAT pwr= nullptr;
+    PRAT pwr = nullptr;
     int32_t intb;
 
     intrat(pa, radix, precision);
-    if ( !zernum( (*pa)->pp ) )
-        {
+    if (!zernum((*pa)->pp))
+    {
         // If input is zero we're done.
-        if ( rat_lt( b, rat_min_exp, precision) )
-            {
+        if (rat_lt(b, rat_min_exp, precision))
+        {
             // Don't attempt rsh of anything big and negative.
-            throw( CALC_E_DOMAIN );
-            }
+            throw(CALC_E_DOMAIN);
+        }
         intb = rattoi32(b, radix, precision);
-        DUPRAT(pwr,rat_two);
+        DUPRAT(pwr, rat_two);
         ratpowi32(&pwr, intb, precision);
         divrat(pa, pwr, precision);
         destroyrat(pwr);
-       }
+    }
 }
 
-void boolrat( PRAT *pa, PRAT b, int func, uint32_t radix, int32_t precision);
-void boolnum( PNUMBER *pa, PNUMBER b, int func );
+void boolrat(PRAT *pa, PRAT b, int func, uint32_t radix, int32_t precision);
+void boolnum(PNUMBER *pa, PNUMBER b, int func);
 
 
 enum {
@@ -74,22 +74,22 @@ enum {
     FUNC_XOR
 } BOOL_FUNCS;
 
-void andrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void andrat(PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
 
 {
-    boolrat( pa, b, FUNC_AND, radix, precision);
+    boolrat(pa, b, FUNC_AND, radix, precision);
 }
 
-void orrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void orrat(PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
 
 {
-    boolrat( pa, b, FUNC_OR, radix, precision);
+    boolrat(pa, b, FUNC_OR, radix, precision);
 }
 
-void xorrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
+void xorrat(PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
 
 {
-    boolrat( pa, b, FUNC_XOR, radix, precision);
+    boolrat(pa, b, FUNC_XOR, radix, precision);
 }
 
 //---------------------------------------------------------------------------
@@ -104,15 +104,15 @@ void xorrat( PRAT *pa, PRAT b, uint32_t radix, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-void boolrat( PRAT *pa, PRAT b, int func, uint32_t radix, int32_t precision)
+void boolrat(PRAT *pa, PRAT b, int func, uint32_t radix, int32_t precision)
 
 {
-    PRAT tmp= nullptr;
-    intrat( pa, radix, precision);
-    DUPRAT(tmp,b);
-    intrat( &tmp, radix, precision);
+    PRAT tmp = nullptr;
+    intrat(pa, radix, precision);
+    DUPRAT(tmp, b);
+    intrat(&tmp, radix, precision);
 
-    boolnum( &((*pa)->pp), tmp->pp, func );
+    boolnum(&((*pa)->pp), tmp->pp, func);
     destroyrat(tmp);
 }
 
@@ -130,11 +130,11 @@ void boolrat( PRAT *pa, PRAT b, int func, uint32_t radix, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-void boolnum( PNUMBER *pa, PNUMBER b, int func )
+void boolnum(PNUMBER *pa, PNUMBER b, int func)
 
 {
-    PNUMBER c= nullptr;
-    PNUMBER a= nullptr;
+    PNUMBER c = nullptr;
+    PNUMBER a = nullptr;
     MANTTYPE *pcha;
     MANTTYPE *pchb;
     MANTTYPE *pchc;
@@ -143,26 +143,26 @@ void boolnum( PNUMBER *pa, PNUMBER b, int func )
     MANTTYPE da;
     MANTTYPE db;
 
-    a=*pa;
-    cdigits = max( a->cdigit+a->exp, b->cdigit+b->exp ) -
-            min( a->exp, b->exp );
-    createnum( c, cdigits );
-    c->exp = min( a->exp, b->exp );
+    a = *pa;
+    cdigits = max(a->cdigit + a->exp, b->cdigit + b->exp) -
+        min(a->exp, b->exp);
+    createnum(c, cdigits);
+    c->exp = min(a->exp, b->exp);
     mexp = c->exp;
     c->cdigit = cdigits;
     pcha = a->mant;
     pchb = b->mant;
     pchc = c->mant;
-    for ( ;cdigits > 0; cdigits--, mexp++ )
+    for (; cdigits > 0; cdigits--, mexp++)
+    {
+        da = (((mexp >= a->exp) && (cdigits + a->exp - c->exp >
+            (c->cdigit - a->cdigit))) ?
+            *pcha++ : 0);
+        db = (((mexp >= b->exp) && (cdigits + b->exp - c->exp >
+            (c->cdigit - b->cdigit))) ?
+            *pchb++ : 0);
+        switch (func)
         {
-        da = ( ( ( mexp >= a->exp ) && ( cdigits + a->exp - c->exp >
-                    (c->cdigit - a->cdigit) ) ) ?
-                    *pcha++ : 0 );
-        db = ( ( ( mexp >= b->exp ) && ( cdigits + b->exp - c->exp >
-                    (c->cdigit - b->cdigit) ) ) ?
-                    *pchb++ : 0 );
-        switch ( func )
-            {
         case FUNC_AND:
             *pchc++ = da & db;
             break;
@@ -172,15 +172,15 @@ void boolnum( PNUMBER *pa, PNUMBER b, int func )
         case FUNC_XOR:
             *pchc++ = da ^ db;
             break;
-            }
         }
+    }
     c->sign = a->sign;
-    while ( c->cdigit > 1 && *(--pchc) == 0 )
-        {
+    while (c->cdigit > 1 && *(--pchc) == 0)
+    {
         c->cdigit--;
-        }
-    destroynum( *pa );
-    *pa=c;
+    }
+    destroynum(*pa);
+    *pa = c;
 }
 
 //-----------------------------------------------------------------------------
@@ -191,8 +191,9 @@ void boolnum( PNUMBER *pa, PNUMBER b, int func )
 //
 //    RETURN: None, changes pointer.
 //
-//    DESCRIPTION: Calculate the remainder of *pa / b, equivalent of 'pa % b' in C;
-//    NOTE: produces a result that is either zero or has the same sign as the dividend.
+//    DESCRIPTION: Calculate the remainder of *pa / b,
+//                 equivalent of 'pa % b' in C/C++ and produces a result
+//                 that is either zero or has the same sign as the dividend.
 //
 //-----------------------------------------------------------------------------
 
@@ -226,8 +227,10 @@ void remrat(PRAT *pa, PRAT b)
 //
 //    RETURN: None, changes pointer.
 //
-//    DESCRIPTION: Calculate the remainder of *pa / b, equivalent of 'pa modulo b' in arithmetic
-//    NOTE: produces a result that is either zero or has the same sign as the divisor.
+//    DESCRIPTION: Calculate the remainder of *pa / b, with the sign of the result
+//                 either zero or has the same sign as the divisor. 
+//    NOTE: When *pa or b are negative, the result won't be the same as
+//          the C/C++ operator %, use remrat if it's the behavior you expect. 
 //
 //-----------------------------------------------------------------------------
 
@@ -249,7 +252,7 @@ void modrat(PRAT *pa, PRAT b)
     remnum(&((*pa)->pp), tmp->pp, BASEX);
     mulnumx(&((*pa)->pq), tmp->pq);
 
-    if (needAdjust)
+    if (needAdjust && !zerrat(*pa))
     {
         addrat(pa, b, BASEX);
     }

--- a/src/CalcManager/Ratpack/logic.cpp
+++ b/src/CalcManager/Ratpack/logic.cpp
@@ -185,34 +185,77 @@ void boolnum( PNUMBER *pa, PNUMBER b, int func )
 
 //-----------------------------------------------------------------------------
 //
+//    FUNCTION: remrat
+//
+//    ARGUMENTS: pointer to a rational a second rational.
+//
+//    RETURN: None, changes pointer.
+//
+//    DESCRIPTION: Calculate the remainder of *pa / b, equivalent of 'pa % b' in C;
+//    NOTE: produces a result that is either zero or has the same sign as the dividend.
+//
+//-----------------------------------------------------------------------------
+
+void remrat(PRAT *pa, PRAT b)
+
+{
+    if (zerrat(b))
+    {
+        throw CALC_E_INDEFINITE;
+    }
+
+    PRAT tmp = nullptr;
+    DUPRAT(tmp, b);
+
+    mulnumx(&((*pa)->pp), tmp->pq);
+    mulnumx(&(tmp->pp), (*pa)->pq);
+    remnum(&((*pa)->pp), tmp->pp, BASEX);
+    mulnumx(&((*pa)->pq), tmp->pq);
+
+    // Get *pa back in the integer over integer form.
+    RENORMALIZE(*pa);
+
+    destroyrat(tmp);
+}
+
+//-----------------------------------------------------------------------------
+//
 //    FUNCTION: modrat
 //
 //    ARGUMENTS: pointer to a rational a second rational.
 //
 //    RETURN: None, changes pointer.
 //
-//    DESCRIPTION: Does the rational equivalent of frac(*pa);
+//    DESCRIPTION: Calculate the remainder of *pa / b, equivalent of 'pa modulo b' in arithmetic
+//    NOTE: produces a result that is either zero or has the same sign as the divisor.
 //
 //-----------------------------------------------------------------------------
 
-void modrat( PRAT *pa, PRAT b )
-
+void modrat(PRAT *pa, PRAT b)
 {
+    //contrary to remrat, modrat(a, 0) must return a
+    if (zerrat(b))
+    {
+        return;
+    }
+
     PRAT tmp = nullptr;
+    DUPRAT(tmp, b);
 
-    if ( zerrat( b ) )
-        {
-        throw CALC_E_INDEFINITE;
-        }
-    DUPRAT(tmp,b);
+    auto needAdjust = (SIGN(*pa) == -1 ? (SIGN(b) == 1) : (SIGN(b) == -1));
 
-    mulnumx( &((*pa)->pp), tmp->pq );
-    mulnumx( &(tmp->pp), (*pa)->pq );
-    remnum( &((*pa)->pp), tmp->pp, BASEX );
-    mulnumx( &((*pa)->pq), tmp->pq );
+    mulnumx(&((*pa)->pp), tmp->pq);
+    mulnumx(&(tmp->pp), (*pa)->pq);
+    remnum(&((*pa)->pp), tmp->pp, BASEX);
+    mulnumx(&((*pa)->pq), tmp->pq);
+
+    if (needAdjust)
+    {
+        addrat(pa, b, BASEX);
+    }
 
     // Get *pa back in the integer over integer form.
     RENORMALIZE(*pa);
 
-    destroyrat( tmp );
+    destroyrat(tmp);
 }

--- a/src/CalcManager/Ratpack/logic.cpp
+++ b/src/CalcManager/Ratpack/logic.cpp
@@ -236,7 +236,7 @@ void remrat(PRAT *pa, PRAT b)
 
 void modrat(PRAT *pa, PRAT b)
 {
-    //contrary to remrat, modrat(a, 0) must return a
+    //contrary to remrat(X, 0) returning 0, modrat(X, 0) must return X
     if (zerrat(b))
     {
         return;

--- a/src/CalcManager/Ratpack/ratpak.h
+++ b/src/CalcManager/Ratpack/ratpak.h
@@ -148,6 +148,9 @@ extern PRAT rat_min_i32;
 #define LOGNUM2(pnum) ((pnum)->cdigit+(pnum)->exp)
 #define LOGRAT2(prat) (LOGNUM2((prat)->pp)-LOGNUM2((prat)->pq))
 
+// SIGN returns the sign of the rational
+#define SIGN(prat) ((prat)->pp->sign*(prat)->pq->sign)
+
 #if defined( DEBUG_RATPAK )
 //-----------------------------------------------------------------------------
 //
@@ -423,7 +426,8 @@ extern void divnumx( _Inout_ PNUMBER *pa, _In_ PNUMBER b, int32_t precision);
 extern void divrat( _Inout_ PRAT *pa, _In_ PRAT b, int32_t precision);
 extern void fracrat( _Inout_ PRAT *pa , uint32_t radix, int32_t precision);
 extern void factrat( _Inout_ PRAT *pa, uint32_t radix, int32_t precision);
-extern void modrat( _Inout_ PRAT *pa, _In_ PRAT b );
+extern void remrat(_Inout_ PRAT *pa, _In_ PRAT b);
+extern void modrat(_Inout_ PRAT *pa, _In_ PRAT b);
 extern void gcdrat( _Inout_ PRAT *pa, int32_t precision);
 extern void intrat( _Inout_ PRAT *px, uint32_t radix, int32_t precision);
 extern void mulnum( _Inout_ PNUMBER *pa, _In_ PNUMBER b, uint32_t radix);

--- a/src/CalcManager/Ratpack/support.cpp
+++ b/src/CalcManager/Ratpack/support.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //----------------------------------------------------------------------------
@@ -296,7 +296,7 @@ void intrat( PRAT *px, uint32_t radix, int32_t precision)
         // Subtract the fractional part of the rational
         PRAT pret = nullptr;
         DUPRAT(pret,*px);
-        modrat( &pret, rat_one );
+        remrat( &pret, rat_one );
 
         subrat( px, pret, precision);
         destroyrat( pret );
@@ -348,8 +348,7 @@ bool rat_ge( PRAT a, PRAT b, int32_t precision)
     b->pp->sign *= -1;
     addrat( &rattmp, b, precision);
     b->pp->sign *= -1;
-    bool bret = ( zernum( rattmp->pp ) ||
-        rattmp->pp->sign * rattmp->pq->sign == 1 );
+    bool bret = ( zernum( rattmp->pp ) || SIGN(rattmp) == 1 );
     destroyrat( rattmp );
     return( bret );
 }
@@ -374,8 +373,7 @@ bool rat_gt( PRAT a, PRAT b, int32_t precision)
     b->pp->sign *= -1;
     addrat( &rattmp, b, precision);
     b->pp->sign *= -1;
-    bool bret = ( !zernum( rattmp->pp ) &&
-        rattmp->pp->sign * rattmp->pq->sign == 1 );
+    bool bret = ( !zernum( rattmp->pp ) && SIGN(rattmp) == 1 );
     destroyrat( rattmp );
     return( bret );
 }
@@ -400,8 +398,7 @@ bool rat_le( PRAT a, PRAT b, int32_t precision)
     b->pp->sign *= -1;
     addrat( &rattmp, b, precision);
     b->pp->sign *= -1;
-    bool bret = ( zernum( rattmp->pp ) ||
-        rattmp->pp->sign * rattmp->pq->sign == -1 );
+    bool bret = ( zernum( rattmp->pp ) || SIGN(rattmp) == -1 );
     destroyrat( rattmp );
     return( bret );
 }
@@ -426,8 +423,7 @@ bool rat_lt( PRAT a, PRAT b, int32_t precision)
     b->pp->sign *= -1;
     addrat( &rattmp, b, precision);
     b->pp->sign *= -1;
-    bool bret = ( !zernum( rattmp->pp ) &&
-        rattmp->pp->sign * rattmp->pq->sign == -1 );
+    bool bret = ( !zernum( rattmp->pp ) && SIGN(rattmp) == -1 );
     destroyrat( rattmp );
     return( bret );
 }

--- a/src/CalculatorUnitTests/CalcEngineTests.cpp
+++ b/src/CalculatorUnitTests/CalcEngineTests.cpp
@@ -13,7 +13,7 @@ using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
 static constexpr size_t MAX_HISTORY_SIZE = 20;
 
-namespace CalculatorUnitTests
+namespace CalculatorEngineTests
 {
     TEST_CLASS(CalcEngineTests)
     {

--- a/src/CalculatorUnitTests/CalcInputTest.cpp
+++ b/src/CalculatorUnitTests/CalcInputTest.cpp
@@ -8,7 +8,7 @@ using namespace std;
 using namespace CalculationManager;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
-namespace CalculatorUnitTests
+namespace CalculatorEngineTests
 {
     TEST_CLASS(CalcInputTest)
     {

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -248,6 +248,7 @@
     <ClCompile Include="Module.cpp" />
     <ClCompile Include="MultiWindowUnitTests.cpp" />
     <ClCompile Include="NavCategoryUnitTests.cpp" />
+    <ClCompile Include="RationalTest.cpp" />
     <ClCompile Include="StandardViewModelUnitTests.cpp" />
     <ClCompile Include="UnitConverterTest.cpp" />
     <ClCompile Include="UnitConverterViewModelUnitTests.cpp" />

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
@@ -29,6 +29,7 @@
     <ClCompile Include="Mocks\CurrencyHttpClient.cpp">
       <Filter>Mocks</Filter>
     </ClCompile>
+    <ClCompile Include="RationalTest.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="AsyncHelper.h" />

--- a/src/CalculatorUnitTests/RationalTest.cpp
+++ b/src/CalculatorUnitTests/RationalTest.cpp
@@ -104,7 +104,7 @@ namespace CalculatorEngineTests
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-0.32");
         }
 
-        TEST_METHOD(TestRemainerOperandsNotModified)
+        TEST_METHOD(TestRemainderOperandsNotModified)
         {
             //Verify results but also check that operands are not modified
             Rational rat25(25);
@@ -129,7 +129,7 @@ namespace CalculatorEngineTests
             VERIFY_ARE_EQUAL(rat4, 4);
         }
 
-        TEST_METHOD(TestRemainerInteger)
+        TEST_METHOD(TestRemainderInteger)
         {
             // Check with integers
             auto res = Rational(426) % Rational(56478);
@@ -148,7 +148,7 @@ namespace CalculatorEngineTests
             VERIFY_ARE_EQUAL(res, 0);
         }
 
-        TEST_METHOD(TestRemainerZero)
+        TEST_METHOD(TestRemainderZero)
         {
             // Test with Zero
             auto res = Rational(0) % Rational(3654);
@@ -193,7 +193,7 @@ namespace CalculatorEngineTests
             }
         }
 
-        TEST_METHOD(TestRemainerRational)
+        TEST_METHOD(TestRemainderRational)
         {
             //Test with rational numbers
             auto res = Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })) % Rational(89);
@@ -211,7 +211,6 @@ namespace CalculatorEngineTests
             res = Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(1);
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.33333333");
             res = Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(-10);
-            auto sdsdas = res.ToString(10, FMT_FLOAT, 8);
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"3.3333333");
             res = Rational(Number(-1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(-10);
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-3.3333333");

--- a/src/CalculatorUnitTests/RationalTest.cpp
+++ b/src/CalculatorUnitTests/RationalTest.cpp
@@ -10,7 +10,7 @@ using namespace CalcEngine;
 using namespace CalcEngine::RationalMath;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
-namespace CalculatorManagerTest
+namespace CalculatorEngineTests
 {
     TEST_CLASS(RationalTest)
     {
@@ -44,10 +44,44 @@ namespace CalculatorManagerTest
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-8113");
             res = Mod(Rational(-643), Rational(-8756));
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
-
+            res = Mod(Rational(1000), Rational(250));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+            res = Mod(Rational(1000), Rational(-250));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
             //Test with Zero
             res = Mod(Rational(343654332), Rational(0));
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"343654332");
+            res = Mod(Rational(0), Rational(8756));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+            res = Mod(Rational(0), Rational(-242));
+            auto dfd = res.ToString(10, FMT_FLOAT, 128);
+            VERIFY_ARE_EQUAL(dfd, L"0");
+            res = Mod(Rational(0), Rational(0));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+            res = Mod(Rational(Number(1, 0, { 23242 }), Number(1, 0, { 2 })), Rational(Number(1, 0, { 0 }), Number(1, 0, { 23 })));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"11621");
+
+            //Test with rational numbers
+            res = Mod(Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })), Rational(89));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            res = Mod(Rational(Number(1, 0, { 3330 }), Number(1, 0, { 1332 })), Rational(1));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0.5");
+            res = Mod(Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(10));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            res = Mod(Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(10));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"7.5");
+            res = Mod(Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(-10));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-2.5");
+            res = Mod(Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(-10));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-7.5");
+            res = Mod(Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })), Rational(1));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.33333333");
+            res = Mod(Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })), Rational(-10));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-6.6666667");
+            res = Mod(Rational(834345), Rational(Number(1, 0, { 103 }), Number(1, 0, { 100 })));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.71");
+            res = Mod(Rational(834345), Rational(Number(-1, 0, { 103 }), Number(1, 0, { 100 })));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-0.32");
         }
 
         TEST_METHOD(RemainderTest)
@@ -76,23 +110,80 @@ namespace CalculatorManagerTest
             res = Rational(-643) % Rational(-8756);
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
 
+            res = Rational(-124) % Rational(-124);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+            res = Rational(24) % Rational(24);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+
             //Test with Zero
-            try
+            res = Rational(0) % Rational(3654);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+
+            res = Rational(0) % Rational(-242);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+            for (auto number : { 343654332, 0, -23423 })
             {
-                res = Rational(343654332) % Rational(0);
-                Assert::Fail();
-            }
-            catch (uint32_t t)
-            {
-                if (t != CALC_E_INDEFINITE)
+                try
+                {
+                    res = Rational(number) % Rational(0);
+                    Assert::Fail();
+                }
+                catch (uint32_t t)
+                {
+                    if (t != CALC_E_INDEFINITE)
+                    {
+                        Assert::Fail();
+                    }
+                }
+                catch (...)
+                {
+                    Assert::Fail();
+                }
+
+                try
+                {
+                    res = Rational(Number(1, number, { 0 }), Number(1, 0, { 2 })) % Rational(Number(1, 0, { 0 }), Number(1, 0, { 23 }));
+                    Assert::Fail();
+                }
+                catch (uint32_t t)
+                {
+                    if (t != CALC_E_INDEFINITE)
+                    {
+                        Assert::Fail();
+                    }
+                }
+                catch (...)
                 {
                     Assert::Fail();
                 }
             }
-            catch (...)
-            {
-                Assert::Fail();
-            }
+
+            //Test with rational numbers
+            res = Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })) % Rational(89);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            res = Rational(Number(1, 0, { 3330 }), Number(1, 0, { 1332 })) % Rational(1);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0.5");
+            res = Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(10);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            res = Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(10);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-2.5");
+            res = Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(-10);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-2.5");
+            res = Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(-10);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            res = Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(1);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.33333333");
+            res = Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(-10);
+            auto sdsdas = res.ToString(10, FMT_FLOAT, 8);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"3.3333333");
+            res = Rational(Number(-1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(-10);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-3.3333333");
+            res = Rational(834345) % Rational(Number(1, 0, { 103 }), Number(1, 0, { 100 }));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.71");
+            res = Rational(834345) % Rational(Number(-1, 0, { 103 }), Number(1, 0, { 100 }));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.71");
+            res = Rational(-834345) % Rational(Number(1, 0, { 103 }), Number(1, 0, { 100 }));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-0.71");
         }
     };
 }

--- a/src/CalculatorUnitTests/RationalTest.cpp
+++ b/src/CalculatorUnitTests/RationalTest.cpp
@@ -21,59 +21,69 @@ namespace CalculatorEngineTests
         }
         TEST_METHOD(ModuloTest)
         {
+            // Verify results but also check that operands are not modified
             Rational rat25(25);
             Rational ratminus25(-25);
             Rational rat4(4);
             Rational ratminus4(-4);
             Rational res = Mod(rat25, rat4);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"1");
+            VERIFY_ARE_EQUAL(res, 1);
+            VERIFY_ARE_EQUAL(rat25, 25);
+            VERIFY_ARE_EQUAL(rat4, 4);
             res = Mod(rat25, ratminus4);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-3");
+            VERIFY_ARE_EQUAL(res, -3);
+            VERIFY_ARE_EQUAL(rat25, 25);
+            VERIFY_ARE_EQUAL(ratminus4, -4);
             res = Mod(ratminus25, ratminus4);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-1");
+            VERIFY_ARE_EQUAL(res, -1);
+            VERIFY_ARE_EQUAL(ratminus25, -25);
+            VERIFY_ARE_EQUAL(ratminus4, -4);
             res = Mod(ratminus25, rat4);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"3");
+            VERIFY_ARE_EQUAL(res, 3);
+            VERIFY_ARE_EQUAL(ratminus25, -25);
+            VERIFY_ARE_EQUAL(rat4, 4);
 
+            // Check with integers
             res = Mod(Rational(426), Rational(56478));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"426");
+            VERIFY_ARE_EQUAL(res, 426);
             res = Mod(Rational(56478), Rational(426));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"246");
+            VERIFY_ARE_EQUAL(res, 246);
             res = Mod(Rational(-643), Rational(8756));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"8113");
+            VERIFY_ARE_EQUAL(res, 8113);
             res = Mod(Rational(643), Rational(-8756));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-8113");
+            VERIFY_ARE_EQUAL(res, -8113);
             res = Mod(Rational(-643), Rational(-8756));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
+            VERIFY_ARE_EQUAL(res, -643);
             res = Mod(Rational(1000), Rational(250));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+            VERIFY_ARE_EQUAL(res, 0);
             res = Mod(Rational(1000), Rational(-250));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
-            //Test with Zero
-            res = Mod(Rational(343654332), Rational(0));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"343654332");
-            res = Mod(Rational(0), Rational(8756));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
-            res = Mod(Rational(0), Rational(-242));
-            auto dfd = res.ToString(10, FMT_FLOAT, 128);
-            VERIFY_ARE_EQUAL(dfd, L"0");
-            res = Mod(Rational(0), Rational(0));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
-            res = Mod(Rational(Number(1, 0, { 23242 }), Number(1, 0, { 2 })), Rational(Number(1, 0, { 0 }), Number(1, 0, { 23 })));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"11621");
+            VERIFY_ARE_EQUAL(res, 0);
 
-            //Test with rational numbers
+            // Test with Zero
+            res = Mod(Rational(343654332), Rational(0));
+            VERIFY_ARE_EQUAL(res, 343654332);
+            res = Mod(Rational(0), Rational(8756));
+            VERIFY_ARE_EQUAL(res, 0);
+            res = Mod(Rational(0), Rational(-242));
+            VERIFY_ARE_EQUAL(res, 0);
+            res = Mod(Rational(0), Rational(0));
+            VERIFY_ARE_EQUAL(res, 0);
+            res = Mod(Rational(Number(1, 0, { 23242 }), Number(1, 0, { 2 })), Rational(Number(1, 0, { 0 }), Number(1, 0, { 23 })));
+            VERIFY_ARE_EQUAL(res, 11621);
+
+            // Test with rational numbers
             res = Mod(Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })), Rational(89));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
             res = Mod(Rational(Number(1, 0, { 3330 }), Number(1, 0, { 1332 })), Rational(1));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.5");
             res = Mod(Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(10));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
             res = Mod(Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(10));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"7.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"7.5");
             res = Mod(Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(-10));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-2.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-2.5");
             res = Mod(Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(-10));
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-7.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-7.5");
             res = Mod(Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })), Rational(1));
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.33333333");
             res = Mod(Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })), Rational(-10));
@@ -86,41 +96,50 @@ namespace CalculatorEngineTests
 
         TEST_METHOD(RemainderTest)
         {
+            //Verify results but also check that operands are not modified
             Rational rat25(25);
             Rational ratminus25(-25);
             Rational rat4(4);
             Rational ratminus4(-4);
             Rational res = rat25 % rat4;
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"1");
+            VERIFY_ARE_EQUAL(res, 1);
+            VERIFY_ARE_EQUAL(rat25, 25);
+            VERIFY_ARE_EQUAL(rat4, 4);
             res = rat25 % ratminus4;
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"1");
+            VERIFY_ARE_EQUAL(res, 1);
+            VERIFY_ARE_EQUAL(rat25, 25);
+            VERIFY_ARE_EQUAL(ratminus4, -4);
             res = ratminus25 % ratminus4;
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-1");
+            VERIFY_ARE_EQUAL(res, -1);
+            VERIFY_ARE_EQUAL(ratminus25, -25);
+            VERIFY_ARE_EQUAL(ratminus4, -4);
             res = ratminus25 % rat4;
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-1");
+            VERIFY_ARE_EQUAL(res, -1);
+            VERIFY_ARE_EQUAL(ratminus25, -25);
+            VERIFY_ARE_EQUAL(rat4, 4);
 
+
+            // Check with integers
             res = Rational(426) % Rational(56478);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"426");
+            VERIFY_ARE_EQUAL(res, 426);
             res = Rational(56478) % Rational(426);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"246");
+            VERIFY_ARE_EQUAL(res, 246);
             res = Rational(-643) % Rational(8756);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
+            VERIFY_ARE_EQUAL(res, -643);
             res = Rational(643) % Rational(-8756);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"643");
+            VERIFY_ARE_EQUAL(res, 643);
             res = Rational(-643) % Rational(-8756);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
-
+            VERIFY_ARE_EQUAL(res, -643);
             res = Rational(-124) % Rational(-124);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+            VERIFY_ARE_EQUAL(res, 0);
             res = Rational(24) % Rational(24);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+            VERIFY_ARE_EQUAL(res, 0);
 
-            //Test with Zero
+            // Test with Zero
             res = Rational(0) % Rational(3654);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
-
+            VERIFY_ARE_EQUAL(res, 0);
             res = Rational(0) % Rational(-242);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0");
+            VERIFY_ARE_EQUAL(res, 0);
             for (auto number : { 343654332, 0, -23423 })
             {
                 try
@@ -160,17 +179,17 @@ namespace CalculatorEngineTests
 
             //Test with rational numbers
             res = Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })) % Rational(89);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
             res = Rational(Number(1, 0, { 3330 }), Number(1, 0, { 1332 })) % Rational(1);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"0.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.5");
             res = Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(10);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
             res = Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(10);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-2.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-2.5");
             res = Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(-10);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-2.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-2.5");
             res = Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(-10);
-            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"2.5");
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
             res = Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(1);
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.33333333");
             res = Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(-10);

--- a/src/CalculatorUnitTests/RationalTest.cpp
+++ b/src/CalculatorUnitTests/RationalTest.cpp
@@ -10,7 +10,7 @@ using namespace CalcEngine;
 using namespace CalcEngine::RationalMath;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
 
-namespace RationalTests
+namespace CalculatorManagerTest
 {
     TEST_CLASS(RationalTest)
     {
@@ -44,6 +44,10 @@ namespace RationalTests
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-8113");
             res = Mod(Rational(-643), Rational(-8756));
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
+
+            //Test with Zero
+            res = Mod(Rational(343654332), Rational(0));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"343654332");
         }
 
         TEST_METHOD(RemainderTest)
@@ -71,6 +75,24 @@ namespace RationalTests
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"643");
             res = Rational(-643) % Rational(-8756);
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
+
+            //Test with Zero
+            try
+            {
+                res = Rational(343654332) % Rational(0);
+                Assert::Fail();
+            }
+            catch (uint32_t t)
+            {
+                if (t != CALC_E_INDEFINITE)
+                {
+                    Assert::Fail();
+                }
+            }
+            catch (...)
+            {
+                Assert::Fail();
+            }
         }
     };
 }

--- a/src/CalculatorUnitTests/RationalTest.cpp
+++ b/src/CalculatorUnitTests/RationalTest.cpp
@@ -19,7 +19,8 @@ namespace CalculatorEngineTests
         {
             ChangeConstants(10, 128);
         }
-        TEST_METHOD(ModuloTest)
+
+        TEST_METHOD(TestModuloOperandsNotModified)
         {
             // Verify results but also check that operands are not modified
             Rational rat25(25);
@@ -42,9 +43,12 @@ namespace CalculatorEngineTests
             VERIFY_ARE_EQUAL(res, 3);
             VERIFY_ARE_EQUAL(ratminus25, -25);
             VERIFY_ARE_EQUAL(rat4, 4);
+        }
 
+        TEST_METHOD(TestModuloInteger)
+        {
             // Check with integers
-            res = Mod(Rational(426), Rational(56478));
+            auto res = Mod(Rational(426), Rational(56478));
             VERIFY_ARE_EQUAL(res, 426);
             res = Mod(Rational(56478), Rational(426));
             VERIFY_ARE_EQUAL(res, 246);
@@ -58,9 +62,12 @@ namespace CalculatorEngineTests
             VERIFY_ARE_EQUAL(res, 0);
             res = Mod(Rational(1000), Rational(-250));
             VERIFY_ARE_EQUAL(res, 0);
+        }
 
+        TEST_METHOD(TestModuloZero)
+        {
             // Test with Zero
-            res = Mod(Rational(343654332), Rational(0));
+            auto res = Mod(Rational(343654332), Rational(0));
             VERIFY_ARE_EQUAL(res, 343654332);
             res = Mod(Rational(0), Rational(8756));
             VERIFY_ARE_EQUAL(res, 0);
@@ -70,9 +77,12 @@ namespace CalculatorEngineTests
             VERIFY_ARE_EQUAL(res, 0);
             res = Mod(Rational(Number(1, 0, { 23242 }), Number(1, 0, { 2 })), Rational(Number(1, 0, { 0 }), Number(1, 0, { 23 })));
             VERIFY_ARE_EQUAL(res, 11621);
+        }
 
+        TEST_METHOD(TestModuloRational)
+        {
             // Test with rational numbers
-            res = Mod(Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })), Rational(89));
+            auto res = Mod(Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })), Rational(89));
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
             res = Mod(Rational(Number(1, 0, { 3330 }), Number(1, 0, { 1332 })), Rational(1));
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.5");
@@ -94,7 +104,7 @@ namespace CalculatorEngineTests
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-0.32");
         }
 
-        TEST_METHOD(RemainderTest)
+        TEST_METHOD(TestRemainerOperandsNotModified)
         {
             //Verify results but also check that operands are not modified
             Rational rat25(25);
@@ -117,10 +127,12 @@ namespace CalculatorEngineTests
             VERIFY_ARE_EQUAL(res, -1);
             VERIFY_ARE_EQUAL(ratminus25, -25);
             VERIFY_ARE_EQUAL(rat4, 4);
+        }
 
-
+        TEST_METHOD(TestRemainerInteger)
+        {
             // Check with integers
-            res = Rational(426) % Rational(56478);
+            auto res = Rational(426) % Rational(56478);
             VERIFY_ARE_EQUAL(res, 426);
             res = Rational(56478) % Rational(426);
             VERIFY_ARE_EQUAL(res, 246);
@@ -134,9 +146,12 @@ namespace CalculatorEngineTests
             VERIFY_ARE_EQUAL(res, 0);
             res = Rational(24) % Rational(24);
             VERIFY_ARE_EQUAL(res, 0);
+        }
 
+        TEST_METHOD(TestRemainerZero)
+        {
             // Test with Zero
-            res = Rational(0) % Rational(3654);
+            auto res = Rational(0) % Rational(3654);
             VERIFY_ARE_EQUAL(res, 0);
             res = Rational(0) % Rational(-242);
             VERIFY_ARE_EQUAL(res, 0);
@@ -176,9 +191,12 @@ namespace CalculatorEngineTests
                     Assert::Fail();
                 }
             }
+        }
 
+        TEST_METHOD(TestRemainerRational)
+        {
             //Test with rational numbers
-            res = Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })) % Rational(89);
+            auto res = Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })) % Rational(89);
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
             res = Rational(Number(1, 0, { 3330 }), Number(1, 0, { 1332 })) % Rational(1);
             VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.5");

--- a/src/CalculatorUnitTests/RationalTest.cpp
+++ b/src/CalculatorUnitTests/RationalTest.cpp
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include <CppUnitTest.h>
+#include "Header Files/Rational.h"
+#include "Header Files/RationalMath.h"
+
+using namespace CalcEngine;
+using namespace CalcEngine::RationalMath;
+using namespace Microsoft::VisualStudio::CppUnitTestFramework;
+
+namespace RationalTests
+{
+    TEST_CLASS(RationalTest)
+    {
+    public:
+        TEST_CLASS_INITIALIZE(CommonSetup)
+        {
+            ChangeConstants(10, 128);
+        }
+        TEST_METHOD(ModuloTest)
+        {
+            Rational rat25(25);
+            Rational ratminus25(-25);
+            Rational rat4(4);
+            Rational ratminus4(-4);
+            Rational res = Mod(rat25, rat4);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"1");
+            res = Mod(rat25, ratminus4);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-3");
+            res = Mod(ratminus25, ratminus4);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-1");
+            res = Mod(ratminus25, rat4);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"3");
+
+            res = Mod(Rational(426), Rational(56478));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"426");
+            res = Mod(Rational(56478), Rational(426));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"246");
+            res = Mod(Rational(-643), Rational(8756));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"8113");
+            res = Mod(Rational(643), Rational(-8756));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-8113");
+            res = Mod(Rational(-643), Rational(-8756));
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
+        }
+
+        TEST_METHOD(RemainderTest)
+        {
+            Rational rat25(25);
+            Rational ratminus25(-25);
+            Rational rat4(4);
+            Rational ratminus4(-4);
+            Rational res = rat25 % rat4;
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"1");
+            res = rat25 % ratminus4;
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"1");
+            res = ratminus25 % ratminus4;
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-1");
+            res = ratminus25 % rat4;
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-1");
+
+            res = Rational(426) % Rational(56478);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"426");
+            res = Rational(56478) % Rational(426);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"246");
+            res = Rational(-643) % Rational(8756);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
+            res = Rational(643) % Rational(-8756);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"643");
+            res = Rational(-643) % Rational(-8756);
+            VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 128), L"-643");
+        }
+    };
+}


### PR DESCRIPTION
## Fixes #111

> The modulo operator on this calculator gives the result that is different to the most used calculators.

The current `modrate` function is the equivalent of rem(...)/remainder(...), not mod(...)/modulo(...) available in some popular Math apps. 

### Description of the changes:
- rename `modrate` in `remrate` to be more accurate.
- add `modrate`, calculating modulo similarly to Matlab, Bing, Google calculator, Maxima, Wolfram Alpha and Microsoft Excel 
- Add `RationalMath::Mod` using `modrate` as an alternative to `Rational::operator%` using `remrate`
- Add a helper `SIGN` to retrieve the sign of a `Rational`.
- modify `CalcEngine` to use `modrate` in Normal and Scientific mode and `remrate` in Programmer mode.

### How changes were validated:
- manually and unit tests added