### PR TITLE
Collapse CurrencySecondaryStatus when no text is present in the text block

### DIFF
--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -428,14 +428,21 @@
                 </VisualState>
             </VisualStateGroup>
             <VisualStateGroup x:Name="CurrencySecondaryStatusStates">
+                <VisualState x:Name="NormalCurrencyStatus">
+                    <VisualState.Setters>
+                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Collapsed"/>
+                    </VisualState.Setters>
+                </VisualState>
                 <VisualState x:Name="ChargesMayApplyCurrencyStatus">
                     <VisualState.Setters>
                         <Setter Target="CurrencySecondaryStatus.Foreground" Value="{ThemeResource AppControlPageTextBaseHighColorBrush}"/>
+                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Visible"/>
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FailedCurrencyStatus">
                     <VisualState.Setters>
                         <Setter Target="CurrencySecondaryStatus.Foreground" Value="{ThemeResource AppControlPageTextRedColorBrush}"/>
+                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Visible"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -615,7 +622,8 @@
                                          x:Uid="RefreshButtonText"
                                          Foreground="{ThemeResource SystemControlHyperlinkBaseHighBrush}"
                                          Click="CurrencyRefreshButton_Click"/>
-                        <TextBlock Margin="0,7,0,0" Style="{ThemeResource CaptionTextBlockStyle}">
+                        <TextBlock x:Name="CurrencySecondaryStatusBlock" Margin="0,7,0,0"
+                                   Style="{ThemeResource CaptionTextBlockStyle}">
                             <Run x:Name="Spacing" Text="&#x200A;"/>
                             <Run x:Name="CurrencySecondaryStatus"
                                  FontWeight="SemiBold"

--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -428,11 +428,7 @@
                 </VisualState>
             </VisualStateGroup>
             <VisualStateGroup x:Name="CurrencySecondaryStatusStates">
-                <VisualState x:Name="NormalCurrencyStatus">
-                    <VisualState.Setters>
-                        <Setter Target="CurrencySecondaryStatusTextBlock.Visibility" Value="Collapsed"/>
-                    </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="NormalCurrencyStatus"/>
                 <VisualState x:Name="ChargesMayApplyCurrencyStatus">
                     <VisualState.Setters>
                         <Setter Target="CurrencySecondaryStatus.Foreground" Value="{ThemeResource AppControlPageTextBaseHighColorBrush}"/>
@@ -622,8 +618,10 @@
                                          x:Uid="RefreshButtonText"
                                          Foreground="{ThemeResource SystemControlHyperlinkBaseHighBrush}"
                                          Click="CurrencyRefreshButton_Click"/>
-                        <TextBlock x:Name="CurrencySecondaryStatusTextBlock" Margin="0,7,0,0"
-                                   Style="{ThemeResource CaptionTextBlockStyle}">
+                        <TextBlock x:Name="CurrencySecondaryStatusTextBlock"
+                                   Margin="0,7,0,0"
+                                   Style="{ThemeResource CaptionTextBlockStyle}"
+                                   Visibility="Collapsed">
                             <Run x:Name="Spacing" Text="&#x200A;"/>
                             <Run x:Name="CurrencySecondaryStatus"
                                  FontWeight="SemiBold"

--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -430,19 +430,19 @@
             <VisualStateGroup x:Name="CurrencySecondaryStatusStates">
                 <VisualState x:Name="NormalCurrencyStatus">
                     <VisualState.Setters>
-                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Collapsed"/>
+                        <Setter Target="CurrencySecondaryStatusTextBlock.Visibility" Value="Collapsed"/>
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="ChargesMayApplyCurrencyStatus">
                     <VisualState.Setters>
                         <Setter Target="CurrencySecondaryStatus.Foreground" Value="{ThemeResource AppControlPageTextBaseHighColorBrush}"/>
-                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Visible"/>
+                        <Setter Target="CurrencySecondaryStatusTextBlock.Visibility" Value="Visible"/>
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FailedCurrencyStatus">
                     <VisualState.Setters>
                         <Setter Target="CurrencySecondaryStatus.Foreground" Value="{ThemeResource AppControlPageTextRedColorBrush}"/>
-                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Visible"/>
+                        <Setter Target="CurrencySecondaryStatusTextBlock.Visibility" Value="Visible"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -622,7 +622,7 @@
                                          x:Uid="RefreshButtonText"
                                          Foreground="{ThemeResource SystemControlHyperlinkBaseHighBrush}"
                                          Click="CurrencyRefreshButton_Click"/>
