### PR TITLE
[JaEra] Calc: subtracting 1-year from date during Reiwa 1 yields unexpected results.

### DIFF
--- a/src/CalculatorUnitTests/DateCalculatorUnitTests.cpp
+++ b/src/CalculatorUnitTests/DateCalculatorUnitTests.cpp
@@ -664,5 +664,57 @@ namespace DateCalculationUnitTests
                 VERIFY_IS_TRUE(actualValue.find(expectedValue) != wstring::npos, message.c_str());
             }
         }
+
+        TEST_METHOD(JaEraTransitionAddition)
+        {
+            auto viewModel = make_unique<DateCalculationEngine>(CalendarIdentifiers::Japanese);
+            auto cal = ref new Calendar();
+
+            // Showa period ended in Jan 1989.
+            cal->Year = 1989;
+            cal->Month = 1;
+            cal->Day = 1;
+            auto startTime = cal->GetDateTime();
+
+            cal->Year = 1990;
+            cal->Month = 1;
+            cal->Day = 1;
+
+            // Expect that adding a year across boundaries adds the equivalent in the Gregorian calendar.
+            auto expectedResult = cal->GetDateTime();
+            DateDifference duration;
+            duration.year = 1;
+
+            DateTime actualResult;
+            viewModel->AddDuration(startTime, duration, &actualResult);
+
+            VERIFY_ARE_EQUAL(expectedResult.UniversalTime, actualResult.UniversalTime);
+        }
+
+        TEST_METHOD(JaEraTransitionSubtraction)
+        {
+            auto viewModel = make_unique<DateCalculationEngine>(CalendarIdentifiers::Japanese);
+            auto cal = ref new Calendar();
+
+            // Showa period ended in Jan 1989.
+            cal->Year = 1990;
+            cal->Month = 1;
+            cal->Day = 1;
+            auto startTime = cal->GetDateTime();
+
+            cal->Year = 1989;
+            cal->Month = 1;
+            cal->Day = 1;
+
+            // Expect that adding a year across boundaries adds the equivalent in the Gregorian calendar.
+            auto expectedResult = cal->GetDateTime();
+            DateDifference duration;
+            duration.year = 1;
+
+            DateTime actualResult;
+            viewModel->SubtractDuration(startTime, duration, &actualResult);
+
+            VERIFY_ARE_EQUAL(expectedResult.UniversalTime, actualResult.UniversalTime);
+        }
     };
 }


### PR DESCRIPTION
## Fixes 471#.
[JaEra] Calc: subtracting 1-year from date during Reiwa 1 yields unexpected results.

### Description of the changes:
- When doing addition or subtraction of dates, if using the Japanese Era Calendar system, use the gregorian system to perform year addition/subtraction.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually verified that the transition between Reiwa and Heisei eras are handled correctly
- Wrote tests covering an already established era transition between Heisei and Showa eras.

