### PR TITLE
Change the awkward Simplified Chinese translation for "bit toggling keypad"

### DIFF
--- a/src/Calculator/Resources/zh-CN/Resources.resw
+++ b/src/Calculator/Resources/zh-CN/Resources.resw
@@ -442,7 +442,7 @@
     <comment>This is the tool tip automation name for the history button.</comment>
   </data>
   <data name="bitFlip.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>比特绷板键盘</value>
+    <value>位切换键盘</value>
     <comment>This is the tool tip automation name for the bitFlip button.</comment>
   </data>
   <data name="fullKeypad.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">


### PR DESCRIPTION
**Bit toggling keypad** is translated to 比特绷板键盘. I use a more clear and simple string like 位切换键盘 instead. 绷板 is a rare word even in daily life, never used at all in the computer industry.
