### PR TITLE
Add support for Pyeong, a Korean floorspace unit.

### DIFF
--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -403,12 +403,29 @@ void UnitConverter::RestoreUserPreferences(const wstring& userPreferences)
     }
 
     vector<wstring> outerTokens = StringToVector(userPreferences, L"|");
-    if (outerTokens.size() == 3)
+    if (outerTokens.size() != 3)
     {
-        m_fromType = StringToUnit(outerTokens[0]);
-        m_toType = StringToUnit(outerTokens[1]);
-        m_currentCategory = StringToCategory(outerTokens[2]);
+        return;
     }
+    auto fromType = StringToUnit(outerTokens[0]);
+    auto toType = StringToUnit(outerTokens[1]);
+    m_currentCategory = StringToCategory(outerTokens[2]);
+
+    // Only restore from the saved units if they are valid in the current available units.
+    auto itr = m_categoryToUnits.find(m_currentCategory);
+    if (itr != m_categoryToUnits.end())
+    {
+        auto curUnits = itr->second;
+        if (find(curUnits.begin(), curUnits.end(), fromType) != curUnits.end())
+        {
+            m_fromType = fromType;
+        }
+        if (find(curUnits.begin(), curUnits.end(), toType) != curUnits.end())
+        {
+            m_toType = toType;
+        }
+    }
+
 }
 
 /// <summary>

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -407,6 +407,7 @@ void UnitConverter::RestoreUserPreferences(const wstring& userPreferences)
     {
         return;
     }
+
     auto fromType = StringToUnit(outerTokens[0]);
     auto toType = StringToUnit(outerTokens[1]);
     m_currentCategory = StringToCategory(outerTokens[2]);
@@ -415,7 +416,7 @@ void UnitConverter::RestoreUserPreferences(const wstring& userPreferences)
     auto itr = m_categoryToUnits.find(m_currentCategory);
     if (itr != m_categoryToUnits.end())
     {
-        auto curUnits = itr->second;
+        const auto& curUnits = itr->second;
         if (find(curUnits.begin(), curUnits.end(), fromType) != curUnits.end())
         {
             m_fromType = fromType;

--- a/src/CalcViewModel/DataLoaders/UnitConverterDataConstants.h
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataConstants.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 namespace CalculatorApp
@@ -162,7 +162,8 @@ namespace CalculatorApp
             Data_Zebibytes = UnitStart + 162,
             Data_Zetabits = UnitStart + 163,
             Data_Zetabytes = UnitStart + 164,
-            UnitEnd = Data_Zetabytes
+            Area_Pyeong = UnitStart + 165,
+            UnitEnd = Area_Pyeong
         };
     }
 }

