### PR TITLE
Drop __inline from conflicting declarations

### DIFF
--- a/src/CalcManager/Ratpack/basex.cpp
+++ b/src/CalcManager/Ratpack/basex.cpp
@@ -34,7 +34,7 @@ void _mulnumx(PNUMBER* pa, PNUMBER b);
 //
 //----------------------------------------------------------------------------
 
-void __inline mulnumx(PNUMBER* pa, PNUMBER b)
+void mulnumx(PNUMBER* pa, PNUMBER b)
 
 {
     if (b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0)
@@ -215,7 +215,7 @@ void _divnumx(PNUMBER* pa, PNUMBER b, int32_t precision);
 //
 //----------------------------------------------------------------------------
 
-void __inline divnumx(PNUMBER* pa, PNUMBER b, int32_t precision)
+void divnumx(PNUMBER* pa, PNUMBER b, int32_t precision)
 
 {
     if (b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0)

--- a/src/CalcManager/Ratpack/num.cpp
+++ b/src/CalcManager/Ratpack/num.cpp
@@ -43,7 +43,7 @@ using namespace std;
 
 void _addnum(PNUMBER* pa, PNUMBER b, uint32_t radix);
 
-void __inline addnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
+void addnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
 
 {
     if (b->cdigit > 1 || b->mant[0] != 0)
@@ -186,7 +186,7 @@ void _addnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
 
 void _mulnum(PNUMBER* pa, PNUMBER b, uint32_t radix);
 
-void __inline mulnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
+void mulnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
 
 {
     if (b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0)
@@ -365,7 +365,7 @@ void remnum(PNUMBER* pa, PNUMBER b, uint32_t radix)
 
 void _divnum(PNUMBER* pa, PNUMBER b, uint32_t radix, int32_t precision);
 
-void __inline divnum(PNUMBER* pa, PNUMBER b, uint32_t radix, int32_t precision)
+void divnum(PNUMBER* pa, PNUMBER b, uint32_t radix, int32_t precision)
 
 {
     if (b->cdigit > 1 || b->mant[0] != 1 || b->exp != 0)


### PR DESCRIPTION
`mulnum` et al. are declared `extern` in `ratpak.h`, which conflicts
with the `__inline` used with them. Additionally, most similar functions
don't have such keyword applied to them.

See https://github.com/microsoft/calculator/blob/fe30c7cabc1f30c239b5a22ff6d0f7fa0fba5cd1/src/CalcManager/Ratpack/ratpak.h#L463-L464