### PR TITLE
Unit Converter - Calculate the rounding precision of results based on the source

### DIFF
--- a/src/CalcManager/CalcManager.vcxproj
+++ b/src/CalcManager/CalcManager.vcxproj
@@ -309,6 +309,7 @@
     <ClInclude Include="Ratpack\CalcErr.h" />
     <ClInclude Include="Ratpack\ratconst.h" />
     <ClInclude Include="Ratpack\ratpak.h" />
+    <ClInclude Include="NumberFormattingUtils.h" />
     <ClInclude Include="UnitConverter.h" />
   </ItemGroup>
   <ItemGroup>
@@ -349,6 +350,7 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="NumberFormattingUtils.cpp" />
     <ClCompile Include="UnitConverter.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/src/CalcManager/CalcManager.vcxproj.filters
+++ b/src/CalcManager/CalcManager.vcxproj.filters
@@ -89,6 +89,7 @@
     <ClCompile Include="CEngine\RationalMath.cpp">
       <Filter>CEngine</Filter>
     </ClCompile>
+    <ClCompile Include="NumberFormattingUtils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Command.h" />
@@ -160,5 +161,6 @@
     <ClInclude Include="Header Files\RationalMath.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="NumberFormattingUtils.h" />
   </ItemGroup>
 </Project>

--- a/src/CalcManager/NumberFormattingUtils.cpp
+++ b/src/CalcManager/NumberFormattingUtils.cpp
@@ -1,7 +1,6 @@
 #include "pch.h"
 #include "NumberFormattingUtils.h"
-#include <iostream>
-#include <math.h>
+
 using namespace std;
 
 namespace CalcManager::NumberFormattingUtils

--- a/src/CalcManager/NumberFormattingUtils.cpp
+++ b/src/CalcManager/NumberFormattingUtils.cpp
@@ -33,7 +33,7 @@ namespace CalcManager::NumberFormattingUtils
     }
 
     /// <summary>
