### PR TITLE
Ensure the calculator uses correctly unary operations when the equal button is pressed

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -711,13 +711,6 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         break;
 
     case IDC_PI:
-
-        m_bNoPrevEqu = true;
-        if (!m_bChangeOp)
-        {
-            m_nOpCode = 0;
-        }
-
         if (!m_fIntegerMode)
         {
             CheckAndAddLastBinOpToHistory(); // pi is like entering the number


### PR DESCRIPTION
## Fixes #264 

### Fix unary actions displaying faulty results when a binary operation was previously

![a2019-03-08_4-36-01](https://user-images.githubusercontent.com/1226538/54029006-e5846800-415b-11e9-8ef1-4911983c11c5.gif)

- Type a random binary operation: `3 + 5` (for example)
- press Enter
- Use an unary action (Power or square root for example)
- press Enter


### Make unary operations (including <kbd>+/-</kbd> ) are repeatable when the equal button is pressed instead of using the last binary action done.

![76B914F7-E585-488A-AEAC-906926574955](https://user-images.githubusercontent.com/1226538/58091046-7e345c80-7b7d-11e9-850d-69c6ee78f791.GIF)

- Type a random binary operation: 3 + 5 (for example)
- press Enter
- Use an unary action (Power or square root for example)
- press Enter
- press Enter
- press Enter

### Description of the changes:
- Add support of unary actions in `ResolveHighestPrecedenceOperation`
- Modify `ProcessCommandWorker` to set `m_nOpCode`, `m_bNoPrevEqu` when an unary action is used.

### How changes were validated:
- manually tested


