### PR TITLE
Port number's mantissa to std::vector

### DIFF
--- a/src/CalcManager/CEngine/History.cpp
+++ b/src/CalcManager/CEngine/History.cpp
@@ -4,6 +4,7 @@
 #include "Header Files/CalcEngine.h"
 #include "Command.h"
 #include "ExpressionCommand.h"
+#include "winerror_cross_platform.h"
 
 constexpr int ASCII_0 = 48;
 

--- a/src/CalcManager/CEngine/Number.cpp
+++ b/src/CalcManager/CEngine/Number.cpp
@@ -19,28 +19,22 @@ namespace CalcEngine
     {
     }
 
-    Number::Number(PNUMBER p) noexcept
-        : m_sign{ p->sign }
-        , m_exp{ p->exp }
+    Number::Number(NUMBER p) noexcept
+        : m_sign{ p.sign }
+        , m_exp{ p.exp }
         , m_mantissa{}
     {
-        m_mantissa.reserve(p->cdigit);
-        copy(p->mant, p->mant + p->cdigit, back_inserter(m_mantissa));
+        m_mantissa.reserve(p.cdigit);
+        copy(p.mant.begin(), p.mant.begin() + p.cdigit, back_inserter(m_mantissa));
     }
 
-    PNUMBER Number::ToPNUMBER() const
+    NUMBER Number::ToNUMBER() const
     {
-        PNUMBER ret = _createnum(static_cast<uint32_t>(this->Mantissa().size()) + 1);
-        ret->sign = this->Sign();
-        ret->exp = this->Exp();
-        ret->cdigit = static_cast<int32_t>(this->Mantissa().size());
-
-        MANTTYPE* ptrRet = ret->mant;
-        for (auto const& digit : this->Mantissa())
-        {
-            *ptrRet++ = digit;
-        }
-
+        NUMBER ret = _createnum(static_cast<uint32_t>(this->Mantissa().size()) + 1);
+        ret.sign = this->Sign();
+        ret.exp = this->Exp();
+        ret.cdigit = static_cast<int32_t>(this->Mantissa().size());
+        ret.mant = this->Mantissa();
         return ret;
     }
 