-    /// Get number of digits (whole number part + decinmal part)</summary>
+    /// Get number of digits (whole number part + decimal part)</summary>
     /// <param name="value">the number</param>
     unsigned int GetNumberDigits(wstring value)
     {

--- a/src/CalcManager/NumberFormattingUtils.cpp
+++ b/src/CalcManager/NumberFormattingUtils.cpp
@@ -1,0 +1,85 @@
+#include "pch.h"
+#include "NumberFormattingUtils.h"
+#include <iostream>
+#include <math.h>
+using namespace std;
+
+namespace CalculationManager::NumberFormattingUtils
+{
+    /// <summary>
+    /// Trims out any trailing zeros or decimals in the given input string
+    /// </summary>
+    /// <param name="number">number to trim</param>
+    void TrimTrailingZeros(_Inout_ wstring& number)
+    {
+        if (number.find(L'.') == wstring::npos)
+        {
+            return;
+        }
+
+        wstring::iterator iter;
+        for (iter = number.end() - 1;; iter--)
+        {
+            if (*iter != L'0')
+            {
+                number.erase(iter + 1, number.end());
+                break;
+            }
+        }
+        if (*(number.end() - 1) == L'.')
+        {
+            number.erase(number.end() - 1, number.end());
+        }
+    }
+
+    /// <summary>
+    /// Get number of digits (whole number part + decinmal part)</summary>
+    /// <param name="value">the number</param>
+    unsigned int GetNumberDigits(wstring value)
+    {
+        TrimTrailingZeros(value);
+        unsigned int numberSignificantDigits = static_cast<unsigned int>(value.size());
+        if (value.find(L'.') != wstring::npos)
+        {
+            --numberSignificantDigits;
+        }
+        if (value.find(L'-') != wstring::npos)
+        {
+            --numberSignificantDigits;
+        }
+        return numberSignificantDigits;
+    }
+
+    /// <summary>
+    /// Get number of digits (whole number part only)</summary>
+    /// <param name="value">the number</param>
+    unsigned int GetNumberDigitsWholeNumberPart(double value)
+    {
+        return value == 0 ? 1 : (1 + (int)log10(abs(value)));
+    }
+
+    /// <summary>
+    /// Rounds the given double to the given number of significant digits
+    /// </summary>
+    /// <param name="num">input double</param>
+    /// <param name="numSignificant">int number of significant digits to round to</param>
+    wstring RoundSignificantDigits(double num, int numSignificant)
+    {
+        wstringstream out(wstringstream::out);
+        out << fixed;
+        out.precision(numSignificant);
+        out << num;
+        return out.str();
+    }
+
+    /// <summary>
+    ///  Convert a Number to Scientific Notation
+    /// </summary>
+    /// <param name="number">number to convert</param>
+    wstring ToScientificNumber(double number)
+    {
+        wstringstream out(wstringstream::out);
+        out << scientific << number;
+        return out.str();
+    }
+}

--- a/src/CalcManager/NumberFormattingUtils.cpp
+++ b/src/CalcManager/NumberFormattingUtils.cpp
@@ -4,7 +4,7 @@
 #include <math.h>
 using namespace std;
 
-namespace CalculationManager::NumberFormattingUtils
+namespace CalcManager::NumberFormattingUtils
 {
     /// <summary>
     /// Trims out any trailing zeros or decimals in the given input string

--- a/src/CalcManager/NumberFormattingUtils.h
+++ b/src/CalcManager/NumberFormattingUtils.h
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+
+namespace CalculationManager::NumberFormattingUtils
+{
+    void TrimTrailingZeros(_Inout_ std::wstring& input);
+    unsigned int GetNumberDigits(std::wstring value);
+    unsigned int GetNumberDigitsWholeNumberPart(double value);
+    std::wstring RoundSignificantDigits(double value, int numberSignificantDigits);
+    std::wstring ToScientificNumber(double number);
+}

--- a/src/CalcManager/NumberFormattingUtils.h
+++ b/src/CalcManager/NumberFormattingUtils.h
@@ -5,7 +5,7 @@
 
 #include <string>
 
-namespace CalculationManager::NumberFormattingUtils
+namespace CalcManager::NumberFormattingUtils
 {
     void TrimTrailingZeros(_Inout_ std::wstring& input);
     unsigned int GetNumberDigits(std::wstring value);

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -885,6 +885,8 @@ void UnitConverter::Calculate()
                 }
                 else
                 {
+					// Fewer digits are needed following the decimal if the number is large,
+					// we calculate the number of decimals necessary based on the number of digits in the integer part.
                     precision = max(0, max(OPTIMALDIGITSALLOWED, min(MAXIMUMDIGITSALLOWED, currentNumberSignificantDigits)) - numPreDecimal);
                 }
 

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -178,7 +178,7 @@ void UnitConverter::SwitchActive(const wstring& newValue)
     swap(m_currentHasDecimal, m_returnHasDecimal);
     m_returnDisplay = m_currentDisplay;
     m_currentDisplay = newValue;
-    m_currentHasDecimal = (m_currentDisplay.find(L'.') != m_currentDisplay.npos);
+    m_currentHasDecimal = (m_currentDisplay.find(L'.') != wstring::npos);
     m_switchedActive = true;
 
     if (m_currencyDataLoader != nullptr && m_vmCurrencyCallback != nullptr)
@@ -202,7 +202,7 @@ vector<wstring> UnitConverter::StringToVector(const wstring& w, const wchar_t* d
     size_t delimiterIndex = w.find(delimiter);
     size_t startIndex = 0;
     vector<wstring> serializedTokens = vector<wstring>();
-    while (delimiterIndex != w.npos)
+    while (delimiterIndex != wstring::npos)
     {
         serializedTokens.push_back(w.substr(startIndex, delimiterIndex - startIndex));
         startIndex = delimiterIndex + (int)wcslen(delimiter);
@@ -891,7 +891,7 @@ void UnitConverter::Calculate()
                 m_returnDisplay = RoundSignificant(returnValue, precision);
                 TrimString(m_returnDisplay);
             }
-            m_returnHasDecimal = (m_returnDisplay.find(L'.') != m_returnDisplay.npos);
+            m_returnHasDecimal = (m_returnDisplay.find(L'.') != wstring::npos);
         }
     }
     UpdateViewModel();
@@ -930,11 +930,11 @@ unsigned int UnitConverter::GetNumberSignificantDigits(std::wstring value)
 {
     TrimString(value);
     unsigned int numberSignificantDigits = static_cast<unsigned int>(value.size());
-    if (value.find(L'.') != value.npos)
+    if (value.find(L'.') != wstring::npos)
     {
         --numberSignificantDigits;
     }
-    if (value.find(L'-') != value.npos)
+    if (value.find(L'-') != wstring::npos)
     {
         --numberSignificantDigits;
     }

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -882,7 +882,7 @@ void UnitConverter::Calculate()
 
             auto currentDisplayTrimmed = m_currentDisplay;
             TrimString(currentDisplayTrimmed);
-            int currentNumberSignificantDigits = currentDisplayTrimmed.size();
+            int currentNumberSignificantDigits = static_cast<int>(currentDisplayTrimmed.size());
             if (currentDisplayTrimmed.find(L'.') != currentDisplayTrimmed.npos)
                 --currentNumberSignificantDigits;
             if (currentValue < 0)

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -929,16 +929,16 @@ void UnitConverter::TrimString(_Inout_ wstring& returnString)
 unsigned int UnitConverter::GetNumberSignificantDigits(std::wstring value)
 {
     TrimString(value);
-    int currentNumberSignificantDigits = value.size();
+    unsigned int numberSignificantDigits = value.size();
     if (value.find(L'.') != value.npos)
     {
-        --currentNumberSignificantDigits;
+        --numberSignificantDigits;
     }
     if (value.find(L'-') != value.npos)
     {
-        --currentNumberSignificantDigits;
+        --numberSignificantDigits;
     }
-    return currentNumberSignificantDigits;
+    return numberSignificantDigits;
 }
 
 /// <summary>

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -929,7 +929,7 @@ void UnitConverter::TrimString(_Inout_ wstring& returnString)
 unsigned int UnitConverter::GetNumberSignificantDigits(std::wstring value)
 {
     TrimString(value);
-    unsigned int numberSignificantDigits = value.size();
+    unsigned int numberSignificantDigits = static_cast<unsigned int>(value.size());
     if (value.find(L'.') != value.npos)
     {
         --numberSignificantDigits;

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -11,7 +11,7 @@
 using namespace concurrency;
 using namespace std;
 using namespace UnitConversionManager;
-using namespace CalculationManager::NumberFormattingUtils;
+using namespace CalcManager::NumberFormattingUtils;
 
 static constexpr uint32_t EXPECTEDSERIALIZEDCATEGORYTOKENCOUNT = 3;
 static constexpr uint32_t EXPECTEDSERIALIZEDUNITTOKENCOUNT = 6;

--- a/src/CalcManager/UnitConverter.h
+++ b/src/CalcManager/UnitConverter.h
@@ -290,10 +290,6 @@ namespace UnitConversionManager
         std::shared_ptr<IConverterDataLoader> GetDataLoaderForCategory(const Category& category);
         std::shared_ptr<ICurrencyConverterDataLoader> GetCurrencyConverterDataLoader();
 
-        static void TrimString(_Inout_ std::wstring& input);
-        static unsigned int GetNumberSignificantDigits(std::wstring value);
-        static std::wstring RoundSignificant(double num, int numSignificant);
-
     private:
         std::shared_ptr<IConverterDataLoader> m_dataLoader;
         std::shared_ptr<IConverterDataLoader> m_currencyDataLoader;

--- a/src/CalcManager/UnitConverter.h
+++ b/src/CalcManager/UnitConverter.h
@@ -279,9 +279,7 @@ namespace UnitConversionManager
         double Convert(double value, ConversionData conversionData);
         std::vector<std::tuple<std::wstring, Unit>> CalculateSuggested();
         void ClearValues();
-        void TrimString(std::wstring& input);
         void InitializeSelectedUnits();
-        std::wstring RoundSignificant(double num, int numSignificant);
         Category StringToCategory(const std::wstring& w);
         std::wstring CategoryToString(const Category& c, const wchar_t* delimiter);
         std::wstring UnitToString(const Unit& u, const wchar_t* delimiter);
@@ -291,6 +289,10 @@ namespace UnitConversionManager
         bool AnyUnitIsEmpty();
         std::shared_ptr<IConverterDataLoader> GetDataLoaderForCategory(const Category& category);
         std::shared_ptr<ICurrencyConverterDataLoader> GetCurrencyConverterDataLoader();
+
+        static void TrimString(_Inout_ std::wstring& input);
+        static unsigned int GetNumberSignificantDigits(std::wstring value);
+        static std::wstring RoundSignificant(double num, int numSignificant);
 
     private:
         std::shared_ptr<IConverterDataLoader> m_dataLoader;

--- a/src/CalcManager/pch.h
+++ b/src/CalcManager/pch.h
@@ -20,3 +20,5 @@
 #include <unordered_map>
 #include <vector>
 #include <winerror.h>
+#include <iostream>
+#include <math.h>

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -7,9 +7,11 @@
 
 #include "CalcManager/CalculatorHistory.h"
 #include "CalcViewModel/Common/EngineResourceProvider.h"
+#include "CalcManager/NumberFormattingUtils.h"
 
 using namespace CalculatorApp;
 using namespace CalculationManager;
+using namespace CalculationManager::NumberFormattingUtils;
 using namespace Platform;
 using namespace std;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;
@@ -185,6 +187,11 @@ namespace CalculatorManagerTest
         TEST_METHOD(CalculatorManagerTestMaxDigitsReached_LeadingDecimal);
         TEST_METHOD(CalculatorManagerTestMaxDigitsReached_TrailingDecimal);
 
+        TEST_METHOD(CalculatorManagerNumberFormattingUtils_TrimTrailingZeros);
+        TEST_METHOD(CalculatorManagerNumberFormattingUtils_GetNumberDigits);
+        TEST_METHOD(CalculatorManagerNumberFormattingUtils_GetNumberDigitsWholeNumberPart);
+        TEST_METHOD(CalculatorManagerNumberFormattingUtils_RoundSignificantDigits);
+        TEST_METHOD(CalculatorManagerNumberFormattingUtils_ToScientificNumber);
         // TODO re-enable when cause of failure is determined. Bug 20226670
         // TEST_METHOD(CalculatorManagerTestBinaryOperatorReceived);
         // TEST_METHOD(CalculatorManagerTestBinaryOperatorReceived_Multiple);
@@ -805,6 +812,102 @@ namespace CalculatorManagerTest
     void CalculatorManagerTest::CalculatorManagerTestMaxDigitsReached_TrailingDecimal()
     {
         TestMaxDigitsReachedScenario(L"123,456,789,101,112.13");
+    }
+
+    void CalculatorManagerTest::CalculatorManagerNumberFormattingUtils_TrimTrailingZeros()
+    {
+        wstring number = L"2.1032100000000";
+        TrimTrailingZeros(number);
+        VERIFY_ARE_EQUAL(number, L"2.10321");
+        number = L"-122.123200";
+        TrimTrailingZeros(number);
+        VERIFY_ARE_EQUAL(number, L"-122.1232");
+        number = L"0.0001200";
+        TrimTrailingZeros(number);
+        VERIFY_ARE_EQUAL(number, L"0.00012");
+        number = L"12.000";
+        TrimTrailingZeros(number);
+        VERIFY_ARE_EQUAL(number, L"12");
+        number = L"-12.00000";
+        TrimTrailingZeros(number);
+        VERIFY_ARE_EQUAL(number, L"-12");
+        number = L"0.000";
+        TrimTrailingZeros(number);
+        VERIFY_ARE_EQUAL(number, L"0");
+        number = L"322423";
+        TrimTrailingZeros(number);
+        VERIFY_ARE_EQUAL(number, L"322423");
+    }
+
+    void CalculatorManagerTest::CalculatorManagerNumberFormattingUtils_GetNumberDigits()
+    {
+        wstring number = L"2.10321";
+        unsigned int digitsCount = GetNumberDigits(number);
+        VERIFY_ARE_EQUAL(digitsCount, 6);
+        number = L"-122.1232";
+        digitsCount = GetNumberDigits(number);
+        VERIFY_ARE_EQUAL(digitsCount, 7);
+        number = L"-3432";
+        digitsCount = GetNumberDigits(number);
+        VERIFY_ARE_EQUAL(digitsCount, 4);
+        number = L"0";
+        digitsCount = GetNumberDigits(number);
+        VERIFY_ARE_EQUAL(digitsCount, 1);
+        number = L"0.0001223";
+        digitsCount = GetNumberDigits(number);
+        VERIFY_ARE_EQUAL(digitsCount, 8);
+    }
+
+    void CalculatorManagerTest::CalculatorManagerNumberFormattingUtils_GetNumberDigitsWholeNumberPart()
+    {
+        unsigned int digitsCount = GetNumberDigitsWholeNumberPart(2.10321);
+        VERIFY_ARE_EQUAL(digitsCount, 1);
+        digitsCount = GetNumberDigitsWholeNumberPart(-122.1232);
+        VERIFY_ARE_EQUAL(digitsCount, 3);
+        digitsCount = GetNumberDigitsWholeNumberPart(-3432);
+        VERIFY_ARE_EQUAL(digitsCount, 4);
+        digitsCount = GetNumberDigitsWholeNumberPart(0);
+        VERIFY_ARE_EQUAL(digitsCount, 1);
+        digitsCount = GetNumberDigitsWholeNumberPart(324328412837382);
+        VERIFY_ARE_EQUAL(digitsCount, 15);
+        digitsCount = GetNumberDigitsWholeNumberPart(324328412837382.232213214324234);
+        VERIFY_ARE_EQUAL(digitsCount, 15);
+    }
+
+    void CalculatorManagerTest::CalculatorManagerNumberFormattingUtils_RoundSignificantDigits()
+    {
+        wstring result = RoundSignificantDigits(12.342343242, 3);
+        VERIFY_ARE_EQUAL(result, L"12.342");
+        result = RoundSignificantDigits(12.3429999, 3);
+        VERIFY_ARE_EQUAL(result, L"12.343");
+        result = RoundSignificantDigits(12.342500001, 3);
+        VERIFY_ARE_EQUAL(result, L"12.343");
+        result = RoundSignificantDigits(-2312.1244243346454345, 5);
+        VERIFY_ARE_EQUAL(result, L"-2312.12442");
+        result = RoundSignificantDigits(0.3423432423, 5);
+        VERIFY_ARE_EQUAL(result, L"0.34234");
+        result = RoundSignificantDigits(0.3423, 7);
+        VERIFY_ARE_EQUAL(result, L"0.3423000");
+    }
+
+    void CalculatorManagerTest::CalculatorManagerNumberFormattingUtils_ToScientificNumber()
+    {
+        wstring result = ToScientificNumber(3423);
+        VERIFY_ARE_EQUAL(result, L"3.423000e+03");
+        result = ToScientificNumber(-21);
+        VERIFY_ARE_EQUAL(result, L"-2.100000e+01");
+        result = ToScientificNumber(0.0232);
+        VERIFY_ARE_EQUAL(result, L"2.320000e-02");
+        result = ToScientificNumber(-0.00921);
+        VERIFY_ARE_EQUAL(result, L"-9.210000e-03");
+        result = ToScientificNumber(2343243345677);
+        VERIFY_ARE_EQUAL(result, L"2.343243e+12");
+        result = ToScientificNumber(-3432474247332942);
+        VERIFY_ARE_EQUAL(result, L"-3.432474e+15");
+        result = ToScientificNumber(0.000000003432432);
+        VERIFY_ARE_EQUAL(result, L"3.432432e-09");
+        result = ToScientificNumber(-0.000000003432432);
+        VERIFY_ARE_EQUAL(result, L"-3.432432e-09");
     }
 
     // TODO re-enable when cause of failure is determined. Bug 20226670

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -11,7 +11,7 @@
 
 using namespace CalculatorApp;
 using namespace CalculationManager;
-using namespace CalculationManager::NumberFormattingUtils;
+using namespace CalcManager::NumberFormattingUtils;
 using namespace Platform;
 using namespace std;
 using namespace Microsoft::VisualStudio::CppUnitTestFramework;

--- a/src/CalculatorUnitTests/UnitConverterTest.cpp
+++ b/src/CalculatorUnitTests/UnitConverterTest.cpp
@@ -441,7 +441,7 @@ namespace UnitConverterUnitTests
         s_unitConverter->SendCommand(Command::Six);
         s_unitConverter->SendCommand(Command::Seven);
         s_unitConverter->SendCommand(Command::Eight);
-        VERIFY_IS_TRUE(s_testVMCallback->CheckDisplayValues(wstring(L"12345678"), wstring(L"27217528.63236")));
+        VERIFY_IS_TRUE(s_testVMCallback->CheckDisplayValues(wstring(L"12345678"), wstring(L"27217529")));
     }
 
     // Test large values


### PR DESCRIPTION
## Fixes #455 and #416 

### Description of the changes:
- Ignore trailing zeros (issue #416), negative sign, decimal separator of the source when calculating the precision of the result 
- Round the result number based on the number of digits in the source value

### How changes were validated:
Manually tested, including the 2 repros from #455 and #416 