### PR TITLE
Improving accessibility in scan mode

### DIFF
--- a/src/Calculator/Controls/HorizontalNoOverflowStackPanel.cpp
+++ b/src/Calculator/Controls/HorizontalNoOverflowStackPanel.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 //
@@ -59,7 +59,7 @@ Size HorizontalNoOverflowStackPanel::ArrangeOverride(Size finalSize)
         {
             // stack the items horizontally (left to right)
             item->Arrange(Rect(posX, 0, itemWidth, finalSize.Height));
-            AutomationProperties::SetAccessibilityView(item, ::AccessibilityView::Control);
+            AutomationProperties::SetAccessibilityView(item, ::AccessibilityView::Content);
             posX += item->RenderSize.Width;
         }
         else

--- a/src/Calculator/Controls/HorizontalNoOverflowStackPanel.cpp
+++ b/src/Calculator/Controls/HorizontalNoOverflowStackPanel.cpp
@@ -12,6 +12,8 @@
 using namespace std;
 using namespace CalculatorApp::Controls;
 using namespace Windows::Foundation;
+using namespace Windows::UI::Xaml::Automation;
+using namespace Windows::UI::Xaml::Automation::Peers;
 
 Size HorizontalNoOverflowStackPanel::MeasureOverride(Size availableSize)
 {
@@ -57,12 +59,14 @@ Size HorizontalNoOverflowStackPanel::ArrangeOverride(Size finalSize)
         {
             // stack the items horizontally (left to right)
             item->Arrange(Rect(posX, 0, itemWidth, finalSize.Height));
+            AutomationProperties::SetAccessibilityView(item, ::AccessibilityView::Control);
             posX += item->RenderSize.Width;
         }
         else
         {
             // Not display the item
             item->Arrange(Rect(0, 0, 0, 0));
+            AutomationProperties::SetAccessibilityView(item, ::AccessibilityView::Raw);
         }
     }
     return finalSize;


### PR DESCRIPTION
## Fixes #483.

### Description of the changes:
- Sets the AccessibilityView property to Raw and Control for hidden and shown units respectively. These updates are performed in the ArrangeOverride function of the HorizontalNoOverflowStackPanel class.

### How changes were validated:
- Manual/ad-hoc testing based on the steps outlined in #483 was performed and the indicated issue involving Narrator no longer appears.
