### PR TITLE
Fix inline script in loc pipeline

### DIFF
--- a/build/pipelines/azure-pipelines.loc.yaml
+++ b/build/pipelines/azure-pipelines.loc.yaml
@@ -35,7 +35,7 @@ jobs:
       cd $(Build.SourcesDirectory)
       git add -A
       git diff --cached --exit-code
-      echo '##vso[task.setvariable variable=hasChanges]%errorlevel%'
+      echo ##vso[task.setvariable variable=hasChanges]%errorlevel%
       git diff --cached > $(Build.ArtifactStagingDirectory)\LocalizedStrings.patch
     displayName: Check for changes and create patch file
 


### PR DESCRIPTION
Our loc pipeline wasn't telling us when there were loc changes to merge back into the repo, because a YAML string was quoted incorrectly.