### PR TITLE
Update bug/feature templates to track if submitter requests assignment

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -53,7 +53,7 @@ Run the following commands in Powershell and copy/paste the output.
 <!--
 Some people just want to report a bug and let someone else fix it.
 Other people want to not only submit the bug report, but fix it as well.
-Both scenarios are completely ok.  We just want to know which one it is.
+Both scenarios are completely ok. We just want to know which one it is.
 Please indicate which bucket you fall into by keeping one and removing the other.
 -->
 If possible, I would like to fix this.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -34,9 +34,9 @@ Steps to reproduce the behavior:
  - OS Build:
  - Architecture:
  - Application Version:
- - Region: 
- - Dev Version Installed: 
- 
+ - Region:
+ - Dev Version Installed:
+
 <!--
 Run the following commands in Powershell and copy/paste the output.
 " - OS Build: $([Environment]::OSVersion.Version)"
@@ -48,3 +48,13 @@ Run the following commands in Powershell and copy/paste the output.
 
 **Additional context**
 <!-- Add any other context about the problem here. -->
+
+**Requested Assignment**
+<!--
+Some people just want to report a bug and let someone else fix.
+Other people want to not only submit the bug report, but want to fix it as well.
+Both scenarios are completely ok.  We just want to know which one it is.
+Please indicate which bucket you fall into by keeping one and removing the other.
+-->
+If possible, I would like to fix this.
+I'm just reporting this problem.  I don't want to fix it.

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -51,8 +51,8 @@ Run the following commands in Powershell and copy/paste the output.
 
 **Requested Assignment**
 <!--
-Some people just want to report a bug and let someone else fix.
-Other people want to not only submit the bug report, but want to fix it as well.
+Some people just want to report a bug and let someone else fix it.
+Other people want to not only submit the bug report, but fix it as well.
 Both scenarios are completely ok.  We just want to know which one it is.
 Please indicate which bucket you fall into by keeping one and removing the other.
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -46,7 +46,7 @@ Show as much of the experience as needed to explain the idea. This can be as sim
 <!--
 Some people just want to suggest a feature and let someone else implement it.
 Other people want to not only suggest a feature, but implement it as well.
-Both scenarios are completely ok.  We just want to know which one it is.
+Both scenarios are completely ok. We just want to know which one it is.
 We are likely to prioritize the review of feature requests if they already have someone who can implement them.
 Please indicate which bucket you fall into by keeping one and removing the other.
 -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -13,7 +13,7 @@ See https://github.com/Microsoft/calculator/blob/master/docs/NewFeatureProcess.m
 
 **Problem Statement**
 <!--
-What problem are we trying to solve? Who’s the target audience? Is there a customer need or pain point we need to remedy? Is there a business goal or metric we are trying to improve? Do we have a hypothesis we want to prove or disprove? 
+What problem are we trying to solve? Who’s the target audience? Is there a customer need or pain point we need to remedy? Is there a business goal or metric we are trying to improve? Do we have a hypothesis we want to prove or disprove?
 -->
 
 **Evidence or User Insights**
@@ -41,3 +41,14 @@ Things we are explicitly not doing or supporting or that are out of scope, inclu
 <!--
 Show as much of the experience as needed to explain the idea. This can be as simple as a napkin drawing but can also be a code prototype, or a design comp. Keep it simple at this stage, as it can be refined later during the pre-production stage.
 -->
+
+**Requested Assignment**
+<!--
+Some people just want to suggest a feature and let someone else implement it.
+Other people want to not only suggest a feature, but want to implement it as well.
+Both scenarios are completely ok.  We just want to know which one it is.
+We are likely to prioritize the review of feature requests if they already have someone who can implement them.
+Please indicate which bucket you fall into by keeping one and removing the other.
+-->
+If possible, I would like to implement this.
+I'm just suggesting this idea.  I don't want to implement it.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -45,7 +45,7 @@ Show as much of the experience as needed to explain the idea. This can be as sim
 **Requested Assignment**
 <!--
 Some people just want to suggest a feature and let someone else implement it.
-Other people want to not only suggest a feature, but want to implement it as well.
+Other people want to not only suggest a feature, but implement it as well.
 Both scenarios are completely ok.  We just want to know which one it is.
 We are likely to prioritize the review of feature requests if they already have someone who can implement them.
 Please indicate which bucket you fall into by keeping one and removing the other.


### PR DESCRIPTION
An additional datapoint that can be helpful during triage of bugs and features
is if the submitter is interested in being the implementor as well.

Updating the bug_report and feature_request templates to help track this.