### PR TITLE
Update .gitignore to ignore VSCode settings directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ bld/
 [Oo]bj/
 [Ll]og/
 
+# Visual Studio Code user setting files
+**/.vscode/
+
 # Visual Studio 2015 cache/options directory
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot


### PR DESCRIPTION
Some users (including this one) occasionally use VSCode for
inspecting/updating the project, so let's keep `git status`
clean by ignoring the VSCode user settings directory.

### Description of the changes:
- tells `git` to Ignore the `.vscode` directory within the root directory as well as any sub-directory

### How changes were validated:
- Added a `.vscode` directory to my root and a number of random sub-directories to my clone and ensured that `git status` reported that there were no new files to be added.