### PR TITLE
Removed entrance transition for about button in NavigationView

### DIFF
--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -110,6 +110,10 @@
                                              x:Load="False"
                                              IsItemClickEnabled="True"
                                              ItemClick="OnAboutButtonClick">
+                        <muxc:NavigationViewList.ItemContainerTransitions>
+                            <!-- Remove EntranceThemeTransition which is a default transition for NavigationViewList -->
+                            <TransitionCollection/>
+                        </muxc:NavigationViewList.ItemContainerTransitions>
                         <muxc:NavigationViewList.Items>
                             <muxc:NavigationViewItem x:Name="AboutButton"
                                                      x:Uid="AboutButton"


### PR DESCRIPTION
## Fixes #285.


### Description of the changes:
- Remove EntranceThemeTransition (which is a default transition for NavigationViewList) for the NavigationViewList on PaneFooter of NavigationView.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual testing
