### PR TITLE
Added the name property for right/left scroll buttons on screen

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -400,6 +400,7 @@
                                                TextWrapping="NoWrap"/>
                                 </ScrollViewer>
                                 <HyperlinkButton x:Name="ScrollLeft"
+                                                 x:Uid="ScrollLeft"
                                                  Grid.Column="0"
                                                  Width="20"
                                                  MinWidth="20"
@@ -411,7 +412,7 @@
                                                  VerticalContentAlignment="Center"
                                                  Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
                                                  BorderThickness="0"
-                                                 AutomationProperties.Name="ScrollLeft"
+                                                 AutomationProperties.AutomationId="CalculationResultScrollLeft"
                                                  Visibility="Collapsed">
                                     <FontIcon x:Name="ScrollLeftText"
                                               FontFamily="{ThemeResource SymbolThemeFontFamily}"
@@ -419,6 +420,7 @@
                                               Glyph="&#xE26C;"/>
                                 </HyperlinkButton>
                                 <HyperlinkButton x:Name="ScrollRight"
+                                                 x:Uid="ScrollRight"
                                                  Grid.Column="2"
                                                  Width="20"
                                                  MinWidth="20"
@@ -430,7 +432,7 @@
                                                  VerticalContentAlignment="Center"
                                                  Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
                                                  BorderThickness="0"
-                                                 AutomationProperties.Name="ScrollRight"
+                                                 AutomationProperties.AutomationId="CalculationResultScrollRight"
                                                  Visibility="Collapsed">
                                     <FontIcon x:Name="ScrollRightText"
                                               FontFamily="{ThemeResource SymbolThemeFontFamily}"

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -400,7 +400,7 @@
                                                TextWrapping="NoWrap"/>
                                 </ScrollViewer>
                                 <HyperlinkButton x:Name="ScrollLeft"
-                                                 x:Uid="ScrollLeft"
+                                                 x:Uid="CalculationResultScrollLeft"
                                                  Grid.Column="0"
                                                  Width="20"
                                                  MinWidth="20"
@@ -420,7 +420,7 @@
                                               Glyph="&#xE26C;"/>
                                 </HyperlinkButton>
                                 <HyperlinkButton x:Name="ScrollRight"
-                                                 x:Uid="ScrollRight"
+                                                 x:Uid="CalculationResultScrollRight"
                                                  Grid.Column="2"
                                                  Width="20"
                                                  MinWidth="20"

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -353,8 +353,7 @@
                 <Setter Property="ZoomMode" Value="Disabled"/>
             </Style>
 
-            <Style x:Key="CalculationResultStyle"
-                   TargetType="Controls:CalculationResult">
+            <Style x:Key="CalculationResultStyle" TargetType="Controls:CalculationResult">
                 <Setter Property="Background" Value="Transparent"/>
                 <Setter Property="Foreground" Value="{ThemeResource SystemControlPageTextBaseHighBrush}"/>
                 <Setter Property="HorizontalAlignment" Value="Stretch"/>
@@ -412,6 +411,7 @@
                                                  VerticalContentAlignment="Center"
                                                  Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
                                                  BorderThickness="0"
+                                                 AutomationProperties.Name="ScrollLeft"
                                                  Visibility="Collapsed">
                                     <FontIcon x:Name="ScrollLeftText"
                                               FontFamily="{ThemeResource SymbolThemeFontFamily}"
@@ -430,6 +430,7 @@
                                                  VerticalContentAlignment="Center"
                                                  Foreground="{ThemeResource SystemControlForegroundAccentBrush}"
                                                  BorderThickness="0"
+                                                 AutomationProperties.Name="ScrollRight"
                                                  Visibility="Collapsed">
                                     <FontIcon x:Name="ScrollRightText"
                                               FontFamily="{ThemeResource SymbolThemeFontFamily}"

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3387,4 +3387,12 @@
     <value>Pyeong</value>
     <comment>A measurement unit for area.</comment>
   </data>
+  <data name="CalculationResultScrollLeft.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Scroll Calculation Result Left</value>
+    <comment>Automation label for the "Scroll Left" button that appears when a calculation result is too large to fit in calculation result text box.</comment>
+  </data>
+  <data name="CalculationResultScrollRight.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Scroll Calculation Result Right</value>
+    <comment>Automation label for the "Scroll Right" button that appears when a calculation result is too large to fit in calculation result text box.</comment>
+  </data>
 </root>


### PR DESCRIPTION
## Fixes #482 

### Description of the changes:
-  Added the 'AutomationProperties.Name' tag to the HyperlinkButton template used to create the button
- The above was done for both the right and left buttons
- The left and right buttons now have accessible names as intended.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-Manually
- The fix was tested by running the application and trying to reproduce the original problem described in issue #482. 
- The expected results as specified by the report on the issue was that the 'Name Property should be defined' for both the right and left buttons and this was achieved and tested by using the inspector tool.


