### PR TITLE
Use 2020 as the major version for the appxbundle

### DIFF
--- a/build/pipelines/templates/package-appxbundle.yaml
+++ b/build/pipelines/templates/package-appxbundle.yaml
@@ -38,10 +38,13 @@ jobs:
       filePath: $(Build.SourcesDirectory)\build\scripts\CreateAppxBundleMapping.ps1
       arguments: '-InputPath $(Build.ArtifactStagingDirectory)\drop\Release -ProjectName Calculator -OutputFile $(Build.BinariesDirectory)\AppxBundleMapping.txt'
 
-  - script: '"C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\MakeAppx.exe" bundle /v /bv %BUNDLEVERSION% /f %MAPPINGFILEPATH% /p %OUTPUTPATH%'
+  - powershell: |
+      $buildVersion = [version]$Env:BUILDVERSION
+      $bundleVersion = "2020.$($buildVersion.Minor).$($buildVersion.Build).$($buildVersion.Revision)"
+      & "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x86\MakeAppx.exe" bundle /v /bv $bundleVersion /f $Env:MAPPINGFILEPATH /p $Env:OUTPUTPATH
     displayName: Make AppxBundle
     env:
-      BUNDLEVERSION: $(Build.BuildNumber)
+      BUILDVERSION: $(Build.BuildNumber)
       MAPPINGFILEPATH: $(Build.BinariesDirectory)\AppxBundleMapping.txt
       OUTPUTPATH: $(Build.BinariesDirectory)\Microsoft.WindowsCalculator_8wekyb3d8bbwe.appxbundle
 


### PR DESCRIPTION
Calculator's build number in release builds follows the pattern 10.{YYMM}.{build}.0. We use the build number in lots of places, including the app binaries, the app package version, and the app _bundle_ version. Before Calculator moved to GitHub, the app _bundle_ version was generated using a date-based formula which produced versions like "2019.105.612.0". This means that the bundles generated from GitHub have a lower version than previous bundles. This appears to cause some issues during device reset.

This change sets the app bundle major version number to "2020" to ensure that newly-produced appxbundles have higher versions than legacy bundles. The remaining parts of the bundle version number will match the build number for easy reference.

Also updating the MakeAppx version used in bundle creation to 18362.