### PR TITLE
Bound the calendar picker to the control above

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -2904,9 +2904,9 @@
     <value>Difference</value>
     <comment>Difference result label</comment>
   </data>
-  <data name="Date_FromLabel.Text" xml:space="preserve">
+  <data name="DateDiff_FromHeader.Header" xml:space="preserve">
     <value>From</value>
-    <comment>From Date label for Date Picker</comment>
+    <comment>From Date Header for Difference Date Picker</comment>
   </data>
   <data name="MonthsLabel.Text" xml:space="preserve">
     <value>Months</value>
@@ -2916,9 +2916,9 @@
     <value>Subtract</value>
     <comment>Subtract toggle button text</comment>
   </data>
-  <data name="Date_ToLabel.Text" xml:space="preserve">
+  <data name="DateDiff_ToHeader.Header" xml:space="preserve">
     <value>To</value>
-    <comment>To Date label for Date Picker</comment>
+    <comment>To Date Header for Difference Date Picker</comment>
   </data>
   <data name="YearsLabel.Text" xml:space="preserve">
     <value>Years</value>
@@ -3386,5 +3386,9 @@
   <data name="UnitName_Pyeong" xml:space="preserve">
     <value>Pyeong</value>
     <comment>A measurement unit for area.</comment>
+  </data>
+  <data name="AddSubtract_Date_FromHeader.Header" xml:space="preserve">
+    <value>From</value>
+    <comment>From Date Header for AddSubtract Date Picker</comment>
   </data>
 </root>

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -502,7 +502,7 @@
                                 Grid.Row="2"
                                 Margin="0,0,0,0"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
-                                AutomationProperties.LabeledBy="{x:Bind AddSubtract_Date_FromLabel}"
+                                AutomationProperties.LabeledBy="{x:Bind Date_FromLabel}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
                                 Closed="CalendarFlyoutClosed"
                                 DateChanged="AddSubtract_DateChanged"/>

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -417,19 +417,13 @@
             </Grid.RowDefinitions>
 
             <!-- From Date -->
-            <TextBlock x:Name="Date_FromLabel"
-                       x:Uid="Date_FromLabel"
-                       Grid.Row="1"
-                       Margin="0,0,0,2"
-                       Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
-                       TextWrapping="Wrap"/>
             <CalendarDatePicker x:Name="DateDiff_FromDate"
                                 Grid.Row="2"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
-                                AutomationProperties.LabeledBy="{x:Bind Date_FromLabel}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
                                 Closed="CalendarFlyoutClosed"
-                                DateChanged="FromDate_DateChanged"/>
+                                DateChanged="FromDate_DateChanged"
+                                Header="From"/>
 
             <!-- To Date -->
             <TextBlock x:Name="Date_ToLabel"
@@ -502,7 +496,6 @@
                                 Grid.Row="2"
                                 Margin="0,0,0,0"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
-                                AutomationProperties.LabeledBy="{x:Bind Date_FromLabel}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
                                 Closed="CalendarFlyoutClosed"
                                 DateChanged="AddSubtract_DateChanged"/>

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -403,10 +403,8 @@
               Grid.Row="2"
               Visibility="{Binding IsDateDiffMode, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Grid.RowDefinitions>
-                <RowDefinition Height="1*" MaxHeight="17"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto" MinHeight="32"/>
-                <RowDefinition Height="1*" MaxHeight="24"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto" MinHeight="32"/>
                 <RowDefinition Height="1*" MaxHeight="24"/>
@@ -419,7 +417,7 @@
             <!-- From Date -->
             <CalendarDatePicker x:Name="DateDiff_FromDate"
                                 x:Uid="DateDiff_FromHeader"
-                                Grid.Row="2"
+                                Grid.Row="1"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
                                 Closed="CalendarFlyoutClosed"
@@ -428,7 +426,7 @@
             <!-- To Date -->
             <CalendarDatePicker x:Name="DateDiff_ToDate"
                                 x:Uid="DateDiff_ToHeader"
-                                Grid.Row="5"
+                                Grid.Row="3"
                                 Margin="0,0,0,0"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
@@ -437,11 +435,11 @@
 
             <!-- Difference Result -->
             <TextBlock x:Uid="Date_DifferenceLabel"
-                       Grid.Row="7"
+                       Grid.Row="5"
                        Margin="0,0,0,0"
                        Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"/>
             <TextBlock x:Name="DateDiffAllUnitsResultLabel"
-                       Grid.Row="8"
+                       Grid.Row="6"
                        Style="{ThemeResource SubtitleTextBlockStyle}"
                        FontWeight="SemiBold"
                        AutomationProperties.LiveSetting="Polite"
@@ -449,7 +447,7 @@
                        ContextFlyout="{StaticResource ResultsContextMenu}"
                        IsTextSelectionEnabled="True"
                        Text="{Binding StrDateDiffResult}"/>
-            <TextBlock Grid.Row="10"
+            <TextBlock Grid.Row="8"
                        Style="{ThemeResource BaseTextBlockStyle}"
                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
                        ContextFlyout="{StaticResource ResultsContextMenu}"
@@ -466,7 +464,6 @@
               Visibility="{Binding IsDateDiffMode, Converter={StaticResource BooleanToVisibilityNegationConverter}}">
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="1*" MaxHeight="17"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto" MinHeight="32"/>
                 <RowDefinition Height="1*" MaxHeight="23"/>
