### PR TITLE
Add InputPasted Event to Diagnostics Implementation

### DIFF
--- a/src/CalcViewModel/Common/TraceLogger.cpp
+++ b/src/CalcViewModel/Common/TraceLogger.cpp
@@ -33,6 +33,7 @@ namespace CalculatorApp
     constexpr auto EVENT_NAME_MEMORY_ITEM_LOAD = L"MemoryItemLoad";
     constexpr auto EVENT_NAME_VISUAL_STATE_CHANGED = L"VisualStateChanged";
     constexpr auto EVENT_NAME_CONVERTER_INPUT_RECEIVED = L"ConverterInputReceived";
+    constexpr auto EVENT_NAME_INPUT_PASTED = L"InputPasted";
 
     constexpr auto EVENT_NAME_EXCEPTION = L"Exception";
 
@@ -368,5 +369,17 @@ namespace CalculatorApp
         fields.AddGuid(L"SessionGuid", sessionGuid);
         fields.AddUInt64(PDT_PRIVACY_DATA_TAG, PDT_PRODUCT_AND_SERVICE_USAGE);
         LogLevel2Event(EVENT_NAME_NAV_BAR_OPENED, fields);
+    }
+
+    void TraceLogger::LogInputPasted(ViewMode mode) const
+    {
+        if (!GetTraceLoggingProviderEnabled())
+            return;
+
+        LoggingFields fields{};
+        fields.AddGuid(L"SessionGuid", sessionGuid);
+        fields.AddString(L"Mode", NavCategory::GetFriendlyName(mode)->Data());
+        fields.AddUInt64(PDT_PRIVACY_DATA_TAG, PDT_PRODUCT_AND_SERVICE_USAGE);
+        LogLevel2Event(EVENT_NAME_INPUT_PASTED, fields);
     }
 }

--- a/src/CalcViewModel/Common/TraceLogger.h
+++ b/src/CalcViewModel/Common/TraceLogger.h
@@ -54,6 +54,7 @@ namespace CalculatorApp
         void LogStandardException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ const std::exception& e) const;
         void LogWinRTException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ winrt::hresult_error const& e) const;
         void LogPlatformException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ Platform::Exception ^ e) const;
+        void LogInputPasted(CalculatorApp::Common::ViewMode mode) const;
 
     private:
         // Create an instance of TraceLogger

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -765,6 +765,7 @@ void StandardCalculatorViewModel::OnPaste(String ^ pastedString)
         return;
     }
 
+    TraceLogger::GetInstance().LogInputPasted(GetCalculatorMode());
     bool isFirstLegalChar = true;
     m_standardCalculatorManager.SendCommand(Command::CommandCENTR);
     bool sendNegate = false;

--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -893,6 +893,7 @@ void UnitConverterViewModel::OnPaste(String ^ stringToPaste)
         return;
     }
 
+    TraceLogger::GetInstance().LogInputPasted(Mode);
     bool isFirstLegalChar = true;
     bool sendNegate = false;
     wstring accumulation = L"";


### PR DESCRIPTION
## Fixes #592.


### Description of the changes:
- Added LogInputPasted event to the TraceLogger
- Called LogInputPasted from the StandardCalculatorViewModel and the UnitConverterViewModel

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually: copy and pasted values into several modes and verified the event was triggered.]
