### PR TITLE
Migrate currency converter endpoints into the 1904 version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -290,6 +290,7 @@ __pycache__/
 # Calculator specific
 Generated Files/
 src/GraphControl/GraphingImplOverrides.props
+src/CalcViewModel/DataLoaders/DataLoaderConstants.h
 !/build/config/TRexDefs/**
 !src/Calculator/TemporaryKey.pfx
 !src/CalculatorUnitTests/CalculatorUnitTests_TemporaryKey.pfx

--- a/build/pipelines/templates/build-app-internal.yaml
+++ b/build/pipelines/templates/build-app-internal.yaml
@@ -29,7 +29,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.10
+      vstsPackageVersion: 0.0.11
 
   - template: ./build-single-architecture.yaml
     parameters:

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -91,7 +91,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.10
+      vstsPackageVersion: 0.0.11
 
   - task: PkgESStoreBrokerPackage@10
     displayName: Create StoreBroker Packages

--- a/src/CalcViewModel/CalcViewModel.vcxproj
+++ b/src/CalcViewModel/CalcViewModel.vcxproj
@@ -408,6 +408,23 @@
       <Project>{311e866d-8b93-4609-a691-265941fee101}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemDefinitionGroup Condition="!Exists('DataLoaders\DataLoaderConstants.h')">
+    <ClCompile>
+      <AdditionalOptions>/DUSE_MOCK_DATA %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <Choose>
+	<When Condition="Exists('DataLoaders\DataLoaderConstants.h')">
+	  <ItemGroup>
+		<ClInclude Include="DataLoaders\DataLoaderConstants.h" />
+	  </ItemGroup>
+	</When>
+	<Otherwise>
+	  <ItemGroup>
+		<ClInclude Include="DataLoaders\DataLoaderMockConstants.h" />
+	  </ItemGroup>
+	</Otherwise>
+  </Choose>
   <ItemGroup>
     <None Include="DataLoaders\DefaultFromToCurrency.json" />
     <None Include="packages.config" />

--- a/src/CalcViewModel/CalcViewModel.vcxproj.filters
+++ b/src/CalcViewModel/CalcViewModel.vcxproj.filters
@@ -213,6 +213,12 @@
     <ClInclude Include="Common\TraceActivity.h">
       <Filter>Common</Filter>
     </ClInclude>
+    <ClInclude Include="DataLoaders\DataLoaderMockConstants.h">
+      <Filter>DataLoaders</Filter>
+    </ClInclude>
+	<ClInclude Include="DataLoaders\DataLoaderConstants.h">
+      <Filter>DataLoaders</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="DataLoaders\DefaultFromToCurrency.json">

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -530,7 +530,15 @@ bool CurrencyDataLoader::TryParseStaticData(_In_ String^ rawJson, _Inout_ vector
     staticData.resize(size_t{ data->Size });
     for (unsigned int i = 0; i < data->Size; i++)
     {
-        JsonObject^ obj = data->GetAt(i)->GetObject();
+        JsonObject ^ obj;
+        try
+        {
+            obj = data->GetAt(i)->GetObject();
+        }
+        catch (...)
+        {
+            continue;
+        }
 
         for (size_t j = 0; j < values.size(); j++)
         {
@@ -568,7 +576,15 @@ bool CurrencyDataLoader::TryParseAllRatiosData(_In_ String^ rawJson, _Inout_ Cur
     allRatios.clear();
     for (unsigned int i = 0; i < data->Size; i++)
     {
-        JsonObject^ obj = data->GetAt(i)->GetObject();
+        JsonObject ^ obj;
+        try
+        {
+            obj = data->GetAt(i)->GetObject();
+        }
+        catch (...)
+        {
+            continue;
+        }
 
         // Rt is ratio, An is target currency ISO code.
         double relativeRatio = obj->GetNamedNumber(StringReference(RATIO_KEY));

--- a/src/CalcViewModel/DataLoaders/CurrencyHttpClient.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyHttpClient.cpp
@@ -1,17 +1,19 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include "pch.h"
 #include "CurrencyHttpClient.h"
+#ifdef USE_MOCK_DATA
+#include "DataLoaderMockConstants.h"
+#else
+#include "DataLoaderConstants.h"
+#endif
 
 using namespace CalculatorApp::DataLoaders;
 using namespace Platform;
 using namespace std;
 using namespace Windows::Foundation;
 using namespace Windows::Web::Http;
-
-static constexpr auto sc_MetadataUriLocalizeFor = L"https://go.microsoft.com/fwlink/?linkid=2041093&localizeFor=";
-static constexpr auto sc_RatiosUriRelativeTo = L"https://go.microsoft.com/fwlink/?linkid=2041339&localCurrency=";
 
 CurrencyHttpClient::CurrencyHttpClient() :
     m_client(ref new HttpClient()),

--- a/src/CalcViewModel/DataLoaders/DataLoaderMockConstants.h
+++ b/src/CalcViewModel/DataLoaders/DataLoaderMockConstants.h
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace CalculatorApp
+{
+    namespace DataLoaders
+    {
+        static constexpr auto sc_MetadataUriLocalizeFor = L"https://go.microsoft.com/fwlink/?linkid=2091028&localizeFor=";
+        static constexpr auto sc_RatiosUriRelativeTo = L"https://go.microsoft.com/fwlink/?linkid=2091307&localCurrency=";
+    }
+}


### PR DESCRIPTION
## Fixes #77


### Description of the changes:
We are migrating the REST endpoint that Currency Converter uses.  The REST endpoint is not licensed for your use.  To continue to enable community participation in the development of the feature, developer builds will use an alternate REST endpoint that serves mock data (clearly identifiable as it references planets instead of countries).

### How changes were validated:
Manual testing

