### PR TITLE
Repair empty link

### DIFF
--- a/docs/ApplicationArchitecture.md
+++ b/docs/ApplicationArchitecture.md
@@ -201,4 +201,5 @@ instead of regular floating point arithmetic). The interface to this layer is de
 [CalcManager folder]:                 ../src/CalcManager
 [CalculatorManager.h]:                ../src/CalcManager/CalculatorManager.h
 [CalcEngine.h]:                       ../src/CalcManager/Header&#32;Files/CalcEngine.h
+[Infinite Precision]:                 https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic
 [ratpak.h]:                           ../src/CalcManager/Ratpack/ratpak.h


### PR DESCRIPTION
Link to the same infinite-precision-arithmetic article on Wikipedia as in README.md

## Fixes
Existing output in the `ApplicationArchitecture.md` is a literal
`[infinite precision][Infinite Precision]`. It should be a link to https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic.

### Description of the changes:
This patch assumes the author intended to link to [the same Wikipedia article](https://en.wikipedia.org/wiki/Arbitrary-precision_arithmetic) linked to in [README.md](https://github.com/microsoft/calculator/blob/452f18fd8e5264650edc811bafae0937c98cd0b3/README.md#features)

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
A local test on my machine — it’s a Markdown-only edit.