@@ -481,14 +478,14 @@
             <!-- From Date -->
             <CalendarDatePicker x:Name="AddSubtract_FromDate"
                                 x:Uid="AddSubtract_Date_FromHeader"
-                                Grid.Row="2"
+                                Grid.Row="1"
                                 Margin="0,0,0,0"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
                                 Closed="CalendarFlyoutClosed"
                                 DateChanged="AddSubtract_DateChanged"/>
 
-            <Grid Grid.Row="4">
+            <Grid Grid.Row="3">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
@@ -514,7 +511,7 @@
             </Grid>
 
             <!-- Date Offset to be Added/Subtracted -->
-            <Grid x:Name="DateOffsetGrid" Grid.Row="6">
+            <Grid x:Name="DateOffsetGrid" Grid.Row="5">
 
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto"/>
@@ -575,11 +572,11 @@
 
             <!-- Resulting Date -->
             <TextBlock x:Uid="DateLabel"
-                       Grid.Row="8"
+                       Grid.Row="7"
                        Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"/>
 
             <TextBlock x:Name="DateResultLabel"
-                       Grid.Row="9"
+                       Grid.Row="8"
                        Style="{ThemeResource SubtitleTextBlockStyle}"
                        FontWeight="SemiBold"
                        AutomationProperties.LiveSetting="Polite"

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -403,9 +403,9 @@
               Grid.Row="2"
               Visibility="{Binding IsDateDiffMode, Converter={StaticResource BooleanToVisibilityConverter}}">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
+				<RowDefinition Height="1*" MaxHeight="17"/>
                 <RowDefinition Height="Auto" MinHeight="32"/>
-                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="1*" MaxHeight="24"/>
                 <RowDefinition Height="Auto" MinHeight="32"/>
                 <RowDefinition Height="1*" MaxHeight="24"/>
                 <RowDefinition Height="Auto"/>
@@ -464,7 +464,7 @@
               Visibility="{Binding IsDateDiffMode, Converter={StaticResource BooleanToVisibilityNegationConverter}}">
 
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="1*" MaxHeight="17"/>
                 <RowDefinition Height="Auto" MinHeight="32"/>
                 <RowDefinition Height="1*" MaxHeight="23"/>
                 <RowDefinition Height="Auto"/>

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -426,20 +426,14 @@
                                 Header="From"/>
 
             <!-- To Date -->
-            <TextBlock x:Name="Date_ToLabel"
-                       x:Uid="Date_ToLabel"
-                       Grid.Row="4"
-                       Margin="0,0,0,2"
-                       Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
-                       TextWrapping="Wrap"/>
             <CalendarDatePicker x:Name="DateDiff_ToDate"
                                 Grid.Row="5"
                                 Margin="0,0,0,0"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
-                                AutomationProperties.LabeledBy="{x:Bind Date_ToLabel}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
                                 Closed="CalendarFlyoutClosed"
-                                DateChanged="ToDate_DateChanged"/>
+                                DateChanged="ToDate_DateChanged"
+                                Header="To"/>
 
             <!-- Difference Result -->
             <TextBlock x:Uid="Date_DifferenceLabel"

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -418,22 +418,22 @@
 
             <!-- From Date -->
             <CalendarDatePicker x:Name="DateDiff_FromDate"
+                                x:Uid="DateDiff_FromHeader"
                                 Grid.Row="2"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
                                 Closed="CalendarFlyoutClosed"
-                                DateChanged="FromDate_DateChanged"
-                                Header="From"/>
+                                DateChanged="FromDate_DateChanged"/>
 
             <!-- To Date -->
             <CalendarDatePicker x:Name="DateDiff_ToDate"
+                                x:Uid="DateDiff_ToHeader"
                                 Grid.Row="5"
                                 Margin="0,0,0,0"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"
                                 CalendarViewStyle="{StaticResource DateCalculation_CalendarViewStyle}"
                                 Closed="CalendarFlyoutClosed"
-                                DateChanged="ToDate_DateChanged"
-                                Header="To"/>
+                                DateChanged="ToDate_DateChanged"/>
 
             <!-- Difference Result -->
             <TextBlock x:Uid="Date_DifferenceLabel"
@@ -479,14 +479,8 @@
             </Grid.RowDefinitions>
 
             <!-- From Date -->
-            <TextBlock x:Name="AddSubtract_Date_FromLabel"
-                       x:Uid="Date_FromLabel"
-                       Grid.Row="1"
-                       Margin="0,0,0,2"
-                       Style="{ThemeResource BodyTextBlockStyle}"
-                       Foreground="{ThemeResource SystemControlPageTextBaseMediumBrush}"
-                       TextWrapping="Wrap"/>
             <CalendarDatePicker x:Name="AddSubtract_FromDate"
+                                x:Uid="AddSubtract_Date_FromHeader"
                                 Grid.Row="2"
                                 Margin="0,0,0,0"
                                 Style="{StaticResource DateCalculation_CalendarPickerStyle}"


### PR DESCRIPTION
## Fixes #387 


### Description of the changes:
-Initially name of the "From" Calendar picker was bound using the name of the above control
-Bound the name of "From" calendar picker using the id of the above control 


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-manually using the inspect tool


