### PR TITLE
Date difference: display the difference in days (only) when we aren't able to calculate the difference in days/weeks/months..

### DIFF
--- a/src/CalcViewModel/Common/DateCalculator.cpp
+++ b/src/CalcViewModel/Common/DateCalculator.cpp
@@ -126,7 +126,6 @@ bool DateCalculationEngine::TryGetDateDifference(_In_ DateTime date1, _In_ DateT
     DateTime pivotDate;
     DateTime tempPivotDate;
     UINT daysDiff = 0;
-    UINT totalDaysDiff = 0;
     UINT differenceInDates[c_unitsOfDate] = { 0 };
 
     if (date1.UniversalTime < date2.UniversalTime)
@@ -142,7 +141,7 @@ bool DateCalculationEngine::TryGetDateDifference(_In_ DateTime date1, _In_ DateT
 
     pivotDate = startDate;
 
-    totalDaysDiff = daysDiff = GetDifferenceInDays(startDate, endDate);
+    daysDiff = GetDifferenceInDays(startDate, endDate);
 
     // If output has units other than days
     // 0th bit: Year, 1st bit: Month, 2nd bit: Week, 3rd bit: Day

--- a/src/CalcViewModel/Common/DateCalculator.cpp
+++ b/src/CalcViewModel/Common/DateCalculator.cpp
@@ -177,8 +177,9 @@ bool DateCalculationEngine::TryGetDateDifference(_In_ DateTime date1, _In_ DateT
                         catch (Platform::InvalidArgumentException ^)
                         {
                             // Operation failed due to out of bound result
-                            // Do nothing
-                            differenceInDates[unitIndex] = 0;
+                            // For example: 31st Dec, 9999 - last valid date
+                            *difference = DateDifferenceUnknown;
+                            return false;
                         }
                     }
 
@@ -193,6 +194,8 @@ bool DateCalculationEngine::TryGetDateDifference(_In_ DateTime date1, _In_ DateT
                             // pivotDate has gone over the end date; start from the beginning of this unit
                             if (differenceInDates[unitIndex] == 0)
                             {
+                                // differenceInDates[unitIndex] is unsigned, the value can't be negative
+                                *difference = DateDifferenceUnknown;
                                 return false;
                             }
                             differenceInDates[unitIndex] -= 1;
@@ -216,7 +219,9 @@ bool DateCalculationEngine::TryGetDateDifference(_In_ DateTime date1, _In_ DateT
                             }
                             catch (Platform::InvalidArgumentException ^)
                             {
-                                // handling for 31st Dec, 9999 last valid date
+                                // Operation failed due to out of bound result
+                                // For example: 31st Dec, 9999 - last valid date
+                                *difference = DateDifferenceUnknown;
                                 return false;
                             }
                         }
@@ -227,6 +232,8 @@ bool DateCalculationEngine::TryGetDateDifference(_In_ DateTime date1, _In_ DateT
                     int signedDaysDiff = GetDifferenceInDays(pivotDate, endDate);
                     if (signedDaysDiff < 0)
                     {
+                        // daysDiff is unsigned, the value can't be negative
+                        *difference = DateDifferenceUnknown;
                         return false;
                     }
 

--- a/src/CalcViewModel/Common/DateCalculator.h
+++ b/src/CalcViewModel/Common/DateCalculator.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -35,7 +35,14 @@ namespace CalculatorApp
                 int month = 0;
                 int week = 0;
                 int day = 0;
+
+                bool operator==(const DateDifference& dd) const
+                {
+                    return year == dd.year && month == dd.month && week == dd.week && day == day;
+                }
             };
+
+            const DateDifference DateDifferenceUnknown{ INT_MIN, INT_MIN, INT_MIN, INT_MIN };
 
             class DateCalculationEngine
             {
@@ -50,7 +57,7 @@ namespace CalculatorApp
                     _In_ Windows::Foundation::DateTime startDate,
                     _In_ const DateDifference& duration,
                     _Out_ Windows::Foundation::DateTime* endDate);
-                void __nothrow GetDateDifference(
+                bool __nothrow TryGetDateDifference(
                     _In_ Windows::Foundation::DateTime date1,
                     _In_ Windows::Foundation::DateTime date2,
                     _In_ DateUnit outputFormat,

--- a/src/CalcViewModel/DateCalculatorViewModel.cpp
+++ b/src/CalcViewModel/DateCalculatorViewModel.cpp
@@ -174,6 +174,7 @@ void DateCalculatorViewModel::UpdateDisplayResult()
     {
         if (m_dateDiffResultInDays == DateDifferenceUnknown)
         {
+            IsDiffInDays = false;
             StrDateDiffResultInDays = L"";
             StrDateDiffResult = L"";
         }
@@ -184,7 +185,8 @@ void DateCalculatorViewModel::UpdateDisplayResult()
             StrDateDiffResultInDays = L"";
             StrDateDiffResult = AppResourceProvider::GetInstance().GetResourceString(L"Date_SameDates");
         }
-        else if ((m_dateDiffResult.year == 0) && (m_dateDiffResult.month == 0) && (m_dateDiffResult.week == 0))
+        else if (m_dateDiffResult == DateDifferenceUnknown ||
+            (m_dateDiffResult.year == 0 && m_dateDiffResult.month == 0 && m_dateDiffResult.week == 0))
         {
             IsDiffInDays = true;
             StrDateDiffResultInDays = L"";

--- a/src/CalcViewModel/DateCalculatorViewModel.cpp
+++ b/src/CalcViewModel/DateCalculatorViewModel.cpp
@@ -176,7 +176,7 @@ void DateCalculatorViewModel::UpdateDisplayResult()
         {
             IsDiffInDays = false;
             StrDateDiffResultInDays = L"";
-            StrDateDiffResult = L"";
+            StrDateDiffResult = AppResourceProvider::GetInstance().GetResourceString(L"CalculationFailed");
         }
         else if (m_dateDiffResultInDays.day == 0)
         {

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3399,4 +3399,8 @@
     <value>Scroll Calculation Result Right</value>
     <comment>Automation label for the "Scroll Right" button that appears when a calculation result is too large to fit in calculation result text box.</comment>
   </data>
+  <data name="CalculationFailed" xml:space="preserve">
+    <value>Calculation failed</value>
+    <comment>Text displayed when the application is not able to do a calculation</comment>
+  </data>
 </root>

--- a/src/CalculatorUnitTests/DateCalculatorUnitTests.cpp
+++ b/src/CalculatorUnitTests/DateCalculatorUnitTests.cpp
@@ -300,7 +300,7 @@ TEST_METHOD(TestDateDiff)
     //    }
 
     //    // Calculate the difference
-    //    m_DateCalcEngine.GetDateDifference(DateUtils::SystemTimeToDateTime(datetimeDifftest[testIndex].startDate),
+    //    m_DateCalcEngine.TryGetDateDifference(DateUtils::SystemTimeToDateTime(datetimeDifftest[testIndex].startDate),
     //    DateUtils::SystemTimeToDateTime(datetimeDifftest[testIndex].endDate), dateOutputFormat, &diff);
 
     //    // Assert for the result
@@ -1050,8 +1050,7 @@ TEST_METHOD(JaEraTransitionDifference)
     auto endTime = cal->GetDateTime();
 
     DateDifference diff;
-    viewModel->GetDateDifference(startTime, endTime, DateUnit::Day, &diff);
-
+    VERIFY_IS_TRUE(viewModel->TryGetDateDifference(startTime, endTime, DateUnit::Day, &diff));
     VERIFY_ARE_EQUAL(diff.day, 19);
 }
 }


### PR DESCRIPTION
## Fixes #554 

Modify how the Calculator behaves when `DateCalculationEngine::GetDateDifference` isn't able to calculate correctly the number of years, months, weeks, days between two dates.

Instead of displaying an incorrect result, the UI will now display the difference in days (only). 

### Description of the changes:
- Add new constant `DateDifferenceUnknown`
- rename `TryGetDateDifference` to `TryGetDateDifference` and modify the prototype to return a boolean.
- when we aren't able to calculate correctly the result, return false
- Modify `DateCalculatorViewModel::OnInputsChanged()` to display the difference in Days (only) when we were not able to calculate the difference in days/weeks/months 

### How changes were validated:
Manually.
This diff can be test with the same repro as #552 (if still not fixed).