--- a/src/CalcManager/CEngine/Rational.cpp
+++ b/src/CalcManager/CEngine/Rational.cpp
@@ -52,8 +52,8 @@ namespace CalcEngine
 
     Rational::Rational(uint64_t ui)
     {
-        uint32_t hi = (uint32_t) (((ui) >> 32) & 0xffffffff);
-        uint32_t lo = (uint32_t) ui;
+        uint32_t hi = (uint32_t)(((ui) >> 32) & 0xffffffff);
+        uint32_t lo = (uint32_t)ui;
 
         Rational temp = (Rational{ hi } << 32) | lo;
 
@@ -71,8 +71,8 @@ namespace CalcEngine
     {
         PRAT ret = _createrat();
 
-        ret->pp = this->P().ToPNUMBER();
-        ret->pq = this->Q().ToPNUMBER();
+        ret->pp = this->P().ToNUMBER();
+        ret->pq = this->Q().ToNUMBER();
 
         return ret;
     }

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -13,7 +13,9 @@
 * Author:
 \****************************************************************************/
 
+#include <iomanip>
 #include <string>
+#include <sstream>
 #include "Header Files/CalcEngine.h"
 #include "Header Files/CalcUtils.h"
 #include "NumberFormattingUtils.h"

--- a/src/CalcManager/CEngine/scifunc.cpp
+++ b/src/CalcManager/CEngine/scifunc.cpp
@@ -16,7 +16,9 @@
 /***                                                                    ***/
 /***                                                                    ***/
 /**************************************************************************/
+
 #include "Header Files/CalcEngine.h"
+#include "winerror_cross_platform.h"
 
 using namespace std;
 using namespace CalcEngine;

--- a/src/CalcManager/CMakeLists.txt
+++ b/src/CalcManager/CMakeLists.txt
@@ -2,7 +2,6 @@ add_library(CalcManager
 	CalculatorHistory.cpp
 	CalculatorManager.cpp
 	ExpressionCommand.cpp
-	pch.cpp
 	UnitConverter.cpp
 )
 target_include_directories(CalcManager PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/CalcManager/CMakeLists.txt
+++ b/src/CalcManager/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(CalcManager
 	CalculatorHistory.cpp
 	CalculatorManager.cpp
 	ExpressionCommand.cpp
+	NumberFormattingUtils.cpp
 	UnitConverter.cpp
 )
 target_include_directories(CalcManager PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/CalcManager/CalculatorHistory.cpp
+++ b/src/CalcManager/CalculatorHistory.cpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include "CalculatorHistory.h"
+#include "sal_cross_platform.h"
 
 using namespace std;
 using namespace CalculationManager;

--- a/src/CalcManager/CalculatorHistory.h
+++ b/src/CalcManager/CalculatorHistory.h
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #pragma once
+#include <string>
 #include "ExpressionCommandInterface.h"
 #include "Header Files/IHistoryDisplay.h"
 

--- a/src/CalcManager/ExpressionCommandInterface.h
+++ b/src/CalcManager/ExpressionCommandInterface.h
@@ -6,6 +6,7 @@
 #include <memory> // for std::shared_ptr
 #include <vector>
 #include "Command.h"
+#include "sal_cross_platform.h"
 
 class ISerializeCommandVisitor;
 

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -27,6 +27,8 @@
 #include "Rational.h"
 #include "RationalMath.h"
 
+#include <array>
+
 // The following are NOT real exports of CalcEngine, but for forward declarations
 // The real exports follows later
 

--- a/src/CalcManager/Header Files/IHistoryDisplay.h
+++ b/src/CalcManager/Header Files/IHistoryDisplay.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <string_view>
 #include "../ExpressionCommandInterface.h"
 
 // Callback interface to be implemented by the clients of CCalcEngine if they require equation history

--- a/src/CalcManager/Header Files/Number.h
+++ b/src/CalcManager/Header Files/Number.h
@@ -14,8 +14,8 @@ namespace CalcEngine
         Number() noexcept;
         Number(int32_t sign, int32_t exp, std::vector<uint32_t> const& mantissa) noexcept;
 
-        explicit Number(PNUMBER p) noexcept;
-        PNUMBER ToPNUMBER() const;
+        explicit Number(NUMBER p) noexcept;
+        NUMBER ToNUMBER() const;
 
         int32_t const& Sign() const;
         int32_t const& Exp() const;

--- a/src/CalcManager/NumberFormattingUtils.cpp
+++ b/src/CalcManager/NumberFormattingUtils.cpp
@@ -1,5 +1,6 @@
-#include "pch.h"
 #include "NumberFormattingUtils.h"
+#include <cmath>
+#include <sstream>
 
 using namespace std;
 

--- a/src/CalcManager/NumberFormattingUtils.h
+++ b/src/CalcManager/NumberFormattingUtils.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "sal_cross_platform.h"
 #include <string>
 
 namespace CalcManager::NumberFormattingUtils

--- a/src/CalcManager/Ratpack/basex.cpp
+++ b/src/CalcManager/Ratpack/basex.cpp
@@ -17,7 +17,9 @@
 #include "ratpak.h"
 #include <cstring> // for memmove
 
-void _mulnumx(PNUMBER* pa, PNUMBER b);
+using namespace std;
+
+void _mulnumx(NUMBER* pa, const NUMBER& b);
 
 //----------------------------------------------------------------------------
 //
@@ -34,13 +36,13 @@ void _mulnumx(PNUMBER* pa, PNUMBER b);
 //
 //----------------------------------------------------------------------------
 
-void mulnumx(_Inout_ PNUMBER* pa, _In_ PNUMBER b)
+void mulnumx(_Inout_ NUMBER* pa, _In_ const NUMBER& b)
 
 {
-    if (b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0)
+    if (b.cdigit > 1 || b.mant[0] != 1 || b.exp != 0)
     {
         // If b is not one we multiply
-        if ((*pa)->cdigit > 1 || (*pa)->mant[0] != 1 || (*pa)->exp != 0)
+        if ((*pa).cdigit > 1 || (*pa).mant[0] != 1 || (*pa).exp != 0)
         {
             // pa and b are both non-one.
             _mulnumx(pa, b);
@@ -48,15 +50,15 @@ void mulnumx(_Inout_ PNUMBER* pa, _In_ PNUMBER b)
         else
         {
             // if pa is one and b isn't just copy b. and adjust the sign.
-            int32_t sign = (*pa)->sign;
+            int32_t sign = (*pa).sign;
             DUPNUM(*pa, b);
-            (*pa)->sign *= sign;
+            (*pa).sign *= sign;
         }
     }
     else
     {
         // B is +/- 1, But we do have to set the sign.
-        (*pa)->sign *= b->sign;
+        (*pa).sign *= b.sign;
     }
 }
 
@@ -76,45 +78,45 @@ void mulnumx(_Inout_ PNUMBER* pa, _In_ PNUMBER b)
 //
 //----------------------------------------------------------------------------
 
-void _mulnumx(PNUMBER* pa, PNUMBER b)
+void _mulnumx(NUMBER* pa, const NUMBER& b)
 
 {
-    PNUMBER c = nullptr;  // c will contain the result.
-    PNUMBER a = nullptr;  // a is the dereferenced number pointer from *pa
-    MANTTYPE* ptra;       // ptra is a pointer to the mantissa of a.
-    MANTTYPE* ptrb;       // ptrb is a pointer to the mantissa of b.
-    MANTTYPE* ptrc;       // ptrc is a pointer to the mantissa of c.
-    MANTTYPE* ptrcoffset; // ptrcoffset, is the anchor location of the next
-                          // single digit multiply partial result.
-    int32_t iadigit = 0;  // Index of digit being used in the first number.
-    int32_t ibdigit = 0;  // Index of digit being used in the second number.
-    MANTTYPE da = 0;      // da is the digit from the fist number.
-    TWO_MANTTYPE cy = 0;  // cy is the carry resulting from the addition of
-                          // a multiplied row into the result.
-    TWO_MANTTYPE mcy = 0; // mcy is the resultant from a single
-                          // multiply, AND the carry of that multiply.
-    int32_t icdigit = 0;  // Index of digit being calculated in final result.
+    NUMBER c;                              // c will contain the result.
+    NUMBER a;                              // a is the dereferenced number pointer from *pa
+    vector<MANTTYPE>::iterator ptra;       // ptra is an iterator pointing to the mantissa of a.
+    vector<MANTTYPE>::const_iterator ptrb; // ptrb is an iterator pointing to the mantissa of b.
+    vector<MANTTYPE>::iterator ptrc;       // ptrc is an iterator pointing to the mantissa of c.
+    vector<MANTTYPE>::iterator ptrcoffset; // ptrcoffset, is the anchor location of the next
+                                           // single digit multiply partial result.
+    int32_t iadigit = 0;                   // Index of digit being used in the first number.
+    int32_t ibdigit = 0;                   // Index of digit being used in the second number.
+    MANTTYPE da = 0;                       // da is the digit from the fist number.
+    TWO_MANTTYPE cy = 0;                   // cy is the carry resulting from the addition of
+                                           // a multiplied row into the result.
+    TWO_MANTTYPE mcy = 0;                  // mcy is the resultant from a single
+                                           // multiply, AND the carry of that multiply.
+    int32_t icdigit = 0;                   // Index of digit being calculated in final result.
 
     a = *pa;
 
-    ibdigit = a->cdigit + b->cdigit - 1;
+    ibdigit = a.cdigit + b.cdigit - 1;
     createnum(c, ibdigit + 1);
-    c->cdigit = ibdigit;
-    c->sign = a->sign * b->sign;
+    c.cdigit = ibdigit;
+    c.sign = a.sign * b.sign;
 
-    c->exp = a->exp + b->exp;
-    ptra = a->mant;
-    ptrcoffset = c->mant;
+    c.exp = a.exp + b.exp;
+    ptra = a.mant.begin();
+    ptrcoffset = c.mant.begin();
 
-    for (iadigit = a->cdigit; iadigit > 0; iadigit--)
+    for (iadigit = a.cdigit; iadigit > 0; iadigit--)
     {
         da = *ptra++;
-        ptrb = b->mant;
+        ptrb = b.mant.begin();
 
         // Shift ptrc, and ptrcoffset, one for each digit
         ptrc = ptrcoffset++;
 
-        for (ibdigit = b->cdigit; ibdigit > 0; ibdigit--)
+        for (ibdigit = b.cdigit; ibdigit > 0; ibdigit--)
         {
             cy = 0;
             mcy = (uint64_t)da * (*ptrb);
@@ -123,7 +125,7 @@ void _mulnumx(PNUMBER* pa, PNUMBER b)
                 icdigit = 0;
                 if (ibdigit == 1 && iadigit == 1)
                 {
-                    c->cdigit++;
+                    c.cdigit++;
                 }
             }
 
@@ -148,12 +150,11 @@ void _mulnumx(PNUMBER* pa, PNUMBER b)
 
     // prevent different kinds of zeros, by stripping leading duplicate zeros.
     // digits are in order of increasing significance.
-    while (c->cdigit > 1 && c->mant[c->cdigit - 1] == 0)
+    while (c.cdigit > 1 && c.mant[c.cdigit - 1] == 0)
     {
-        c->cdigit--;
+        c.cdigit--;
     }
 
-    destroynum(*pa);
     *pa = c;
 }
 //-----------------------------------------------------------------------------
@@ -172,10 +173,10 @@ void _mulnumx(PNUMBER* pa, PNUMBER b)
 //
 //-----------------------------------------------------------------------------
 
-void numpowi32x(_Inout_ PNUMBER* proot, int32_t power)
+void numpowi32x(_Inout_ NUMBER* proot, int32_t power)
 
 {
-    PNUMBER lret = i32tonum(1, BASEX);
+    NUMBER lret = i32tonum(1, BASEX);
 
     // Once the power remaining is zero we are done.
     while (power > 0)
@@ -194,11 +195,10 @@ void numpowi32x(_Inout_ PNUMBER* proot, int32_t power)
         // move the next bit of the power into place.
         power >>= 1;
     }
-    destroynum(*proot);
     *proot = lret;
 }
 
-void _divnumx(PNUMBER* pa, PNUMBER b, int32_t precision);
+void _divnumx(NUMBER* pa, const NUMBER& b, int32_t precision);
 
 //----------------------------------------------------------------------------
 //
@@ -215,13 +215,13 @@ void _divnumx(PNUMBER* pa, PNUMBER b, int32_t precision);
 //
 //----------------------------------------------------------------------------
 
-void divnumx(_Inout_ PNUMBER* pa, _In_ PNUMBER b, int32_t precision)
+void divnumx(_Inout_ NUMBER* pa, _In_ const NUMBER& b, int32_t precision)
 
 {
-    if (b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0)
+    if (b.cdigit > 1 || b.mant[0] != 1 || b.exp != 0)
     {
         // b is not one.
-        if ((*pa)->cdigit > 1 || (*pa)->mant[0] != 1 || (*pa)->exp != 0)
+        if ((*pa).cdigit > 1 || (*pa).mant[0] != 1 || (*pa).exp != 0)
         {
             // pa and b are both not one.
             _divnumx(pa, b, precision);
@@ -229,15 +229,15 @@ void divnumx(_Inout_ PNUMBER* pa, _In_ PNUMBER b, int32_t precision)
         else
         {
             // if pa is one and b is not one, just copy b, and adjust the sign.
-            int32_t sign = (*pa)->sign;
+            int32_t sign = (*pa).sign;
             DUPNUM(*pa, b);
-            (*pa)->sign *= sign;
+            (*pa).sign *= sign;
         }
     }
     else
     {
         // b is one so don't divide, but set the sign.
-        (*pa)->sign *= b->sign;
+        (*pa).sign *= b.sign;
     }
 }
 
@@ -254,47 +254,47 @@ void divnumx(_Inout_ PNUMBER* pa, _In_ PNUMBER b, int32_t precision)
 //
 //----------------------------------------------------------------------------
 
-void _divnumx(PNUMBER* pa, PNUMBER b, int32_t precision)
+void _divnumx(NUMBER* pa, const NUMBER& b, int32_t precision)
 
 {
-    PNUMBER a = nullptr;       // a is the dereferenced number pointer from *pa
-    PNUMBER c = nullptr;       // c will contain the result.
-    PNUMBER lasttmp = nullptr; // lasttmp allows a backup when the algorithm
-                               // guesses one bit too far.
-    PNUMBER tmp = nullptr;     // current guess being worked on for divide.
-    PNUMBER rem = nullptr;     // remainder after applying guess.
-    int32_t cdigits;           // count of digits for answer.
-    MANTTYPE* ptrc;            // ptrc is a pointer to the mantissa of c.
+    NUMBER a;                        // a is the dereferenced number pointer from *pa
+    NUMBER c;                        // c will contain the result.
+    optional<NUMBER> lasttmp;        // lasttmp allows a backup when the algorithm
+                                     // guesses one bit too far.
+    optional<NUMBER> tmp;            // current guess being worked on for divide.
+    NUMBER rem;                      // remainder after applying guess.
+    int32_t cdigits;                 // count of digits for answer.
+    vector<MANTTYPE>::iterator ptrc; // ptrc is an iterator pointing to the mantissa of c.
 
     int32_t thismax = precision + g_ratio; // set a maximum number of internal digits
                                            // to shoot for in the divide.
 
     a = *pa;
-    if (thismax < a->cdigit)
+    if (thismax < a.cdigit)
     {
         // a has more digits than precision specified, bump up digits to shoot
         // for.
-        thismax = a->cdigit;
+        thismax = a.cdigit;
     }
 
-    if (thismax < b->cdigit)
+    if (thismax < b.cdigit)
     {
         // b has more digits than precision specified, bump up digits to shoot
         // for.
-        thismax = b->cdigit;
+        thismax = b.cdigit;
     }
 
     // Create c (the divide answer) and set up exponent and sign.
     createnum(c, thismax + 1);
-    c->exp = (a->cdigit + a->exp) - (b->cdigit + b->exp) + 1;
-    c->sign = a->sign * b->sign;
+    c.exp = (a.cdigit + a.exp) - (b.cdigit + b.exp) + 1;
+    c.sign = a.sign * b.sign;
 
-    ptrc = c->mant + thismax;
+    ptrc = c.mant.begin() + thismax;
     cdigits = 0;
 
     DUPNUM(rem, a);
-    rem->sign = b->sign;
-    rem->exp = b->cdigit + b->exp - rem->cdigit;
+    rem.sign = b.sign;
+    rem.exp = b.cdigit + b.exp - rem.cdigit;
 
     while (cdigits++ < thismax && !zernum(rem))
     {
@@ -303,60 +303,52 @@ void _divnumx(PNUMBER* pa, PNUMBER b, int32_t precision)
         while (!lessnum(rem, b))
         {
             digit = 1;
-            DUPNUM(tmp, b);
-            destroynum(lasttmp);
+            tmp = b;
             lasttmp = i32tonum(0, BASEX);
-            while (lessnum(tmp, rem))
+            while (lessnum(*tmp, rem))
             {
-                destroynum(lasttmp);
-                DUPNUM(lasttmp, tmp);
-                addnum(&tmp, tmp, BASEX);
+                lasttmp = tmp;
+                addnum(&*tmp, *tmp, BASEX);
                 digit *= 2;
             }
-            if (lessnum(rem, tmp))
+            if (lessnum(rem, *tmp))
             {
                 // too far, back up...
-                destroynum(tmp);
                 digit /= 2;
                 tmp = lasttmp;
-                lasttmp = nullptr;
+                lasttmp = optional<NUMBER>();
             }
 
             tmp->sign *= -1;
-            addnum(&rem, tmp, BASEX);
-            destroynum(tmp);
-            destroynum(lasttmp);
+            addnum(&rem, *tmp, BASEX);
             *ptrc |= digit;
         }
-        rem->exp++;
+        rem.exp++;
         ptrc--;
     }
     cdigits--;
-    if (c->mant != ++ptrc)
+    if (c.mant.begin() != ++ptrc)
     {
-        memmove(c->mant, ptrc, (int)(cdigits * sizeof(MANTTYPE)));
+        copy(ptrc, ptrc + cdigits, c.mant.begin());
     }
 
     if (!cdigits)
     {
         // A zero, make sure no weird exponents creep in
-        c->exp = 0;
-        c->cdigit = 1;
+        c.exp = 0;
+        c.cdigit = 1;
     }
     else
     {
-        c->cdigit = cdigits;
-        c->exp -= cdigits;
+        c.cdigit = cdigits;
+        c.exp -= cdigits;
         // prevent different kinds of zeros, by stripping leading duplicate
         // zeros. digits are in order of increasing significance.
-        while (c->cdigit > 1 && c->mant[c->cdigit - 1] == 0)
+        while (c.cdigit > 1 && c.mant[c.cdigit - 1] == 0)
         {
-            c->cdigit--;
+            c.cdigit--;
         }
     }
 
-    destroynum(rem);
-
-    destroynum(*pa);
     *pa = c;
 }

--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -63,7 +63,7 @@ wchar_t g_decimalSeparator = L'.';
 #define CALC_ULONG_ERROR ((uint32_t)0xffffffffU)
 
 // Used to strip trailing zeros, and prevent combinatorial explosions
-bool stripzeroesnum(_Inout_ NUMBER pnum, int32_t starting);
+bool stripzeroesnum(_Inout_ NUMBER& pnum, int32_t starting);
 
 void SetDecimalSeparator(wchar_t decimalSeparator)
 {
@@ -947,7 +947,7 @@ int32_t numtoi32(_In_ const NUMBER& pnum, uint32_t radix)
 //
 //-----------------------------------------------------------------------------
 
-bool stripzeroesnum(_Inout_ NUMBER pnum, int32_t starting)
+bool stripzeroesnum(_Inout_ NUMBER& pnum, int32_t starting)
 {
     vector<MANTTYPE>::iterator pmant;
     int32_t cdigits;

--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -62,44 +62,6 @@ wchar_t g_decimalSeparator = L'.';
 #define CALC_INTSAFE_E_ARITHMETIC_OVERFLOW ((int32_t)0x80070216L) // 0x216 = 534 = ERROR_ARITHMETIC_OVERFLOW
 #define CALC_ULONG_ERROR ((uint32_t)0xffffffffU)
 
-namespace
-{
-    int32_t Calc_ULongAdd(_In_ uint32_t ulAugend, _In_ uint32_t ulAddend, _Out_ uint32_t* pulResult)
-    {
-        int32_t hr = CALC_INTSAFE_E_ARITHMETIC_OVERFLOW;
-        *pulResult = CALC_ULONG_ERROR;
-
-        if ((ulAugend + ulAddend) >= ulAugend)
-        {
-            *pulResult = (ulAugend + ulAddend);
-            hr = S_OK;
-        }
-
-        return hr;
-    }
-
-    int32_t Calc_ULongLongToULong(_In_ uint64_t ullOperand, _Out_ uint32_t* pulResult)
-    {
-        int32_t hr = CALC_INTSAFE_E_ARITHMETIC_OVERFLOW;
-        *pulResult = CALC_ULONG_ERROR;
-
-        if (ullOperand <= UINT32_MAX)
-        {
-            *pulResult = (uint32_t)ullOperand;
-            hr = S_OK;
-        }
-
-        return hr;
-    }
-
-    int32_t Calc_ULongMult(_In_ uint32_t ulMultiplicand, _In_ uint32_t ulMultiplier, _Out_ uint32_t* pulResult)
-    {
-        uint64_t ull64Result = Calc_UInt32x32To64(ulMultiplicand, ulMultiplier);
-
-        return Calc_ULongLongToULong(ull64Result, pulResult);
-    }
-}
-
 // Used to strip trailing zeros, and prevent combinatorial explosions
 bool stripzeroesnum(_Inout_ NUMBER pnum, int32_t starting);
 

--- a/src/CalcManager/Ratpack/exp.cpp
+++ b/src/CalcManager/Ratpack/exp.cpp
@@ -405,7 +405,7 @@ void powratNumeratorDenominator(_Inout_ PRAT* px, _In_ PRAT y, uint32_t radix, i
 //---------------------------------------------------------------------------
 void powratcomp(_Inout_ PRAT* px, _In_ PRAT y, uint32_t radix, int32_t precision)
 {
-    int32_t sign = ((*px)->pp.sign * (*px)->pq.sign);
+    int32_t sign = SIGN(*px);
 
     // Take the absolute value
     (*px)->pp.sign = 1;

--- a/src/CalcManager/Ratpack/exp.cpp
+++ b/src/CalcManager/Ratpack/exp.cpp
@@ -131,15 +131,15 @@ void _lograt(PRAT* px, int32_t precision)
     createrat(thisterm);
 
     // sub one from x
-    (*px)->pq->sign *= -1;
+    (*px)->pq.sign *= -1;
     addnum(&((*px)->pp), (*px)->pq, BASEX);
-    (*px)->pq->sign *= -1;
+    (*px)->pq.sign *= -1;
 
     DUPRAT(pret, *px);
     DUPRAT(thisterm, *px);
 
     n2 = i32tonum(1L, BASEX);
-    (*px)->pp->sign *= -1;
+    (*px)->pp.sign *= -1;
 
     do
     {
@@ -168,7 +168,7 @@ void lograt(_Inout_ PRAT* px, int32_t precision)
     if (fneglog)
     {
         // WARNING: This is equivalent to doing *px = 1 / *px
-        PNUMBER pnumtemp = nullptr;
+        NUMBER pnumtemp;
         pnumtemp = (*px)->pp;
         (*px)->pp = (*px)->pq;
         (*px)->pq = pnumtemp;
@@ -182,7 +182,7 @@ void lograt(_Inout_ PRAT* px, int32_t precision)
         // a reasonable range.
         int32_t intpwr;
         intpwr = LOGRAT2(*px) - 1;
-        (*px)->pq->exp += intpwr;
+        (*px)->pq.exp += intpwr;
         pwr = i32torat(intpwr * BASEXPWR);
         mulrat(&pwr, ln_two, precision);
         // ln(x+e)-ln(x) looks close to e when x is close to one using some
@@ -217,7 +217,7 @@ void lograt(_Inout_ PRAT* px, int32_t precision)
     // If number started out < 1 rescale answer to negative.
     if (fneglog)
     {
-        (*px)->pp->sign *= -1;
+        (*px)->pp.sign *= -1;
     }
 
     destroyrat(offset);
@@ -344,7 +344,7 @@ void powratNumeratorDenominator(_Inout_ PRAT* px, _In_ PRAT y, uint32_t radix, i
         // ##################################
         PRAT roundedResult = nullptr;
         DUPRAT(roundedResult, originalResult);
-        if (roundedResult->pp->sign == -1)
+        if (roundedResult->pp.sign == -1)
         {
             subrat(&roundedResult, rat_half, precision);
         }
@@ -405,11 +405,11 @@ void powratNumeratorDenominator(_Inout_ PRAT* px, _In_ PRAT y, uint32_t radix, i
 //---------------------------------------------------------------------------
 void powratcomp(_Inout_ PRAT* px, _In_ PRAT y, uint32_t radix, int32_t precision)
 {
-    int32_t sign = SIGN(*px);
+    int32_t sign = ((*px)->pp.sign * (*px)->pq.sign);
 
     // Take the absolute value
-    (*px)->pp->sign = 1;
-    (*px)->pq->sign = 1;
+    (*px)->pp.sign = 1;
+    (*px)->pq.sign = 1;
 
     if (zerrat(*px))
     {
@@ -492,9 +492,9 @@ void powratcomp(_Inout_ PRAT* px, _In_ PRAT y, uint32_t radix, int32_t precision
                     DUPRAT(pDenominator, rat_zero); // pDenominator->pq is 1 one
 
                     DUPNUM(pNumerator->pp, y->pp);
-                    pNumerator->pp->sign = 1;
+                    pNumerator->pp.sign = 1;
                     DUPNUM(pDenominator->pp, y->pq);
-                    pDenominator->pp->sign = 1;
+                    pDenominator->pp.sign = 1;
 
                     while (IsEven(pNumerator, radix, precision) && IsEven(pDenominator, radix, precision)) // both Numerator & denominator is even
                     {
@@ -531,5 +531,5 @@ void powratcomp(_Inout_ PRAT* px, _In_ PRAT y, uint32_t radix, int32_t precision
         }
         destroyrat(pxint);
     }
-    (*px)->pp->sign *= sign;
+    (*px)->pp.sign *= sign;
 }

--- a/src/CalcManager/Ratpack/fact.cpp
+++ b/src/CalcManager/Ratpack/fact.cpp
@@ -15,8 +15,8 @@
 //-----------------------------------------------------------------------------
 #include "ratpak.h"
 
-#define ABSRAT(x) (((x)->pp->sign = 1), ((x)->pq->sign = 1))
-#define NEGATE(x) ((x)->pp->sign *= -1)
+#define ABSRAT(x) (((x)->pp.sign = 1), ((x)->pq.sign = 1))
+#define NEGATE(x) ((x)->pp.sign *= -1)
 
 //-----------------------------------------------------------------------------
 //
@@ -58,7 +58,7 @@ void _gamma(PRAT* pn, uint32_t radix, int32_t precision)
 
 {
     PRAT factorial = nullptr;
-    PNUMBER count = nullptr;
+    NUMBER count;
     PRAT tmp = nullptr;
     PRAT one_pt_five = nullptr;
     PRAT a = nullptr;
@@ -182,8 +182,6 @@ void _gamma(PRAT* pn, uint32_t radix, int32_t precision)
     destroyrat(tmp);
     destroyrat(one_pt_five);
 
-    destroynum(count);
-
     destroyrat(factorial);
     destroyrat(*pn);
     DUPRAT(*pn, sum);
@@ -206,13 +204,13 @@ void factrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
     DUPRAT(fact, rat_one);
 
     DUPRAT(neg_rat_one, rat_one);
-    neg_rat_one->pp->sign *= -1;
+    neg_rat_one->pp.sign *= -1;
 
     DUPRAT(frac, *px);
     fracrat(&frac, radix, precision);
 
     // Check for negative integers and throw an error.
-    if ((zerrat(frac) || (LOGRATRADIX(frac) <= -precision)) && (SIGN(*px) == -1))
+    if ((zerrat(frac) || (LOGRATRADIX(frac) <= -precision)) && ((*px)->pp.sign * (*px)->pq.sign == -1))
     {
         throw CALC_E_DOMAIN;
     }

--- a/src/CalcManager/Ratpack/fact.cpp
+++ b/src/CalcManager/Ratpack/fact.cpp
@@ -210,7 +210,7 @@ void factrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
     fracrat(&frac, radix, precision);
 
     // Check for negative integers and throw an error.
-    if ((zerrat(frac) || (LOGRATRADIX(frac) <= -precision)) && ((*px)->pp.sign * (*px)->pq.sign == -1))
+    if ((zerrat(frac) || (LOGRATRADIX(frac) <= -precision)) && SIGN(*px) == -1)
     {
         throw CALC_E_DOMAIN;
     }

--- a/src/CalcManager/Ratpack/itrans.cpp
+++ b/src/CalcManager/Ratpack/itrans.cpp
@@ -88,10 +88,11 @@ void asinrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
 {
     PRAT pret = nullptr;
     PRAT phack = nullptr;
+
     int32_t sgn = SIGN(*px);
 
-    (*px)->pp->sign = 1;
-    (*px)->pq->sign = 1;
+    (*px)->pp.sign = 1;
+    (*px)->pq.sign = 1;
 
     // Avoid the really bad part of the asin curve near +/-1.
     DUPRAT(phack, *px);
@@ -121,11 +122,11 @@ void asinrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
             }
             DUPRAT(pret, *px);
             mulrat(px, pret, precision);
-            (*px)->pp->sign *= -1;
+            (*px)->pp.sign *= -1;
             addrat(px, rat_one, precision);
             rootrat(px, rat_two, radix, precision);
             _asinrat(px, precision);
-            (*px)->pp->sign *= -1;
+            (*px)->pp.sign *= -1;
             addrat(px, pi_over_two, precision);
             destroyrat(pret);
         }
@@ -134,8 +135,8 @@ void asinrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
             _asinrat(px, precision);
         }
     }
-    (*px)->pp->sign = sgn;
-    (*px)->pq->sign = 1;
+    (*px)->pp.sign = sgn;
+    (*px)->pq.sign = 1;
 }
 
 //-----------------------------------------------------------------------------
@@ -195,8 +196,8 @@ void acosrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
 {
     int32_t sgn = SIGN(*px);
 
-    (*px)->pp->sign = 1;
-    (*px)->pq->sign = 1;
+    (*px)->pp.sign = 1;
+    (*px)->pq.sign = 1;
 
     if (rat_equ(*px, rat_one, precision))
     {
@@ -211,9 +212,9 @@ void acosrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
     }
     else
     {
-        (*px)->pp->sign = sgn;
+        (*px)->pp.sign = sgn;
         asinrat(px, radix, precision);
-        (*px)->pp->sign *= -1;
+        (*px)->pp.sign *= -1;
         addrat(px, pi_over_two, precision);
     }
 }
@@ -266,7 +267,7 @@ void _atanrat(PRAT* px, int32_t precision)
 
     DUPNUM(n2, num_one);
 
-    xx->pp->sign *= -1;
+    xx->pp.sign *= -1;
 
     do
     {
@@ -280,29 +281,30 @@ void atanrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
 
 {
     PRAT tmpx = nullptr;
+
     int32_t sgn = SIGN(*px);
 
-    (*px)->pp->sign = 1;
-    (*px)->pq->sign = 1;
+    (*px)->pp.sign = 1;
+    (*px)->pq.sign = 1;
 
     if (rat_gt((*px), pt_eight_five, precision))
     {
         if (rat_gt((*px), rat_two, precision))
         {
-            (*px)->pp->sign = sgn;
-            (*px)->pq->sign = 1;
+            (*px)->pp.sign = sgn;
+            (*px)->pq.sign = 1;
             DUPRAT(tmpx, rat_one);
             divrat(&tmpx, (*px), precision);
             _atanrat(&tmpx, precision);
-            tmpx->pp->sign = sgn;
-            tmpx->pq->sign = 1;
+            tmpx->pp.sign = sgn;
+            tmpx->pq.sign = 1;
             DUPRAT(*px, pi_over_two);
             subrat(px, tmpx, precision);
             destroyrat(tmpx);
         }
         else
         {
-            (*px)->pp->sign = sgn;
+            (*px)->pp.sign = sgn;
             DUPRAT(tmpx, *px);
             mulrat(&tmpx, *px, precision);
             addrat(&tmpx, rat_one, precision);
@@ -310,14 +312,14 @@ void atanrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
             divrat(px, tmpx, precision);
             destroyrat(tmpx);
             asinrat(px, radix, precision);
-            (*px)->pp->sign = sgn;
-            (*px)->pq->sign = 1;
+            (*px)->pp.sign = sgn;
+            (*px)->pq.sign = 1;
         }
     }
     else
     {
-        (*px)->pp->sign = sgn;
-        (*px)->pq->sign = 1;
+        (*px)->pp.sign = sgn;
+        (*px)->pq.sign = 1;
         _atanrat(px, precision);
     }
     if (rat_gt(*px, pi_over_two, precision))

--- a/src/CalcManager/Ratpack/itransh.cpp
+++ b/src/CalcManager/Ratpack/itransh.cpp
@@ -53,7 +53,7 @@ void asinhrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
     PRAT neg_pt_eight_five = nullptr;
 
     DUPRAT(neg_pt_eight_five, pt_eight_five);
-    neg_pt_eight_five->pp->sign *= -1;
+    neg_pt_eight_five->pp.sign *= -1;
     if (rat_gt(*px, pt_eight_five, precision) || rat_lt(*px, neg_pt_eight_five, precision))
     {
         PRAT ptmp = nullptr;
@@ -68,7 +68,7 @@ void asinhrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
     else
     {
         CREATETAYLOR();
-        xx->pp->sign *= -1;
+        xx->pp.sign *= -1;
 
         DUPRAT(pret, (*px));
         DUPRAT(thisterm, (*px));
@@ -146,7 +146,7 @@ void atanhrat(_Inout_ PRAT* px, int32_t precision)
     subrat(&ptmp, rat_one, precision);
     addrat(px, rat_one, precision);
     divrat(px, ptmp, precision);
-    (*px)->pp->sign *= -1;
+    (*px)->pp.sign *= -1;
     lograt(px, precision);
     divrat(px, rat_two, precision);
     destroyrat(ptmp);

--- a/src/CalcManager/Ratpack/logic.cpp
+++ b/src/CalcManager/Ratpack/logic.cpp
@@ -64,7 +64,7 @@ void rshrat(_Inout_ PRAT* pa, _In_ PRAT b, uint32_t radix, int32_t precision)
 }
 
 void boolrat(PRAT* pa, PRAT b, int func, uint32_t radix, int32_t precision);
-void boolnum(PNUMBER* pa, PNUMBER b, int func);
+void boolnum(NUMBER* pa, const NUMBER& b, int func);
 
 enum
 {
@@ -129,32 +129,32 @@ void boolrat(PRAT* pa, PRAT b, int func, uint32_t radix, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-void boolnum(PNUMBER* pa, PNUMBER b, int func)
+void boolnum(NUMBER* pa, const NUMBER& b, int func)
 
 {
-    PNUMBER c = nullptr;
-    PNUMBER a = nullptr;
-    MANTTYPE* pcha;
-    MANTTYPE* pchb;
-    MANTTYPE* pchc;
+    NUMBER c;
+    NUMBER a;
+    vector<MANTTYPE>::iterator pcha;
+    vector<MANTTYPE>::const_iterator pchb;
+    vector<MANTTYPE>::iterator pchc;
     int32_t cdigits;
     int32_t mexp;
     MANTTYPE da;
     MANTTYPE db;
 
     a = *pa;
-    cdigits = max(a->cdigit + a->exp, b->cdigit + b->exp) - min(a->exp, b->exp);
+    cdigits = max(a.cdigit + a.exp, b.cdigit + b.exp) - min(a.exp, b.exp);
     createnum(c, cdigits);
-    c->exp = min(a->exp, b->exp);
-    mexp = c->exp;
-    c->cdigit = cdigits;
-    pcha = a->mant;
-    pchb = b->mant;
-    pchc = c->mant;
+    c.exp = min(a.exp, b.exp);
+    mexp = c.exp;
+    c.cdigit = cdigits;
+    pcha = a.mant.begin();
+    pchb = b.mant.begin();
+    pchc = c.mant.begin();
     for (; cdigits > 0; cdigits--, mexp++)
     {
-        da = (((mexp >= a->exp) && (cdigits + a->exp - c->exp > (c->cdigit - a->cdigit))) ? *pcha++ : 0);
-        db = (((mexp >= b->exp) && (cdigits + b->exp - c->exp > (c->cdigit - b->cdigit))) ? *pchb++ : 0);
+        da = (((mexp >= a.exp) && (cdigits + a.exp - c.exp > (c.cdigit - a.cdigit))) ? *pcha++ : 0);
+        db = (((mexp >= b.exp) && (cdigits + b.exp - c.exp > (c.cdigit - b.cdigit))) ? *pchb++ : 0);
         switch (func)
         {
         case FUNC_AND:
@@ -168,12 +168,11 @@ void boolnum(PNUMBER* pa, PNUMBER b, int func)
             break;
         }
     }
-    c->sign = a->sign;
-    while (c->cdigit > 1 && *(--pchc) == 0)
+    c.sign = a.sign;
+    while (c.cdigit > 1 && *(--pchc) == 0)
     {
-        c->cdigit--;
+        c.cdigit--;
     }
-    destroynum(*pa);
     *pa = c;
 }
 

--- a/src/CalcManager/Ratpack/num.cpp
+++ b/src/CalcManager/Ratpack/num.cpp
@@ -41,14 +41,14 @@ using namespace std;
 //
 //----------------------------------------------------------------------------
 
-void _addnum(PNUMBER* pa, PNUMBER b, uint32_t radix);
+void _addnum(NUMBER* pa, const NUMBER& b, uint32_t radix);
 
-void addnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix)
+void addnum(_Inout_ NUMBER* pa, _In_ const NUMBER& b, uint32_t radix)
 
 {
-    if (b->cdigit > 1 || b->mant[0] != 0)
+    if (b.cdigit > 1 || b.mant[0] != 0)
     { // If b is zero we are done.
-        if ((*pa)->cdigit > 1 || (*pa)->mant[0] != 0)
+        if ((*pa).cdigit > 1 || (*pa).mant[0] != 0)
         { // pa and b are both nonzero.
             _addnum(pa, b, radix);
         }
@@ -59,43 +59,43 @@ void addnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix)
     }
 }
 
-void _addnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
+void _addnum(NUMBER* pa, const NUMBER& b, uint32_t radix)
 
 {
-    PNUMBER c = nullptr; // c will contain the result.
-    PNUMBER a = nullptr; // a is the dereferenced number pointer from *pa
-    MANTTYPE* pcha;      // pcha is a pointer to the mantissa of a.
-    MANTTYPE* pchb;      // pchb is a pointer to the mantissa of b.
-    MANTTYPE* pchc;      // pchc is a pointer to the mantissa of c.
-    int32_t cdigits;     // cdigits is the max count of the digits results
-                         // used as a counter.
-    int32_t mexp;        // mexp is the exponent of the result.
-    MANTTYPE da;         // da is a single 'digit' after possible padding.
-    MANTTYPE db;         // db is a single 'digit' after possible padding.
-    MANTTYPE cy = 0;     // cy is the value of a carry after adding two 'digits'
-    int32_t fcompla = 0; // fcompla is a flag to signal a is negative.
-    int32_t fcomplb = 0; // fcomplb is a flag to signal b is negative.
+    NUMBER c;                              // c will contain the result.
+    NUMBER a;                              // a is the dereferenced number pointer from *pa
+    vector<MANTTYPE>::iterator pcha;       // pcha is an iterator pointing to the mantissa of a.
+    vector<MANTTYPE>::const_iterator pchb; // pchb is an iterator pointing to the mantissa of b.
+    vector<MANTTYPE>::iterator pchc;       // pchc is an iterator pointing to the mantissa of c.
+    int32_t cdigits;                       // cdigits is the max count of the digits results
+                                           // used as a counter.
+    int32_t mexp;                          // mexp is the exponent of the result.
+    MANTTYPE da;                           // da is a single 'digit' after possible padding.
+    MANTTYPE db;                           // db is a single 'digit' after possible padding.
+    MANTTYPE cy = 0;                       // cy is the value of a carry after adding two 'digits'
+    int32_t fcompla = 0;                   // fcompla is a flag to signal a is negative.
+    int32_t fcomplb = 0;                   // fcomplb is a flag to signal b is negative.
 
     a = *pa;
 
     // Calculate the overlap of the numbers after alignment, this includes
     // necessary padding 0's
-    cdigits = max(a->cdigit + a->exp, b->cdigit + b->exp) - min(a->exp, b->exp);
+    cdigits = max(a.cdigit + a.exp, b.cdigit + b.exp) - min(a.exp, b.exp);
 
     createnum(c, cdigits + 1);
-    c->exp = min(a->exp, b->exp);
-    mexp = c->exp;
-    c->cdigit = cdigits;
-    pcha = a->mant;
-    pchb = b->mant;
-    pchc = c->mant;
+    c.exp = min(a.exp, b.exp);
+    mexp = c.exp;
+    c.cdigit = cdigits;
+    pcha = a.mant.begin();
+    pchb = b.mant.begin();
+    pchc = c.mant.begin();
 
     // Figure out the sign of the numbers
-    if (a->sign != b->sign)
+    if (a.sign != b.sign)
     {
         cy = 1;
-        fcompla = (a->sign == -1);
-        fcomplb = (b->sign == -1);
+        fcompla = (a.sign == -1);
+        fcomplb = (b.sign == -1);
     }
 
     // Loop over all the digits, real and 0 padded. Here we know a and b are
@@ -103,9 +103,9 @@ void _addnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
     for (; cdigits > 0; cdigits--, mexp++)
     {
         // Get digit from a, taking padding into account.
-        da = (((mexp >= a->exp) && (cdigits + a->exp - c->exp > (c->cdigit - a->cdigit))) ? *pcha++ : 0);
+        da = (((mexp >= a.exp) && (cdigits + a.exp - c.exp > (c.cdigit - a.cdigit))) ? *pcha++ : 0);
         // Get digit from b, taking padding into account.
-        db = (((mexp >= b->exp) && (cdigits + b->exp - c->exp > (c->cdigit - b->cdigit))) ? *pchb++ : 0);
+        db = (((mexp >= b.exp) && (cdigits + b.exp - c.exp > (c.cdigit - b.cdigit))) ? *pchb++ : 0);
 
         // Handle complementing for a and b digit. Might be a better way, but
         // haven't found it yet.
@@ -128,19 +128,19 @@ void _addnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
     if (cy && !(fcompla || fcomplb))
     {
         *pchc++ = cy;
-        c->cdigit++;
+        c.cdigit++;
     }
 
     // Compute sign of result
     if (!(fcompla || fcomplb))
     {
-        c->sign = a->sign;
+        c.sign = a.sign;
     }
     else
     {
         if (cy)
         {
-            c->sign = 1;
+            c.sign = 1;
         }
         else
         {
@@ -148,9 +148,9 @@ void _addnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
             // and all the digits need to be complemented, at one time an
             // attempt to handle this above was made, it turned out to be much
             // slower on average.
-            c->sign = -1;
+            c.sign = -1;
             cy = 1;
-            for ((cdigits = c->cdigit), (pchc = c->mant); cdigits > 0; cdigits--)
+            for ((cdigits = c.cdigit), (pchc = c.mant.begin()); cdigits > 0; cdigits--)
             {
                 cy = (MANTTYPE)radix - (MANTTYPE)1 - *pchc + cy;
                 *pchc++ = (MANTTYPE)(cy % (MANTTYPE)radix);
@@ -161,11 +161,10 @@ void _addnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
 
     // Remove leading zeros, remember digits are in order of
     // increasing significance. i.e. 100 would be 0,0,1
-    while (c->cdigit > 1 && *(--pchc) == 0)
+    while (c.cdigit > 1 && *(--pchc) == 0)
     {
-        c->cdigit--;
+        c.cdigit--;
     }
-    destroynum(*pa);
     *pa = c;
 }
 
@@ -184,68 +183,67 @@ void _addnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
 //
 //----------------------------------------------------------------------------
 
-void _mulnum(PNUMBER* pa, PNUMBER b, uint32_t radix);
+void _mulnum(NUMBER* pa, const NUMBER& b, uint32_t radix);
 
-void mulnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix)
-
+void mulnum(_Inout_ NUMBER* pa, _In_ const NUMBER& b, uint32_t radix)
 {
-    if (b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0)
+    if (b.cdigit > 1 || b.mant[0] != 1 || b.exp != 0)
     { // If b is one we don't multiply exactly.
-        if ((*pa)->cdigit > 1 || (*pa)->mant[0] != 1 || (*pa)->exp != 0)
+        if ((*pa).cdigit > 1 || (*pa).mant[0] != 1 || (*pa).exp != 0)
         { // pa and b are both non-one.
             _mulnum(pa, b, radix);
         }
         else
         { // if pa is one and b isn't just copy b, and adjust the sign.
-            int32_t sign = (*pa)->sign;
+            int32_t sign = (*pa).sign;
             DUPNUM(*pa, b);
-            (*pa)->sign *= sign;
+            (*pa).sign *= sign;
         }
     }
     else
     { // But we do have to set the sign.
-        (*pa)->sign *= b->sign;
+        (*pa).sign *= b.sign;
     }
 }
 
-void _mulnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
+void _mulnum(NUMBER* pa, const NUMBER& b, uint32_t radix)
 
 {
-    PNUMBER c = nullptr;  // c will contain the result.
-    PNUMBER a = nullptr;  // a is the dereferenced number pointer from *pa
-    MANTTYPE* pcha;       // pcha is a pointer to the mantissa of a.
-    MANTTYPE* pchb;       // pchb is a pointer to the mantissa of b.
-    MANTTYPE* pchc;       // pchc is a pointer to the mantissa of c.
-    MANTTYPE* pchcoffset; // pchcoffset, is the anchor location of the next
-                          // single digit multiply partial result.
-    int32_t iadigit = 0;  // Index of digit being used in the first number.
-    int32_t ibdigit = 0;  // Index of digit being used in the second number.
-    MANTTYPE da = 0;      // da is the digit from the fist number.
-    TWO_MANTTYPE cy = 0;  // cy is the carry resulting from the addition of
-                          // a multiplied row into the result.
-    TWO_MANTTYPE mcy = 0; // mcy is the resultant from a single
-                          // multiply, AND the carry of that multiply.
-    int32_t icdigit = 0;  // Index of digit being calculated in final result.
+    NUMBER c;                              // c will contain the result.
+    NUMBER a;                              // a is the dereferenced number pointer from *pa
+    vector<MANTTYPE>::iterator pcha;       // pcha is an iterator pointing to the mantissa of a.
+    vector<MANTTYPE>::const_iterator pchb; // pchb is an iterator pointing to the mantissa of b.
+    vector<MANTTYPE>::iterator pchc;       // pchc is an iterator pointing to the mantissa of c.
+    vector<MANTTYPE>::iterator pchcoffset; // pchcoffset, is the anchor location of the next
+                                           // single digit multiply partial result.
+    int32_t iadigit = 0;                   // Index of digit being used in the first number.
+    int32_t ibdigit = 0;                   // Index of digit being used in the second number.
+    MANTTYPE da = 0;                       // da is the digit from the fist number.
+    TWO_MANTTYPE cy = 0;                   // cy is the carry resulting from the addition of
+                                           // a multiplied row into the result.
+    TWO_MANTTYPE mcy = 0;                  // mcy is the resultant from a single
+                                           // multiply, AND the carry of that multiply.
+    int32_t icdigit = 0;                   // Index of digit being calculated in final result.
 
     a = *pa;
-    ibdigit = a->cdigit + b->cdigit - 1;
+    ibdigit = a.cdigit + b.cdigit - 1;
     createnum(c, ibdigit + 1);
-    c->cdigit = ibdigit;
-    c->sign = a->sign * b->sign;
+    c.cdigit = ibdigit;
+    c.sign = a.sign * b.sign;
 
-    c->exp = a->exp + b->exp;
-    pcha = a->mant;
-    pchcoffset = c->mant;
+    c.exp = a.exp + b.exp;
+    pcha = a.mant.begin();
+    pchcoffset = c.mant.begin();
 
-    for (iadigit = a->cdigit; iadigit > 0; iadigit--)
+    for (iadigit = a.cdigit; iadigit > 0; iadigit--)
     {
         da = *pcha++;
-        pchb = b->mant;
+        pchb = b.mant.begin();
 
         // Shift pchc, and pchcoffset, one for each digit
         pchc = pchcoffset++;
 
-        for (ibdigit = b->cdigit; ibdigit > 0; ibdigit--)
+        for (ibdigit = b.cdigit; ibdigit > 0; ibdigit--)
         {
             cy = 0;
             mcy = (TWO_MANTTYPE)da * *pchb;
@@ -254,7 +252,7 @@ void _mulnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
                 icdigit = 0;
                 if (ibdigit == 1 && iadigit == 1)
                 {
-                    c->cdigit++;
+                    c.cdigit++;
                 }
             }
             // If result is nonzero, or while result of carry is nonzero...
@@ -278,12 +276,11 @@ void _mulnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
 
     // prevent different kinds of zeros, by stripping leading duplicate zeros.
     // digits are in order of increasing significance.
-    while (c->cdigit > 1 && c->mant[c->cdigit - 1] == 0)
+    while (c.cdigit > 1 && c.mant[c.cdigit - 1] == 0)
     {
-        c->cdigit--;
+        c.cdigit--;
     }
 
-    destroynum(*pa);
     *pa = c;
 }
 
@@ -302,50 +299,44 @@ void _mulnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
 //
 //----------------------------------------------------------------------------
 
-void remnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix)
-
+void remnum(_Inout_ NUMBER* pa, _In_ const NUMBER& b, uint32_t radix)
 {
-    PNUMBER tmp = nullptr;     // tmp is the working remainder.
-    PNUMBER lasttmp = nullptr; // lasttmp is the last remainder which worked.
+    optional<NUMBER> tmp;     // tmp is the working remainder.
+    optional<NUMBER> lasttmp; // lasttmp is the last remainder which worked.
 
     // Once *pa is less than b, *pa is the remainder.
     while (!lessnum(*pa, b))
     {
-        DUPNUM(tmp, b);
-        if (lessnum(tmp, *pa))
+        tmp = b;
+        if (lessnum(*tmp, *pa))
         {
             // Start off close to the right answer for subtraction.
-            tmp->exp = (*pa)->cdigit + (*pa)->exp - tmp->cdigit;
-            if (MSD(*pa) <= MSD(tmp))
+            tmp->exp = (*pa).cdigit + (*pa).exp - tmp->cdigit;
+            if (MSD(*pa) <= MSD(*tmp))
             {
                 // Don't take the chance that the numbers are equal.
                 tmp->exp--;
             }
         }
 
-        destroynum(lasttmp);
         lasttmp = i32tonum(0, radix);
 
-        while (lessnum(tmp, *pa))
+        while (lessnum(*tmp, *pa))
         {
-            DUPNUM(lasttmp, tmp);
-            addnum(&tmp, tmp, radix);
+            lasttmp = tmp;
+            addnum(&*tmp, *tmp, radix);
         }
 
-        if (lessnum(*pa, tmp))
+        if (lessnum(*pa, *tmp))
         {
             // too far, back up...
-            destroynum(tmp);
             tmp = lasttmp;
-            lasttmp = nullptr;
+            lasttmp = optional<NUMBER>();
         }
 
         // Subtract the working remainder from the remainder holder.
-        tmp->sign = -1 * (*pa)->sign;
-        addnum(pa, tmp, radix);
-
-        destroynum(tmp);
-        destroynum(lasttmp);
+        tmp->sign = -1 * (*pa).sign;
+        addnum(pa, *tmp, radix);
     }
 }
 
@@ -363,116 +354,106 @@ void remnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix)
 //
 //---------------------------------------------------------------------------
 
-void _divnum(PNUMBER* pa, PNUMBER b, uint32_t radix, int32_t precision);
+void _divnum(NUMBER* pa, const NUMBER& b, uint32_t radix, int32_t precision);
 
-void divnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix, int32_t precision)
-
+void divnum(_Inout_ NUMBER* pa, _In_ const NUMBER& b, uint32_t radix, int32_t precision)
 {
-    if (b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0)
+    if (b.cdigit > 1 || b.mant[0] != 1 || b.exp != 0)
     {
         // b is not one
         _divnum(pa, b, radix, precision);
     }
     else
     { // But we do have to set the sign.
-        (*pa)->sign *= b->sign;
+        (*pa).sign *= b.sign;
     }
 }
 
-void _divnum(PNUMBER* pa, PNUMBER b, uint32_t radix, int32_t precision)
+void _divnum(NUMBER* pa, const NUMBER& b, uint32_t radix, int32_t precision)
 {
-    PNUMBER a = *pa;
+    NUMBER a = *pa;
     int32_t thismax = precision + 2;
-    if (thismax < a->cdigit)
+    if (thismax < a.cdigit)
     {
-        thismax = a->cdigit;
+        thismax = a.cdigit;
     }
 
-    if (thismax < b->cdigit)
+    if (thismax < b.cdigit)
     {
-        thismax = b->cdigit;
+        thismax = b.cdigit;
     }
 
-    PNUMBER c = nullptr;
+    NUMBER c;
     createnum(c, thismax + 1);
-    c->exp = (a->cdigit + a->exp) - (b->cdigit + b->exp) + 1;
-    c->sign = a->sign * b->sign;
+    c.exp = (a.cdigit + a.exp) - (b.cdigit + b.exp) + 1;
+    c.sign = a.sign * b.sign;
 
-    MANTTYPE* ptrc = c->mant + thismax;
-    PNUMBER rem = nullptr;
-    PNUMBER tmp = nullptr;
+    vector<MANTTYPE>::iterator ptrc = c.mant.begin() + thismax;
+    NUMBER rem;
+    NUMBER tmp;
     DUPNUM(rem, a);
     DUPNUM(tmp, b);
-    tmp->sign = a->sign;
-    rem->exp = b->cdigit + b->exp - rem->cdigit;
+    tmp.sign = a.sign;
+    rem.exp = b.cdigit + b.exp - rem.cdigit;
 
     // Build a table of multiplications of the divisor, this is quicker for
     // more than radix 'digits'
-    list<PNUMBER> numberList{ i32tonum(0L, radix) };
+    list<NUMBER> numberList{ i32tonum(0L, radix) };
     for (uint32_t i = 1; i < radix; i++)
     {
-        PNUMBER newValue = nullptr;
+        NUMBER newValue;
         DUPNUM(newValue, numberList.front());
         addnum(&newValue, tmp, radix);
 
         numberList.emplace_front(newValue);
     }
-    destroynum(tmp);
 
     int32_t digit;
     int32_t cdigits = 0;
     while (cdigits++ < thismax && !zernum(rem))
     {
         digit = radix - 1;
-        PNUMBER multiple = nullptr;
-        for (const auto& num : numberList)
+
+        for (auto& num : numberList)
         {
             if (!lessnum(rem, num) || !--digit)
             {
-                multiple = num;
+                auto& multiple = num;
+
+                if (digit)
+                {
+                    multiple.sign *= -1;
+                    addnum(&rem, multiple, radix);
+                    multiple.sign *= -1;
+                }
+                rem.exp++;
+                *ptrc-- = (MANTTYPE)digit;
                 break;
             }
         }
-
-        if (digit)
-        {
-            multiple->sign *= -1;
-            addnum(&rem, multiple, radix);
-            multiple->sign *= -1;
-        }
-        rem->exp++;
-        *ptrc-- = (MANTTYPE)digit;
     }
     cdigits--;
 
-    if (c->mant != ++ptrc)
+    if (c.mant.begin() != ++ptrc)
     {
-        memmove(c->mant, ptrc, (int)(cdigits * sizeof(MANTTYPE)));
-    }
-
-    // Cleanup table structure
-    for (auto& num : numberList)
-    {
-        destroynum(num);
+        copy(ptrc, ptrc + cdigits, c.mant.begin());
     }
 
     if (!cdigits)
     {
-        c->cdigit = 1;
-        c->exp = 0;
+        c.cdigit = 1;
+        c.exp = 0;
     }
     else
     {
-        c->cdigit = cdigits;
-        c->exp -= cdigits;
-        while (c->cdigit > 1 && c->mant[c->cdigit - 1] == 0)
+        c.cdigit = cdigits;
+        c.exp -= cdigits;
+        while (c.cdigit > 1 && c.mant[c.cdigit - 1] == 0)
         {
-            c->cdigit--;
+            c.cdigit--;
         }
     }
-    destroynum(rem);
 
-    destroynum(*pa);
     *pa = c;
 }
 
@@ -489,18 +470,17 @@ void _divnum(PNUMBER* pa, PNUMBER b, uint32_t radix, int32_t precision)
 //
 //---------------------------------------------------------------------------
 
-bool equnum(_In_ PNUMBER a, _In_ PNUMBER b)
-
+bool equnum(_In_ const NUMBER& a, _In_ const NUMBER& b)
 {
     int32_t diff;
-    MANTTYPE* pa;
-    MANTTYPE* pb;
+    int32_t ia;
+    int32_t ib;
     int32_t cdigits;
     int32_t ccdigits;
     MANTTYPE da;
     MANTTYPE db;
 
-    diff = (a->cdigit + a->exp) - (b->cdigit + b->exp);
+    diff = (a.cdigit + a.exp) - (b.cdigit + b.exp);
     if (diff < 0)
     {
         // If the exponents are different, these are different numbers.
@@ -516,19 +496,17 @@ bool equnum(_In_ PNUMBER a, _In_ PNUMBER b)
         else
         {
             // OK the exponents match.
-            pa = a->mant;
-            pb = b->mant;
-            pa += a->cdigit - 1;
-            pb += b->cdigit - 1;
-            cdigits = max(a->cdigit, b->cdigit);
+            ia = a.cdigit - 1;
+            ib = b.cdigit - 1;
+            cdigits = max(a.cdigit, b.cdigit);
             ccdigits = cdigits;
 
             // Loop over all digits until we run out of digits or there is a
             // difference in the digits.
             for (; cdigits > 0; cdigits--)
             {
-                da = ((cdigits > (ccdigits - a->cdigit)) ? *pa-- : 0);
-                db = ((cdigits > (ccdigits - b->cdigit)) ? *pb-- : 0);
+                da = ((cdigits > (ccdigits - a.cdigit)) ? a.mant[ia--] : 0);
+                db = ((cdigits > (ccdigits - b.cdigit)) ? b.mant[ib--] : 0);
                 if (da != db)
                 {
                     return false;
@@ -555,18 +533,17 @@ bool equnum(_In_ PNUMBER a, _In_ PNUMBER b)
 //
 //---------------------------------------------------------------------------
 
-bool lessnum(_In_ PNUMBER a, _In_ PNUMBER b)
-
+bool lessnum(_In_ const NUMBER& a, _In_ const NUMBER& b)
 {
     int32_t diff;
-    MANTTYPE* pa;
-    MANTTYPE* pb;
+    int32_t ia;
+    int32_t ib;
     int32_t cdigits;
     int32_t ccdigits;
     MANTTYPE da;
     MANTTYPE db;
 
-    diff = (a->cdigit + a->exp) - (b->cdigit + b->exp);
+    diff = (a.cdigit + a.exp) - (b.cdigit + b.exp);
     if (diff < 0)
     {
         // The exponent of a is less than b
@@ -580,16 +557,14 @@ bool lessnum(_In_ PNUMBER a, _In_ PNUMBER b)
         }
         else
         {
-            pa = a->mant;
-            pb = b->mant;
-            pa += a->cdigit - 1;
-            pb += b->cdigit - 1;
-            cdigits = max(a->cdigit, b->cdigit);
+            ia = a.cdigit - 1;
+            ib = b.cdigit - 1;
+            cdigits = max(a.cdigit, b.cdigit);
             ccdigits = cdigits;
             for (; cdigits > 0; cdigits--)
             {
-                da = ((cdigits > (ccdigits - a->cdigit)) ? *pa-- : 0);
-                db = ((cdigits > (ccdigits - b->cdigit)) ? *pb-- : 0);
+                da = ((cdigits > (ccdigits - a.cdigit)) ? a.mant[ia--] : 0);
+                db = ((cdigits > (ccdigits - b.cdigit)) ? b.mant[ib--] : 0);
                 diff = da - db;
                 if (diff)
                 {
@@ -614,19 +589,16 @@ bool lessnum(_In_ PNUMBER a, _In_ PNUMBER b)
 //
 //----------------------------------------------------------------------------
 
-bool zernum(_In_ PNUMBER a)
-
+bool zernum(_In_ const NUMBER& a)
 {
-    int32_t length;
-    MANTTYPE* pcha;
-    length = a->cdigit;
-    pcha = a->mant;
+    int32_t length = a.cdigit;
+    int32_t index = 0;
 
     // loop over all the digits until you find a nonzero or until you run
     // out of digits
     while (length-- > 0)
     {
-        if (*pcha++)
+        if (a.mant[index++])
         {
             // One of the digits isn't zero, therefore the number isn't zero
             return false;

--- a/src/CalcManager/Ratpack/rat.cpp
+++ b/src/CalcManager/Ratpack/rat.cpp
@@ -40,7 +40,7 @@ using namespace std;
 void gcdrat(_Inout_ PRAT* pa, int32_t precision)
 
 {
-    PNUMBER pgcd = nullptr;
+    NUMBER pgcd;
     PRAT a = nullptr;
 
     a = *pa;
@@ -52,7 +52,6 @@ void gcdrat(_Inout_ PRAT* pa, int32_t precision)
         divnumx(&(a->pq), pgcd, precision);
     }
 
-    destroynum(pgcd);
     *pa = a;
 
     RENORMALIZE(*pa);
@@ -185,9 +184,9 @@ void divrat(_Inout_ PRAT* pa, _In_ PRAT b, int32_t precision)
 void subrat(_Inout_ PRAT* pa, _In_ PRAT b, int32_t precision)
 
 {
-    b->pp->sign *= -1;
+    b->pp.sign *= -1;
     addrat(pa, b, precision);
-    b->pp->sign *= -1;
+    b->pp.sign *= -1;
 }
 
 //-----------------------------------------------------------------------------
@@ -206,7 +205,7 @@ void subrat(_Inout_ PRAT* pa, _In_ PRAT b, int32_t precision)
 void addrat(_Inout_ PRAT* pa, _In_ PRAT b, int32_t precision)
 
 {
-    PNUMBER bot = nullptr;
+    NUMBER bot;
 
     if (equnum((*pa)->pq, b->pq))
     {
@@ -214,10 +213,10 @@ void addrat(_Inout_ PRAT* pa, _In_ PRAT b, int32_t precision)
         // make sure signs are involved in the calculation
         // we have to do this since the optimization here is only
         // working with the top half of the rationals.
-        (*pa)->pp->sign *= (*pa)->pq->sign;
-        (*pa)->pq->sign = 1;
-        b->pp->sign *= b->pq->sign;
-        b->pq->sign = 1;
+        (*pa)->pp.sign *= (*pa)->pq.sign;
+        (*pa)->pq.sign = 1;
+        b->pp.sign *= b->pq.sign;
+        b->pq.sign = 1;
         addnum(&((*pa)->pp), b->pp, BASEX);
     }
     else
@@ -228,13 +227,12 @@ void addrat(_Inout_ PRAT* pa, _In_ PRAT b, int32_t precision)
         mulnumx(&((*pa)->pp), b->pq);
         mulnumx(&((*pa)->pq), b->pp);
         addnum(&((*pa)->pp), (*pa)->pq, BASEX);
-        destroynum((*pa)->pq);
         (*pa)->pq = bot;
         trimit(pa, precision);
 
         // Get rid of negative zeros here.
-        (*pa)->pp->sign *= (*pa)->pq->sign;
-        (*pa)->pq->sign = 1;
+        (*pa)->pp.sign *= (*pa)->pq.sign;
+        (*pa)->pq.sign = 1;
     }
 
 #ifdef ADDGCD

--- a/src/CalcManager/Ratpack/ratpak.h
+++ b/src/CalcManager/Ratpack/ratpak.h
@@ -18,10 +18,12 @@
 //-----------------------------------------------------------------------------
 
 #include <algorithm>
+#include <cstdint>
+#include <optional>
 #include <string>
+#include <vector>
 #include "CalcErr.h"
-#include <cstring> // for memmove
-#include "sal_cross_platform.h"   // for SAL
+#include "sal_cross_platform.h" // for SAL
 
 static constexpr uint32_t BASEXPWR = 31L;     // Internal log2(BASEX)
 static constexpr uint32_t BASEX = 0x80000000; // Internal radix used in calculations, hope to raise
@@ -56,20 +58,15 @@ typedef enum eANGLE_TYPE ANGLE_TYPE;
 //
 //-----------------------------------------------------------------------------
 
-#pragma warning(push)
-#pragma warning(disable : 4200) // nonstandard extension used : zero-sized array in struct/union
 typedef struct _number
 {
-    int32_t sign;   // The sign of the mantissa, +1, or -1
-    int32_t cdigit; // The number of digits, or what passes for digits in the
-                    // radix being used.
-    int32_t exp;    // The offset of digits from the radix point
-                    // (decimal point in radix 10)
-    MANTTYPE mant[];
-    // This is actually allocated as a continuation of the
-    // NUMBER structure.
-} NUMBER, *PNUMBER, **PPNUMBER;
-#pragma warning(pop)
+    int32_t sign = 1;   // The sign of the mantissa, +1, or -1
+    int32_t cdigit = 0; // The number of digits, or what passes for digits in the
+                        // radix being used.
+    int32_t exp = 0;    // The offset of digits from the radix point
+                        // (decimal point in radix 10)
+    std::vector<MANTTYPE> mant;
+} NUMBER;
 
 //-----------------------------------------------------------------------------
 //
@@ -80,8 +77,8 @@ typedef struct _number
 
 typedef struct _rat
 {
-    PNUMBER pp;
-    PNUMBER pq;
+    NUMBER pp;
+    NUMBER pq;
 } RAT, *PRAT;
 
 static constexpr uint32_t MAX_LONG_SIZE = 33; // Base 2 requires 32 'digits'
@@ -93,11 +90,11 @@ static constexpr uint32_t MAX_LONG_SIZE = 33; // Base 2 requires 32 'digits'
 //
 //-----------------------------------------------------------------------------
 
-extern PNUMBER num_one;
-extern PNUMBER num_two;
-extern PNUMBER num_five;
-extern PNUMBER num_six;
-extern PNUMBER num_ten;
+extern NUMBER num_one;
+extern NUMBER num_two;
+extern NUMBER num_five;
+extern NUMBER num_six;
+extern NUMBER num_ten;
 
 extern PRAT ln_ten;
 extern PRAT ln_two;
@@ -136,10 +133,7 @@ extern PRAT rat_max_i32;
 extern PRAT rat_min_i32;
 
 // DUPNUM Duplicates a number taking care of allocation and internals
-#define DUPNUM(a, b)                                                                                                                                           \
-    destroynum(a);                                                                                                                                             \
-    createnum(a, (b)->cdigit);                                                                                                                                 \
-    _dupnum(a, b);
+#define DUPNUM(a, b) (a) = (b);
 
 // DUPRAT Duplicates a rational taking care of allocation and internals
 #define DUPRAT(a, b)                                                                                                                                           \
@@ -151,17 +145,17 @@ extern PRAT rat_min_i32;
 // LOG*RADIX calculates the integral portion of the log of a number in
 // the base currently being used, only accurate to within g_ratio
 
-#define LOGNUMRADIX(pnum) (((pnum)->cdigit + (pnum)->exp) * g_ratio)
+#define LOGNUMRADIX(pnum) (((pnum).cdigit + (pnum).exp) * g_ratio)
 #define LOGRATRADIX(prat) (LOGNUMRADIX((prat)->pp) - LOGNUMRADIX((prat)->pq))
 
 // LOG*2 calculates the integral portion of the log of a number in
 // the internal base being used, only accurate to within g_ratio
 
-#define LOGNUM2(pnum) ((pnum)->cdigit + (pnum)->exp)
+#define LOGNUM2(pnum) ((pnum).cdigit + (pnum).exp)
 #define LOGRAT2(prat) (LOGNUM2((prat)->pp) - LOGNUM2((prat)->pq))
 
 // SIGN returns the sign of the rational
-#define SIGN(prat) ((prat)->pp->sign * (prat)->pq->sign)
+#define SIGN(prat) ((prat)->pp.sign * (prat)->pq.sign)
 
 #if defined(DEBUG_RATPAK)
 //-----------------------------------------------------------------------------
@@ -192,18 +186,14 @@ extern PRAT rat_min_i32;
         outputString << "createnum " << y << " " << #y << " file= " << __FILE__ << ", line= " << __LINE__ << "\n";                                             \
         OutputDebugString(outputString.str().c_str());                                                                                                         \
     }
-#define destroynum(x)                                                                                                                                          \
-    {                                                                                                                                                          \
-        std::wstringstream outputString;                                                                                                                       \
-        outputString << "destroynum " << x << " file= " << __FILE__ << ", line= " << __LINE__ << "\n";                                                         \
-        OutputDebugString(outputString.str().c_str());                                                                                                         \
-    }                                                                                                                                                          \
-    _destroynum(x), (x) = nullptr
+{
+    std::wstringstream outputString;
+    OutputDebugString(outputString.str().c_str());
+}
 #else
 #define createrat(y) (y) = _createrat()
 #define destroyrat(x) _destroyrat(x), (x) = nullptr
 #define createnum(y, x) (y) = _createnum(x)
-#define destroynum(x) _destroynum(x), (x) = nullptr
 #endif
 
 //-----------------------------------------------------------------------------
@@ -215,46 +205,46 @@ extern PRAT rat_min_i32;
 
 // RENORMALIZE, gets the exponents non-negative.
 #define RENORMALIZE(x)                                                                                                                                         \
-    if ((x)->pp->exp < 0)                                                                                                                                      \
+    if ((x)->pp.exp < 0)                                                                                                                                       \
     {                                                                                                                                                          \
-        (x)->pq->exp -= (x)->pp->exp;                                                                                                                          \
-        (x)->pp->exp = 0;                                                                                                                                      \
+        (x)->pq.exp -= (x)->pp.exp;                                                                                                                            \
+        (x)->pp.exp = 0;                                                                                                                                       \
     }                                                                                                                                                          \
-    if ((x)->pq->exp < 0)                                                                                                                                      \
+    if ((x)->pq.exp < 0)                                                                                                                                       \
     {                                                                                                                                                          \
-        (x)->pp->exp -= (x)->pq->exp;                                                                                                                          \
-        (x)->pq->exp = 0;                                                                                                                                      \
+        (x)->pp.exp -= (x)->pq.exp;                                                                                                                            \
+        (x)->pq.exp = 0;                                                                                                                                       \
     }
 
 // TRIMNUM ASSUMES the number is in radix form NOT INTERNAL BASEX!!!
 #define TRIMNUM(x, precision)                                                                                                                                  \
     if (!g_ftrueinfinite)                                                                                                                                      \
     {                                                                                                                                                          \
-        int32_t trim = (x)->cdigit - precision - g_ratio;                                                                                                      \
+        int32_t trim = (x).cdigit - precision - g_ratio;                                                                                                       \
         if (trim > 1)                                                                                                                                          \
         {                                                                                                                                                      \
-            memmove((x)->mant, &((x)->mant[trim]), sizeof(MANTTYPE) * ((x)->cdigit - trim));                                                                   \
-            (x)->cdigit -= trim;                                                                                                                               \
-            (x)->exp += trim;                                                                                                                                  \
+            std::copy((x).mant.begin() + trim, (x).mant.begin() + (x).cdigit, (x).mant.begin());                                                               \
+            (x).cdigit -= trim;                                                                                                                                \
+            (x).exp += trim;                                                                                                                                   \
         }                                                                                                                                                      \
     }
 // TRIMTOP ASSUMES the number is in INTERNAL BASEX!!!
 #define TRIMTOP(x, precision)                                                                                                                                  \
     if (!g_ftrueinfinite)                                                                                                                                      \
     {                                                                                                                                                          \
-        int32_t trim = (x)->pp->cdigit - (precision / g_ratio) - 2;                                                                                            \
+        int32_t trim = (x)->pp.cdigit - (precision / g_ratio) - 2;                                                                                             \
         if (trim > 1)                                                                                                                                          \
         {                                                                                                                                                      \
-            memmove((x)->pp->mant, &((x)->pp->mant[trim]), sizeof(MANTTYPE) * ((x)->pp->cdigit - trim));                                                       \
-            (x)->pp->cdigit -= trim;                                                                                                                           \
-            (x)->pp->exp += trim;                                                                                                                              \
+            std::copy((x)->pp.mant.begin() + trim, (x)->pp.mant.begin() + (x)->pp.cdigit, (x)->pp.mant.begin());                                               \
+            (x)->pp.cdigit -= trim;                                                                                                                            \
+            (x)->pp.exp += trim;                                                                                                                               \
         }                                                                                                                                                      \
-        trim = std::min((x)->pp->exp, (x)->pq->exp);                                                                                                           \
-        (x)->pp->exp -= trim;                                                                                                                                  \
-        (x)->pq->exp -= trim;                                                                                                                                  \
+        trim = std::min((x)->pp.exp, (x)->pq.exp);                                                                                                             \
+        (x)->pp.exp -= trim;                                                                                                                                   \
+        (x)->pq.exp -= trim;                                                                                                                                   \
     }
 
-#define SMALL_ENOUGH_RAT(a, precision) (zernum((a)->pp) || ((((a)->pq->cdigit + (a)->pq->exp) - ((a)->pp->cdigit + (a)->pp->exp) - 1) * g_ratio > precision))
+#define SMALL_ENOUGH_RAT(a, precision) (zernum((a)->pp) || ((((a)->pq.cdigit + (a)->pq.exp) - ((a)->pp.cdigit + (a)->pp.exp) - 1) * g_ratio > precision))
 
 //-----------------------------------------------------------------------------
 //
@@ -265,7 +255,7 @@ extern PRAT rat_min_i32;
 
 #define CREATETAYLOR()                                                                                                                                         \
     PRAT xx = nullptr;                                                                                                                                         \
-    PNUMBER n2 = nullptr;                                                                                                                                      \
+    NUMBER n2;                                                                                                                                                 \
     PRAT pret = nullptr;                                                                                                                                       \
     PRAT thisterm = nullptr;                                                                                                                                   \
     DUPRAT(xx, *px);                                                                                                                                           \
@@ -275,7 +265,6 @@ extern PRAT rat_min_i32;
     pret->pq = i32tonum(0L, BASEX);
 
 #define DESTROYTAYLOR()                                                                                                                                        \
-    destroynum(n2);                                                                                                                                            \
     destroyrat(xx);                                                                                                                                            \
     destroyrat(thisterm);                                                                                                                                      \
     destroyrat(*px);                                                                                                                                           \
@@ -285,16 +274,16 @@ extern PRAT rat_min_i32;
 // INC(a) is the rational equivalent of a++
 // Check to see if we can avoid doing this the hard way.
 #define INC(a)                                                                                                                                                 \
-    if ((a)->mant[0] < BASEX - 1)                                                                                                                              \
+    if ((a).mant[0] < BASEX - 1)                                                                                                                               \
     {                                                                                                                                                          \
-        (a)->mant[0]++;                                                                                                                                        \
+        (a).mant[0]++;                                                                                                                                         \
     }                                                                                                                                                          \
     else                                                                                                                                                       \
     {                                                                                                                                                          \
         addnum(&(a), num_one, BASEX);                                                                                                                          \
     }
 
-#define MSD(x) ((x)->mant[(x)->cdigit - 1])
+#define MSD(x) ((x).mant[(x).cdigit - 1])
 // MULNUM(b) is the rational equivalent of thisterm *= b where thisterm is
 // a rational and b is a number, NOTE this is a mixed type operation for
 // efficiency reasons.
@@ -337,39 +326,37 @@ extern void SetDecimalSeparator(wchar_t decimalSeparator);
 // Call whenever either radix or precision changes, is smarter about recalculating constants.
 extern void ChangeConstants(uint32_t radix, int32_t precision);
 
-extern bool equnum(_In_ PNUMBER a, _In_ PNUMBER b);  // returns true of a == b
-extern bool lessnum(_In_ PNUMBER a, _In_ PNUMBER b); // returns true of a < b
-extern bool zernum(_In_ PNUMBER a);                  // returns true of a == 0
-extern bool zerrat(_In_ PRAT a);                     // returns true if a == 0/q
-extern std::wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_t precision);
+extern bool equnum(_In_ const NUMBER& a, _In_ const NUMBER& b);  // returns true of a == b
+extern bool lessnum(_In_ const NUMBER& a, _In_ const NUMBER& b); // returns true of a < b
+extern bool zernum(_In_ const NUMBER& a);                        // returns true of a == 0
+extern bool zerrat(_In_ PRAT a);                                 // returns true if a == 0/q
+extern std::wstring NumberToString(_Inout_ NUMBER& pnum, int format, uint32_t radix, int32_t precision);
 
 // returns a text representation of a PRAT
 extern std::wstring RatToString(_Inout_ PRAT& prat, int format, uint32_t radix, int32_t precision);
-// converts a PRAT into a PNUMBER
-extern PNUMBER RatToNumber(_In_ PRAT prat, uint32_t radix, int32_t precision);
-// flattens a PRAT by converting it to a PNUMBER and back to a PRAT
+// converts a PRAT into a NUMBER
+extern NUMBER RatToNumber(_In_ PRAT prat, uint32_t radix, int32_t precision);
+// flattens a PRAT by converting it to a NUMBER and back to a PRAT
 extern void flatrat(_Inout_ PRAT& prat, uint32_t radix, int32_t precision);
 
-extern int32_t numtoi32(_In_ PNUMBER pnum, uint32_t radix);
+extern int32_t numtoi32(_In_ const NUMBER& pnum, uint32_t radix);
 extern int32_t rattoi32(_In_ PRAT prat, uint32_t radix, int32_t precision);
 uint64_t rattoUi64(_In_ PRAT prat, uint32_t radix, int32_t precision);
-extern PNUMBER _createnum(_In_ uint32_t size); // returns an empty number structure with size digits
-extern PNUMBER nRadixxtonum(_In_ PNUMBER a, uint32_t radix, int32_t precision);
-extern PNUMBER gcd(_In_ PNUMBER a, _In_ PNUMBER b);
-extern PNUMBER StringToNumber(
-    std::wstring_view numberString,
-    uint32_t radix,
-    int32_t precision); // takes a text representation of a number and returns a number.
+extern NUMBER _createnum(_In_ uint32_t size); // returns an empty number structure with size digits
+extern NUMBER nRadixxtonum(_In_ const NUMBER& a, uint32_t radix, int32_t precision);
+extern NUMBER gcd(_In_ const NUMBER& a, _In_ const NUMBER& b);
+extern std::optional<NUMBER>
+StringToNumber(std::wstring_view numberString, uint32_t radix, int32_t precision); // takes a text representation of a number and returns a number.
 
 // takes a text representation of a number as a mantissa with sign and an exponent with sign.
 extern PRAT
 StringToRat(bool mantissaIsNegative, std::wstring_view mantissa, bool exponentIsNegative, std::wstring_view exponent, uint32_t radix, int32_t precision);
 
-extern PNUMBER i32factnum(int32_t ini32, uint32_t radix);
-extern PNUMBER i32prodnum(int32_t start, int32_t stop, uint32_t radix);
-extern PNUMBER i32tonum(int32_t ini32, uint32_t radix);
-extern PNUMBER Ui32tonum(uint32_t ini32, uint32_t radix);
-extern PNUMBER numtonRadixx(_In_ PNUMBER a, uint32_t radix);
+extern NUMBER i32factnum(int32_t ini32, uint32_t radix);
+extern NUMBER i32prodnum(int32_t start, int32_t stop, uint32_t radix);
+extern NUMBER i32tonum(int32_t ini32, uint32_t radix);
+extern NUMBER Ui32tonum(uint32_t ini32, uint32_t radix);
+extern NUMBER numtonRadixx(_In_ const NUMBER& a, uint32_t radix);
 
 // creates a empty/undefined rational representation (p/q)
 extern PRAT _createrat(void);
@@ -428,7 +415,7 @@ extern void lograt(_Inout_ PRAT* px, int32_t precision);
 
 extern PRAT i32torat(int32_t ini32);
 extern PRAT Ui32torat(uint32_t inui32);
-extern PRAT numtorat(_In_ PNUMBER pin, uint32_t radix);
+extern PRAT numtorat(_In_ const NUMBER& pin, uint32_t radix);
 
 extern void sinhrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
 extern void sinrat(_Inout_ PRAT* px);
@@ -444,15 +431,14 @@ extern void tanrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
 // angle type
 extern void tananglerat(_Inout_ PRAT* px, ANGLE_TYPE angletype, uint32_t radix, int32_t precision);
 
-extern void _dupnum(_In_ PNUMBER dest, _In_ const NUMBER* const src);
+extern void _dupnum(_In_ const NUMBER& dest, _In_ const NUMBER* const src);
 
-extern void _destroynum(_Frees_ptr_opt_ PNUMBER pnum);
 extern void _destroyrat(_Frees_ptr_opt_ PRAT prat);
-extern void addnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix);
+extern void addnum(_Inout_ NUMBER* pa, _In_ const NUMBER& b, uint32_t radix);
 extern void addrat(_Inout_ PRAT* pa, _In_ PRAT b, int32_t precision);
 extern void andrat(_Inout_ PRAT* pa, _In_ PRAT b, uint32_t radix, int32_t precision);
-extern void divnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix, int32_t precision);
-extern void divnumx(_Inout_ PNUMBER* pa, _In_ PNUMBER b, int32_t precision);
+extern void divnum(_Inout_ NUMBER* pa, _In_ const NUMBER& b, uint32_t radix, int32_t precision);
+extern void divnumx(_Inout_ NUMBER* pa, _In_ const NUMBER& b, int32_t precision);
 extern void divrat(_Inout_ PRAT* pa, _In_ PRAT b, int32_t precision);
 extern void fracrat(_Inout_ PRAT* pa, uint32_t radix, int32_t precision);
 extern void factrat(_Inout_ PRAT* pa, uint32_t radix, int32_t precision);
@@ -460,17 +446,17 @@ extern void remrat(_Inout_ PRAT* pa, _In_ PRAT b);
 extern void modrat(_Inout_ PRAT* pa, _In_ PRAT b);
 extern void gcdrat(_Inout_ PRAT* pa, int32_t precision);
 extern void intrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
-extern void mulnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix);
-extern void mulnumx(_Inout_ PNUMBER* pa, _In_ PNUMBER b);
+extern void mulnum(_Inout_ NUMBER* pa, _In_ const NUMBER& b, uint32_t radix);
+extern void mulnumx(_Inout_ NUMBER* pa, _In_ const NUMBER& b);
 extern void mulrat(_Inout_ PRAT* pa, _In_ PRAT b, int32_t precision);
-extern void numpowi32(_Inout_ PNUMBER* proot, int32_t power, uint32_t radix, int32_t precision);
-extern void numpowi32x(_Inout_ PNUMBER* proot, int32_t power);
+extern void numpowi32(_Inout_ NUMBER* proot, int32_t power, uint32_t radix, int32_t precision);
+extern void numpowi32x(_Inout_ NUMBER* proot, int32_t power);
 extern void orrat(_Inout_ PRAT* pa, _In_ PRAT b, uint32_t radix, int32_t precision);
 extern void powrat(_Inout_ PRAT* pa, _In_ PRAT b, uint32_t radix, int32_t precision);
 extern void powratNumeratorDenominator(_Inout_ PRAT* pa, _In_ PRAT b, uint32_t radix, int32_t precision);
 extern void powratcomp(_Inout_ PRAT* pa, _In_ PRAT b, uint32_t radix, int32_t precision);
 extern void ratpowi32(_Inout_ PRAT* proot, int32_t power, int32_t precision);
-extern void remnum(_Inout_ PNUMBER* pa, _In_ PNUMBER b, uint32_t radix);
+extern void remnum(_Inout_ NUMBER* pa, _In_ const NUMBER& b, uint32_t radix);
 extern void rootrat(_Inout_ PRAT* pa, _In_ PRAT b, uint32_t radix, int32_t precision);
 extern void scale2pi(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
 extern void scale(_Inout_ PRAT* px, _In_ PRAT scalefact, uint32_t radix, int32_t precision);
@@ -487,4 +473,4 @@ extern bool rat_le(_In_ PRAT a, _In_ PRAT b, int32_t precision);
 extern void inbetween(_In_ PRAT* px, _In_ PRAT range, int32_t precision);
 extern void trimit(_Inout_ PRAT* px, int32_t precision);
 extern void _dumprawrat(_In_ const wchar_t* varname, _In_ PRAT rat, std::wostream& out);
-extern void _dumprawnum(_In_ const wchar_t* varname, _In_ PNUMBER num, std::wostream& out);
+extern void _dumprawnum(_In_ const wchar_t* varname, _In_ const NUMBER& num, std::wostream& out);

--- a/src/CalcManager/Ratpack/ratpak.h
+++ b/src/CalcManager/Ratpack/ratpak.h
@@ -60,7 +60,7 @@ typedef enum eANGLE_TYPE ANGLE_TYPE;
 
 typedef struct _number
 {
-    int32_t sign = 1;   // The sign of the mantissa, +1, or -1
+    int32_t sign = 0;   // The sign of the mantissa, +1, or -1
     int32_t cdigit = 0; // The number of digits, or what passes for digits in the
                         // radix being used.
     int32_t exp = 0;    // The offset of digits from the radix point

--- a/src/CalcManager/Ratpack/support.cpp
+++ b/src/CalcManager/Ratpack/support.cpp
@@ -408,7 +408,7 @@ bool rat_lt(_In_ PRAT a, _In_ PRAT b, int32_t precision)
     b->pp.sign *= -1;
     addrat(&rattmp, b, precision);
     b->pp.sign *= -1;
-    bool bret = (!zernum(rattmp->pp) && rattmp->pp.sign * rattmp->pq.sign == -1);
+    bool bret = (!zernum(rattmp->pp) && SIGN(rattmp) == -1);
     destroyrat(rattmp);
     return (bret);
 }

--- a/src/CalcManager/Ratpack/support.cpp
+++ b/src/CalcManager/Ratpack/support.cpp
@@ -42,10 +42,10 @@ static int cbitsofprecision = 0;
 #define DUMPRAWRAT(v)
 #define DUMPRAWNUM(v)
 #define READRAWRAT(v) createrat(v); (v)->pp = init_p_##v; (v)->pq = init_q_##v;
-#define READRAWNUM(v) DUPNUM(v, (&(init_##v)))
+#define READRAWNUM(v) DUPNUM(v, ((init_##v)))
 
 #define INIT_AND_DUMP_RAW_NUM_IF_NULL(r, v)                                                                                                                    \
-    if (r == nullptr)                                                                                                                                          \
+    if (r == NUMBER())                                                                                                                                          \
     {                                                                                                                                                          \
         r = i32tonum(v, BASEX);                                                                                                                                \
         DUMPRAWNUM(v);                                                                                                                                         \
@@ -126,6 +126,13 @@ PRAT rat_max_i32 = nullptr; // max signed i32
 //
 //----------------------------------------------------------------------------
 
+constexpr bool operator==(const NUMBER& a, const NUMBER& b)
+{
+    if (a.sign == b.sign && a.cdigit == b.cdigit && a.exp == b.exp && a.mant == b.mant)
+        return true;
+    return false;
+}
+
 void ChangeConstants(uint32_t radix, int32_t precision)
 {
     // ratio is set to the number of digits in the current radix, you can get
@@ -148,6 +155,11 @@ void ChangeConstants(uint32_t radix, int32_t precision)
     {
         g_ftrueinfinite = false;
 
+        INIT_AND_DUMP_RAW_NUM_IF_NULL(num_one, 1L);
+        INIT_AND_DUMP_RAW_NUM_IF_NULL(num_two, 2L);
+        INIT_AND_DUMP_RAW_NUM_IF_NULL(num_five, 5L);
+        INIT_AND_DUMP_RAW_NUM_IF_NULL(num_six, 6L);
+        INIT_AND_DUMP_RAW_NUM_IF_NULL(num_ten, 10L);
         // 3248, is the max number for which calc is able to compute factorial, after that it is unable to compute due to overflow.
         // Hence restricted factorial range as at most 3248.Beyond that calc will throw overflow error immediately.
         INIT_AND_DUMP_RAW_RAT_IF_NULL(rat_max_fact, 3249);
@@ -591,6 +603,11 @@ void _dumprawnum(_In_ const wchar_t* varname, _In_ const NUMBER& num, wostream& 
 void _readconstants(void)
 
 {
+    READRAWNUM(num_one);
+    READRAWNUM(num_two);
+    READRAWNUM(num_five);
+    READRAWNUM(num_six);
+    READRAWNUM(num_ten);
     READRAWRAT(pt_eight_five);
     READRAWRAT(rat_six);
     READRAWRAT(rat_two);

--- a/src/CalcManager/Ratpack/trans.cpp
+++ b/src/CalcManager/Ratpack/trans.cpp
@@ -72,7 +72,7 @@ void _sinrat(PRAT* px, int32_t precision)
     DUPRAT(thisterm, *px);
 
     DUPNUM(n2, num_one);
-    xx->pp->sign *= -1;
+    xx->pp.sign *= -1;
 
     do
     {
@@ -160,16 +160,13 @@ void _cosrat(PRAT* px, uint32_t radix, int32_t precision)
 {
     CREATETAYLOR();
 
-    destroynum(pret->pp);
-    destroynum(pret->pq);
-
     pret->pp = i32tonum(1L, radix);
     pret->pq = i32tonum(1L, radix);
 
     DUPRAT(thisterm, pret)
 
     n2 = i32tonum(0L, radix);
-    xx->pp->sign *= -1;
+    xx->pp.sign *= -1;
 
     do
     {

--- a/src/CalcManager/Ratpack/transh.cpp
+++ b/src/CalcManager/Ratpack/transh.cpp
@@ -97,7 +97,7 @@ void sinhrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
     {
         DUPRAT(tmpx, *px);
         exprat(px, radix, precision);
-        tmpx->pp->sign *= -1;
+        tmpx->pp.sign *= -1;
         exprat(&tmpx, radix, precision);
         subrat(px, tmpx, precision);
         divrat(px, rat_two, precision);
@@ -174,13 +174,13 @@ void coshrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
 {
     PRAT tmpx = nullptr;
 
-    (*px)->pp->sign = 1;
-    (*px)->pq->sign = 1;
+    (*px)->pp.sign = 1;
+    (*px)->pq.sign = 1;
     if (rat_ge(*px, rat_one, precision))
     {
         DUPRAT(tmpx, *px);
         exprat(px, radix, precision);
-        tmpx->pp->sign *= -1;
+        tmpx->pp.sign *= -1;
         exprat(&tmpx, radix, precision);
         addrat(px, tmpx, precision);
         divrat(px, rat_two, precision);


### PR DESCRIPTION
These are the changes extracted from #211 that port number's mantissa
from flexible member arrays, a non-standard C++ extension, to
std::vector, which enables compilation and linkage with clang.

@fwcd is the original author of these changes, I (@janisozaur) merely
rebased them on top of current master.

The rebase was luckily fairly straight-forward, with the only real
conflict coming from 7a7ceb58882828096cac87494f5a1ffb5359e212
(https://github.com/microsoft/calculator/pull/412), but was trivial to
fix.