### PR TITLE
Ensure consistent margins/padding with currency converter keypad

### DIFF
--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -321,8 +321,6 @@
                                                      Threshold="1"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="GutterTop.Height" Value="0.5*"/>
-                        <Setter Target="GutterBottom.Height" Value="0.5*"/>
                         <Setter Target="GutterLeft.Width" Value="48"/>
                         <Setter Target="GutterRight.Width" Value="48"/>
                         <Setter Target="ColumnLeft.Width" Value="1*"/>
@@ -644,31 +642,27 @@
         <Grid x:Name="ConverterNumPad"
               Grid.Row="6"
               Grid.Column="1"
-              Margin="0,0,0,6"
+              Margin="3,0,3,3"
               FlowDirection="LeftToRight"
               RenderTransformOrigin="0.5,0.5">
             <Grid.RenderTransform>
                 <CompositeTransform/>
             </Grid.RenderTransform>
             <Grid.RowDefinitions>
-                <RowDefinition x:Name="GutterTop" Height="0"/>
                 <RowDefinition Height="1*"/>
                 <RowDefinition Height="1*"/>
                 <RowDefinition Height="1*"/>
                 <RowDefinition Height="1*"/>
                 <RowDefinition Height="1*"/>
-                <RowDefinition x:Name="GutterBottom" Height="0"/>
             </Grid.RowDefinitions>
             <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="0.25*"/>
                 <ColumnDefinition Width="1*"/>
                 <ColumnDefinition Width="1*"/>
                 <ColumnDefinition Width="1*"/>
-                <ColumnDefinition Width="0.25*"/>
             </Grid.ColumnDefinitions>
             <Grid x:Uid="DisplayControls"
-                  Grid.Row="1"
-                  Grid.Column="2"
+                  Grid.Row="0"
+                  Grid.Column="1"
                   Grid.ColumnSpan="2"
                   AutomationProperties.HeadingLevel="Level1">
                 <Grid.ColumnDefinitions>
@@ -696,9 +690,9 @@
 
             <local:NumberPad x:Name="NumberPad"
                              x:Uid="NumberPad"
-                             Grid.Row="2"
+                             Grid.Row="1"
                              Grid.RowSpan="4"
-                             Grid.Column="1"
+                             Grid.Column="0"
                              Grid.ColumnSpan="3"
                              VerticalAlignment="Stretch"
                              AutomationProperties.HeadingLevel="Level1"
@@ -707,8 +701,8 @@
                              TabNavigation="Local"/>
             <controls:CalculatorButton x:Name="ConverterNegateButton"
                                        x:Uid="converterNegateButton"
-                                       Grid.Row="5"
-                                       Grid.Column="1"
+                                       Grid.Row="4"
+                                       Grid.Column="0"
                                        Style="{StaticResource SymbolOperatorButtonStyle}"
                                        FontSize="16"
                                        ButtonId="Negate"


### PR DESCRIPTION
## Fixes #87.

### Description of the changes:
- Simplifies the layout of `ConverterNumPad` to match that  seen of `NumpadPanel` in Calculator.xaml.
   - They now both use the same static margin ('`3,0,3,3`)
   - Removed two "gutter" columns that had been used for dynamic margins.

> The `GutterLeft` and `GutterRight` columns were left untouched on purpose.
> They are only activated when in a "landscape" width/height orientation, used to ensure that the app display is evenly split 50/50 between the input fields and the number pad.
> `GutterLeft` gives a margin to the input field column, while `GutterRight` is used to ensure that the number pad column has an equal width available to it (as the numberpad is displayed in a column span that merges its column with that of `GutterRight`.

### How changes were validated:
- Validated with a "screen ruler" that the left/right/bottom margins were the same within Volume.

![Volume (before and after)](https://user-images.githubusercontent.com/22158599/60053943-fff03c00-968d-11e9-872a-d557561eb0ca.png)

- Validated with a "screen ruler" that the left/top/bottom in Volume were identical to those seen in Standard mode.
![Existing standard vs new Volume](https://user-images.githubusercontent.com/22158599/60053948-02eb2c80-968e-11e9-8d38-7fe0595391f6.png)

- Verified the margins in "wide" mode as well
![Volume (wide) (before and after)](https://user-images.githubusercontent.com/22158599/60053973-14343900-968e-11e9-9dd9-899b32b522dd.png)


