### PR TITLE
Taskbar and start menu jumplist items should not be pinnable/unpinnable or removable

### DIFF
--- a/src/Calculator/App.xaml.cpp
+++ b/src/Calculator/App.xaml.cpp
@@ -180,7 +180,6 @@ task<void> App::SetupJumpList()
             ViewMode mode = option->Mode;
             auto item = JumpListItem::CreateWithArguments(((int)mode).ToString(), L"ms-resource:///Resources/" + NavCategory::GetNameResourceKey(mode));
             item->Description = L"ms-resource:///Resources/" + NavCategory::GetNameResourceKey(mode);
-            item->GroupName = L"ms-resource:///Resources/" + NavCategoryGroup::GetHeaderResourceKey(calculatorOptions->GroupType);
             item->Logo = ref new Uri("ms-appx:///Assets/" + mode.ToString() + ".png");
 
             jumpList->Items->Append(item);


### PR DESCRIPTION
## Fixes #281 .


### Description of the changes:
- Removed GroupName for `JumpListItem`s.

    _It seems that the only way for UWP apps to remove pin/unpin and remove ability from jumplist items is to [not specify a group name for them](https://stackoverflow.com/a/39436591/942659). The downside is, the header for jumplist items will be "Tasks" instead of the current header title which is "Calculator"._

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual testing
