### PR TITLE
Fix type of m_openParenCount

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -373,7 +373,8 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         m_lastVal = 0;
 
         m_bChangeOp = false;
-        m_precedenceOpCount = m_nTempCom = m_nLastCom = m_nOpCode = m_openParenCount = 0;
+        m_openParenCount = 0;
+        m_precedenceOpCount = m_nTempCom = m_nLastCom = m_nOpCode = 0;
         m_nPrevOpCode = 0;
         m_bNoPrevEqu = true;
 

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -138,7 +138,7 @@ private:
     std::wstring m_numberString;
 
     int m_nTempCom;                          /* Holding place for the last command.          */
-    int m_openParenCount;                    // Number of open parentheses.
+    size_t m_openParenCount;                 // Number of open parentheses.
     std::array<int, MAXPRECDEPTH> m_nOp;     /* Holding array for parenthesis operations.    */
     std::array<int, MAXPRECDEPTH> m_nPrecOp; /* Holding array for precedence  operations.    */
     size_t m_precedenceOpCount;              /* Current number of precedence ops in holding. */


### PR DESCRIPTION
This is always used as unsigned and compared against unsigneds, e.g.
https://github.com/microsoft/calculator/blob/1eb717f336bae8b35281bbb27571748d458d862e/src/CalcManager/CEngine/scicomm.cpp#L544
much like `m_precedenceOpCount` few lines lower.