### PR TITLE
Modify ClipTime to adjust the datetime to local time before clipping 

### DIFF
--- a/src/CalcViewModel/DateCalculatorViewModel.cpp
+++ b/src/CalcViewModel/DateCalculatorViewModel.cpp
@@ -60,8 +60,7 @@ DateCalculatorViewModel::DateCalculatorViewModel()
     auto today = calendar->GetDateTime();
 
     // FromDate and ToDate should be clipped (adjusted to a consistent hour in UTC)
-    m_fromDate = ClipTime(today);
-    m_toDate = ClipTime(today);
+    m_fromDate = m_toDate = ClipTime(today, true);
 
     // StartDate should not be clipped
     m_startDate = today;
@@ -84,7 +83,7 @@ DateCalculatorViewModel::DateCalculatorViewModel()
 
     DayOfWeek trueDayOfWeek = calendar->DayOfWeek;
 
-    DateTime clippedTime = ClipTime(today);
+    DateTime clippedTime = ClipTime(today, false);
     calendar->SetDateTime(clippedTime);
     if (calendar->DayOfWeek != trueDayOfWeek)
     {
@@ -119,8 +118,8 @@ void DateCalculatorViewModel::OnInputsChanged()
 
     if (m_IsDateDiffMode)
     {
-        DateTime clippedFromDate = ClipTime(FromDate);
-        DateTime clippedToDate = ClipTime(ToDate);
+        DateTime clippedFromDate = ClipTime(FromDate, true);
+        DateTime clippedToDate = ClipTime(ToDate, true);
 
         // Calculate difference between two dates
         m_dateCalcEngine->GetDateDifference(clippedFromDate, clippedToDate, m_allDateUnitsOutputFormat, &dateDiff);
@@ -367,12 +366,34 @@ String ^ DateCalculatorViewModel::GetLocalizedNumberString(int value) const
     return ref new String(numberStr.c_str());
 }
 
-// Adjusts the given DateTime to 12AM (UTC) of the same day
-DateTime DateCalculatorViewModel::ClipTime(DateTime dateTime)
+/// <summary>
+/// Adjusts the given DateTime to 12AM of the same day
+/// </summary>
+/// <param name="dateTime">DateTime to clip</param>
+/// <param name="adjustUsingLocalTime">Adjust the datetime using local time (by default adjust using UTC time)</param>
+DateTime DateCalculatorViewModel::ClipTime(DateTime dateTime, bool adjustUsingLocalTime)
 {
+    DateTime referenceDateTime;
+    if (adjustUsingLocalTime)
+    {
+        FILETIME fileTime;
+        fileTime.dwLowDateTime = (DWORD)(dateTime.UniversalTime & 0xffffffff);
+        fileTime.dwHighDateTime = (DWORD)(dateTime.UniversalTime >> 32);
+
+        FILETIME localFileTime;
+        FileTimeToLocalFileTime(&fileTime, &localFileTime);
+
+        referenceDateTime.UniversalTime = (DWORD)localFileTime.dwHighDateTime;
+        referenceDateTime.UniversalTime <<= 32;
+        referenceDateTime.UniversalTime |= (DWORD)localFileTime.dwLowDateTime;
+    }
+    else
+    {
+        referenceDateTime = dateTime;
+    }
     auto calendar = ref new Calendar();
     calendar->ChangeTimeZone("UTC");
-    calendar->SetDateTime(dateTime);
+    calendar->SetDateTime(referenceDateTime);
     calendar->Period = calendar->FirstPeriodInThisDay;
     calendar->Hour = calendar->FirstHourInThisPeriod;
     calendar->Minute = 0;

--- a/src/CalcViewModel/DateCalculatorViewModel.h
+++ b/src/CalcViewModel/DateCalculatorViewModel.h
@@ -110,7 +110,7 @@ namespace CalculatorApp
             Platform::String ^ GetDateDiffString() const;
             Platform::String ^ GetDateDiffStringInDays() const;
             Platform::String ^ GetLocalizedNumberString(int value) const;
-            static Windows::Foundation::DateTime ClipTime(Windows::Foundation::DateTime dateTime);
+            static Windows::Foundation::DateTime ClipTime(Windows::Foundation::DateTime dateTime, bool adjustToLocalTime);
 
             property bool IsOutOfBound
             {


### PR DESCRIPTION
## Fixes #557 

In some cases (depending on the current time and time zone), the calculation of the difference between two dates was based on the previous or next day of the selected one.

To fix this issue, we need to "convert" FromDate and ToDate to local time (because CalendarDatePicker uses local time to generate the datetime) before clipping the time. 

This PR will make sure that `FromDate` and `ToDate` are correctly set and really match what the user selected.

### Description of the changes:
- Modify `ClipTime` and add an extra parameter to "convert" the current UTC FILETIME to Local FILETIME prior to clipping the time.


### How changes were validated:
- Manually tested with different time zones, date and time.