-                        <TextBlock x:Name="CurrencySecondaryStatusBlock" Margin="0,7,0,0"
+                        <TextBlock x:Name="CurrencySecondaryStatusTextBlock" Margin="0,7,0,0"
                                    Style="{ThemeResource CaptionTextBlockStyle}">
                             <Run x:Name="Spacing" Text="&#x200A;"/>
                             <Run x:Name="CurrencySecondaryStatus"

--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -428,21 +428,14 @@
                 </VisualState>
             </VisualStateGroup>
             <VisualStateGroup x:Name="CurrencySecondaryStatusStates">
-                <VisualState x:Name="NormalCurrencyStatus">
-                    <VisualState.Setters>
-                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Collapsed"/>
-                    </VisualState.Setters>
-                </VisualState>
                 <VisualState x:Name="ChargesMayApplyCurrencyStatus">
                     <VisualState.Setters>
                         <Setter Target="CurrencySecondaryStatus.Foreground" Value="{ThemeResource AppControlPageTextBaseHighColorBrush}"/>
-                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Visible"/>
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FailedCurrencyStatus">
                     <VisualState.Setters>
                         <Setter Target="CurrencySecondaryStatus.Foreground" Value="{ThemeResource AppControlPageTextRedColorBrush}"/>
-                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Visible"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -622,9 +615,7 @@
                                          x:Uid="RefreshButtonText"
                                          Foreground="{ThemeResource SystemControlHyperlinkBaseHighBrush}"
                                          Click="CurrencyRefreshButton_Click"/>
-                        <TextBlock x:Name="CurrencySecondaryStatusBlock"
-                                   Margin="3,7,0,0"
-                                   Style="{ThemeResource CaptionTextBlockStyle}">
+                        <TextBlock Margin="3,7,0,0" Style="{ThemeResource CaptionTextBlockStyle}">
                             <Run x:Name="CurrencySecondaryStatus"
                                  FontWeight="SemiBold"
                                  Text=""/>

--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -428,17 +428,21 @@
                 </VisualState>
             </VisualStateGroup>
             <VisualStateGroup x:Name="CurrencySecondaryStatusStates">
-                <VisualState x:Name="NormalCurrencyStatus"/>
+                <VisualState x:Name="NormalCurrencyStatus">
+                    <VisualState.Setters>
+                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Collapsed"/>
+                    </VisualState.Setters>
+                </VisualState>
                 <VisualState x:Name="ChargesMayApplyCurrencyStatus">
                     <VisualState.Setters>
                         <Setter Target="CurrencySecondaryStatus.Foreground" Value="{ThemeResource AppControlPageTextBaseHighColorBrush}"/>
-                        <Setter Target="CurrencySecondaryStatusTextBlock.Visibility" Value="Visible"/>
+                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Visible"/>
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="FailedCurrencyStatus">
                     <VisualState.Setters>
                         <Setter Target="CurrencySecondaryStatus.Foreground" Value="{ThemeResource AppControlPageTextRedColorBrush}"/>
-                        <Setter Target="CurrencySecondaryStatusTextBlock.Visibility" Value="Visible"/>
+                        <Setter Target="CurrencySecondaryStatusBlock.Visibility" Value="Visible"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -618,11 +622,9 @@
                                          x:Uid="RefreshButtonText"
                                          Foreground="{ThemeResource SystemControlHyperlinkBaseHighBrush}"
                                          Click="CurrencyRefreshButton_Click"/>
-                        <TextBlock x:Name="CurrencySecondaryStatusTextBlock"
-                                   Margin="0,7,0,0"
-                                   Style="{ThemeResource CaptionTextBlockStyle}"
-                                   Visibility="Collapsed">
-                            <Run x:Name="Spacing" Text="&#x200A;"/>
+                        <TextBlock x:Name="CurrencySecondaryStatusBlock"
+                                   Margin="3,7,0,0"
+                                   Style="{ThemeResource CaptionTextBlockStyle}">
                             <Run x:Name="CurrencySecondaryStatus"
                                  FontWeight="SemiBold"
                                  Text=""/>

--- a/src/Calculator/Views/UnitConverter.xaml.cpp
+++ b/src/Calculator/Views/UnitConverter.xaml.cpp
@@ -157,14 +157,14 @@ void UnitConverter::SetNormalCurrencyStatus()
 
 void UnitConverter::SetChargesMayApplyStatus()
 {
-    VisualStateManager::GoToState(this, ChargesMayApplyCurrencyStatus->Name, false);
     CurrencySecondaryStatus->Text = m_chargesMayApplyText;
+    VisualStateManager::GoToState(this, ChargesMayApplyCurrencyStatus->Name, false);
 }
 
 void UnitConverter::SetFailedToRefreshStatus()
 {
-    VisualStateManager::GoToState(this, FailedCurrencyStatus->Name, false);
     CurrencySecondaryStatus->Text = m_failedToRefreshText;
+    VisualStateManager::GoToState(this, FailedCurrencyStatus->Name, false);
 }
 
 void UnitConverter::InitializeOfflineStatusTextBlock()

