### PR TITLE
Allow vcxproj and sln files to merge as text.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -13,29 +13,6 @@
 *.cs     diff=csharp
 
 ###############################################################################
-# Set the merge driver for project and solution files
-#
-# Merging from the command prompt will add diff markers to the files if there
-# are conflicts (Merging from VS is not affected by the settings below, in VS
-# the diff markers are never inserted). Diff markers may cause the following 
-# file extensions to fail to load in VS. An alternative would be to treat
-# these files as binary and thus will always conflict and require user
-# intervention with every merge. To do so, just uncomment the entries below
-###############################################################################
-*.sln       merge=binary
-*.csproj    merge=binary
-*.vbproj    merge=binary
-*.vcxproj   merge=binary
-*.vcproj    merge=binary
-*.dbproj    merge=binary
-*.fsproj    merge=binary
-*.lsproj    merge=binary
-*.wixproj   merge=binary
-*.modelproj merge=binary
-*.sqlproj   merge=binary
-*.wwaproj   merge=binary
-
-###############################################################################
 # behavior for image files
 #
 # image files are treated as binary by default.


### PR DESCRIPTION
### Description of the changes:
This will cause Git to insert conflict markers in the file and make it easier to identify and fix merge conflicts. Previously, Git would complain about conflicts with these files, but no markers were inserted.

### How changes were validated:
Manual.
- Checkout feature/GraphingCalculator and merge in upstream/master.  Git identifies merge conflicts present for Calculator.vcxproj but there are no conflict markers in the file.  Abort the merge.
- Merge in dabelc/MergeProjectFilesAsText.  Confirm Git is able to merge Calculator.vcxproj.

