### PR TITLE
Handle date difference for ends of months

### DIFF
--- a/src/CalcViewModel/Common/DateCalculator.cpp
+++ b/src/CalcViewModel/Common/DateCalculator.cpp
@@ -206,7 +206,7 @@ void DateCalculationEngine::GetDateDifference(_In_ DateTime date1, _In_ DateTime
                             // pivotDate is still below the end date
                             try
                             {
-                                pivotDate = AdjustCalendarDate(pivotDate, dateUnit, 1);
+                                pivotDate = AdjustCalendarDate(tempPivotDate, dateUnit, static_cast<int>(differenceInDates[unitIndex] + 1));
                                 differenceInDates[unitIndex] += 1;
                             }
                             catch (Platform::InvalidArgumentException ^)


### PR DESCRIPTION
## Fixes #552


### Description of the changes:
The incrementally calling `Window::Globalization::Calendar::AddMonths`
resulted in a negative value for `GetDifferenceInDays` which was then
assigned to an unsigned variable `daysDiff`.

One example of the issue when running the calculator in UTC+2 was the
difference between July 31st and December 30th.

The initial guess was 4 months which then landed on November 30th.
This date was stored and then in the loop incremeted by one month.
This then landed precisely on the end date December 30th.
After the loop the final value is then used July 31st + 5 months
which results in the 31st of December.
The resulting difference of -1 days is then assigned to the unsigned
value `daysDiff`.

This commit makes the minimal changes to remedy this bug.
It makes sure to only ever call `AddMonths` with the same starting date
instead of incrementally to different dates.

This commit makes the minimal changes to remedy this bug.
It makes sure to only ever call `AddMonths` with the same starting date
instead of incrementally to different dates.

### How changes were validated:
- manually tested dates near the end of month where this incremental calculation would be triggered