--- a/src/Calculator/Views/UnitConverter.xaml.cpp
+++ b/src/Calculator/Views/UnitConverter.xaml.cpp
@@ -152,7 +152,6 @@ void UnitConverter::OnOfflineNetworkAccess()
 
 void UnitConverter::SetNormalCurrencyStatus()
 {
-    VisualStateManager::GoToState(this, L"NormalCurrencyStatus", false);
     CurrencySecondaryStatus->Text = L"";
 }
 

--- a/src/Calculator/Views/UnitConverter.xaml.cpp
+++ b/src/Calculator/Views/UnitConverter.xaml.cpp
@@ -152,19 +152,20 @@ void UnitConverter::OnOfflineNetworkAccess()
 
 void UnitConverter::SetNormalCurrencyStatus()
 {
-    VisualStateManager::GoToState(this, NormalCurrencyStatus->Name, false);
+    VisualStateManager::GoToState(this, L"NormalCurrencyStatus", false);
+    CurrencySecondaryStatus->Text = L"";
 }
 
 void UnitConverter::SetChargesMayApplyStatus()
 {
+    VisualStateManager::GoToState(this, L"ChargesMayApplyCurrencyStatus", false);
     CurrencySecondaryStatus->Text = m_chargesMayApplyText;
-    VisualStateManager::GoToState(this, ChargesMayApplyCurrencyStatus->Name, false);
 }
 
 void UnitConverter::SetFailedToRefreshStatus()
 {
+    VisualStateManager::GoToState(this, L"FailedCurrencyStatus", false);
     CurrencySecondaryStatus->Text = m_failedToRefreshText;
-    VisualStateManager::GoToState(this, FailedCurrencyStatus->Name, false);
 }
 
 void UnitConverter::InitializeOfflineStatusTextBlock()

--- a/src/Calculator/Views/UnitConverter.xaml.cpp
+++ b/src/Calculator/Views/UnitConverter.xaml.cpp
@@ -152,19 +152,18 @@ void UnitConverter::OnOfflineNetworkAccess()
 
 void UnitConverter::SetNormalCurrencyStatus()
 {
-    VisualStateManager::GoToState(this, L"NormalCurrencyStatus", false);
-    CurrencySecondaryStatus->Text = L"";
+    VisualStateManager::GoToState(this, NormalCurrencyStatus->Name, false);
 }
 
 void UnitConverter::SetChargesMayApplyStatus()
 {
-    VisualStateManager::GoToState(this, L"ChargesMayApplyCurrencyStatus", false);
+    VisualStateManager::GoToState(this, ChargesMayApplyCurrencyStatus->Name, false);
     CurrencySecondaryStatus->Text = m_chargesMayApplyText;
 }
 
 void UnitConverter::SetFailedToRefreshStatus()
 {
-    VisualStateManager::GoToState(this, L"FailedCurrencyStatus", false);
+    VisualStateManager::GoToState(this, FailedCurrencyStatus->Name, false);
     CurrencySecondaryStatus->Text = m_failedToRefreshText;
 }
 

--- a/src/Calculator/Views/UnitConverter.xaml.cpp
+++ b/src/Calculator/Views/UnitConverter.xaml.cpp
@@ -152,6 +152,7 @@ void UnitConverter::OnOfflineNetworkAccess()
 
 void UnitConverter::SetNormalCurrencyStatus()
 {
+    VisualStateManager::GoToState(this, L"NormalCurrencyStatus", false);
     CurrencySecondaryStatus->Text = L"";
 }
 


### PR DESCRIPTION
## Fixes #313 
In Scan/Item mode, Narrator focus navigates to hidden element “No next item” after “Update rates” link in "Currency Converter" window #313

### Description of the changes:
- Adds an x:Name to the CurrencySecondaryStatus text block
- Adds a NormalCurrencyStatus visual state to the CurrencySecondaryStatusStates
- Adds functionality to the CurrencySecondaryStatusStates to show or hide the CurrencySecondaryStatus text block.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Verified that the textblock is not visible in the accessibility tree via inspect.exe from the windows sdk.
- Verified that Narrator also does not stop on the block when in scan mode.
- Verified that the textblock is visible in the accessibility tree and read out in Narrator when the ChargesMayApplyCurrencyStatus or FailedCurrencyStatus viewstates are set.

