### PR TITLE
Change how Narrator reads information of "0th" bit button

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -562,7 +562,7 @@
     <comment>Sub-string used in automation name for each bit in bit flip</comment>
   </data>
   <data name="63" xml:space="preserve">
-    <value>63rd </value>
+    <value>most significant</value>
     <comment>Sub-string used in automation name for 63 bit in bit flip</comment>
   </data>
   <data name="62" xml:space="preserve">
@@ -814,7 +814,7 @@
     <comment>Sub-string used in automation name for 1 bit in bit flip</comment>
   </data>
   <data name="0" xml:space="preserve">
-    <value>0th </value>
+    <value>least significant</value>
     <comment>Sub-string used in automation name for 0 bit in bit flip</comment>
   </data>
   <data name="MemoryButton_Open" xml:space="preserve">


### PR DESCRIPTION
## Fixes #385.


### Description of the changes:
-Changed data name="0" value from "0th" to "least significant"
-Changed data name="63" value from"63rd" to "most significant"
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-Validated manually with Narrator ensuring that Narrator read "least significant bit..." when 0th bit was selected and "most significant bit..." when 63rd bit was selected.
-
-