--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -120,6 +120,12 @@ void UnitConverterDataLoader::LoadData()
 
                 for (auto itr = unitConversions.begin(); itr != unitConversions.end(); ++itr)
                 {
+                    if (idToUnit.find(itr->first) == idToUnit.end())
+                    {
+                        // Optional units will not be in idToUnit but can be in unitConversions.
+                        // For optional units that did not make it to the current set of units, just continue.
+                        continue;
+                    }
                     UCM::ConversionData parsedData = { 1.0, 0.0, false };
                     assert(itr->second > 0); // divide by zero assert
                     parsedData.ratio = unitFactor / itr->second;
@@ -175,6 +181,10 @@ void UnitConverterDataLoader::GetUnits(_In_ unordered_map<ViewMode, vector<Order
 
     bool useWattInsteadOfKilowatt = m_currentRegionCode == "GB";
 
+    // Use Pyeong, a Korean floorspace unit.
+    // https://en.wikipedia.org/wiki/Korean_units_of_measurement#Area
+    bool usePyeong = m_currentRegionCode == L"KP" || m_currentRegionCode == L"KR";
+    
     vector<OrderedUnit> areaUnits;
     areaUnits.push_back(OrderedUnit{ UnitConverterUnits::Area_Acre, GetLocalizedStringName(L"UnitName_Acre"), GetLocalizedStringName(L"UnitAbbreviation_Acre"), 9 });
     areaUnits.push_back(OrderedUnit{ UnitConverterUnits::Area_Hectare, GetLocalizedStringName(L"UnitName_Hectare"), GetLocalizedStringName(L"UnitAbbreviation_Hectare"), 4 });
@@ -190,6 +200,10 @@ void UnitConverterDataLoader::GetUnits(_In_ unordered_map<ViewMode, vector<Order
     areaUnits.push_back(OrderedUnit{ UnitConverterUnits::Area_Paper, GetLocalizedStringName(L"UnitName_Paper"), GetLocalizedStringName(L"UnitAbbreviation_Paper"), 12, false, false, true });
     areaUnits.push_back(OrderedUnit{ UnitConverterUnits::Area_SoccerField, GetLocalizedStringName(L"UnitName_SoccerField"), GetLocalizedStringName(L"UnitAbbreviation_SoccerField"),13, false, false, true });
     areaUnits.push_back(OrderedUnit{ UnitConverterUnits::Area_Castle, GetLocalizedStringName(L"UnitName_Castle"), GetLocalizedStringName(L"UnitAbbreviation_Castle"), 14, false, false, true });
+    if (usePyeong)
+    {
+        areaUnits.push_back(OrderedUnit{ UnitConverterUnits::Area_Pyeong, GetLocalizedStringName(L"UnitName_PYeong"), GetLocalizedStringName(L"UnitAbbreviation_Pyeong"), 15, false, false, false });
+    }
     unitMap.emplace(ViewMode::Area, areaUnits);
 
     vector<OrderedUnit> dataUnits;
@@ -384,6 +398,7 @@ void UnitConverterDataLoader::GetConversionData(_In_ unordered_map<ViewMode, uno
             { ViewMode::Area, UnitConverterUnits::Area_Paper, 0.06032246 },
             { ViewMode::Area, UnitConverterUnits::Area_SoccerField, 10869.66 },
             { ViewMode::Area, UnitConverterUnits::Area_Castle, 100000 },
+            { ViewMode::Area, UnitConverterUnits::Area_Pyeong, 3.305785 }, // apprx of 400/121
 
             { ViewMode::Data, UnitConverterUnits::Data_Bit, 0.000000125 },
             { ViewMode::Data, UnitConverterUnits::Data_Byte, 0.000001 },

--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -203,7 +203,7 @@ void UnitConverterDataLoader::GetUnits(_In_ unordered_map<ViewMode, vector<Order
     areaUnits.push_back(OrderedUnit{ UnitConverterUnits::Area_Castle, GetLocalizedStringName(L"UnitName_Castle"), GetLocalizedStringName(L"UnitAbbreviation_Castle"), 14, false, false, true });
     if (usePyeong)
     {
-        areaUnits.push_back(OrderedUnit{ UnitConverterUnits::Area_Pyeong, GetLocalizedStringName(L"UnitName_PYeong"), GetLocalizedStringName(L"UnitAbbreviation_Pyeong"), 15, false, false, false });
+        areaUnits.push_back(OrderedUnit{ UnitConverterUnits::Area_Pyeong, GetLocalizedStringName(L"UnitName_Pyeong"), GetLocalizedStringName(L"UnitAbbreviation_Pyeong"), 15, false, false, false });
     }
     unitMap.emplace(ViewMode::Area, areaUnits);
 

--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -118,18 +118,19 @@ void UnitConverterDataLoader::LoadData()
                 unordered_map<int, double> unitConversions = categoryToUnitConversionDataMap.at(categoryViewMode);
                 double unitFactor = unitConversions[unit.id];
 
-                for (auto itr = unitConversions.begin(); itr != unitConversions.end(); ++itr)
+                 for (const auto&[id, conversionFactor] : unitConversions)
                 {
-                    if (idToUnit.find(itr->first) == idToUnit.end())
+                    if (idToUnit.find(id) == idToUnit.end())
                     {
                         // Optional units will not be in idToUnit but can be in unitConversions.
                         // For optional units that did not make it to the current set of units, just continue.
                         continue;
                     }
+
                     UCM::ConversionData parsedData = { 1.0, 0.0, false };
-                    assert(itr->second > 0); // divide by zero assert
-                    parsedData.ratio = unitFactor / itr->second;
-                    conversions.insert(pair<UCM::Unit, UCM::ConversionData>(idToUnit.at(itr->first), parsedData));
+                    assert(conversionFactor > 0); // divide by zero assert
+                    parsedData.ratio = unitFactor / conversionFactor;
+                    conversions.insert(pair<UCM::Unit, UCM::ConversionData>(idToUnit.at(id), parsedData));
                 }
             }
             else

--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -398,7 +398,7 @@ void UnitConverterDataLoader::GetConversionData(_In_ unordered_map<ViewMode, uno
             { ViewMode::Area, UnitConverterUnits::Area_Paper, 0.06032246 },
             { ViewMode::Area, UnitConverterUnits::Area_SoccerField, 10869.66 },
             { ViewMode::Area, UnitConverterUnits::Area_Castle, 100000 },
-            { ViewMode::Area, UnitConverterUnits::Area_Pyeong, 3.305785 }, // apprx of 400/121
+            { ViewMode::Area, UnitConverterUnits::Area_Pyeong, 400.0 / 121.0 },
 
             { ViewMode::Data, UnitConverterUnits::Data_Bit, 0.000000125 },
             { ViewMode::Data, UnitConverterUnits::Data_Byte, 0.000001 },

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3379,4 +3379,12 @@
     <value>Microsoft Services Agreement</value>
     <comment>Displayed on a link to the Microsoft Services Agreement in the about this app information</comment>
   </data>
+  <data name="UnitAbbreviation_Pyeong" xml:space="preserve">
+    <value>Pyeong</value>
+    <comment>An abbreviation for a measurement unit of area.</comment>
+  </data>
+  <data name="UnitName_Pyeong" xml:space="preserve">
+    <value>Pyeong</value>
+    <comment>A measurement unit for area.</comment>
+  </data>
 </root>

--- a/src/Calculator/Resources/ko-KR/Resources.resw
+++ b/src/Calculator/Resources/ko-KR/Resources.resw
@@ -2907,12 +2907,4 @@
     <value>Microsoft 서비스 계약</value>
     <comment>Displayed on a link to the Microsoft Services Agreement in the about this app information</comment>
   </data>
-  <data name="UnitAbbreviation_Pyeong" xml:space="preserve">
-    <value>평</value>
-    <comment>An abbreviation for a measurement unit of area.</comment>
-  </data>
-  <data name="UnitName_Pyeong" xml:space="preserve">
-    <value>평</value>
-    <comment>A measurement unit for area.</comment>
-  </data>
 </root>

--- a/src/Calculator/Resources/ko-KR/Resources.resw
+++ b/src/Calculator/Resources/ko-KR/Resources.resw
@@ -2907,4 +2907,12 @@
     <value>Microsoft 서비스 계약</value>
     <comment>Displayed on a link to the Microsoft Services Agreement in the about this app information</comment>
   </data>
+  <data name="UnitAbbreviation_Pyeong" xml:space="preserve">
+    <value>평</value>
+    <comment>An abbreviation for a measurement unit of area.</comment>
+  </data>
+  <data name="UnitName_Pyeong" xml:space="preserve">
+    <value>평</value>
+    <comment>A measurement unit for area.</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Fixes #382 

### Description of the changes:
- Add Pyeong as an Area conversion unit.
- Pyeong shows up only if the user's current **region** is Korea ( i.e. region is either `KP` or `KR` ).
- Added Korean translation for Pyeong (평). For other locales, we default to English ( Pyeong ).

### How changes were validated:
Manually tested the below
1) For non-Korean regions, Pyeong does not show up.

2) Korean region with Korean locale => Pyeong shows up and Pyeong is correctly translated.
![pyeong_Korean](https://user-images.githubusercontent.com/3166423/55676874-4190f800-5892-11e9-9c67-35d9a75540bc.gif)

3) Korean region with English locale => Pyeong shows up and Pyeong is in English.
![pyeong_English](https://user-images.githubusercontent.com/3166423/55676890-946aaf80-5892-11e9-9bff-44e467e2884a.gif)

4) Korean region with simplified Chinese locale => Pyeong shows up and Pyeong is in English.
![pyeong_Chinese](https://user-images.githubusercontent.com/3166423/55676893-9af92700-5892-11e9-9e62-c8dc4c087e01.gif)
