### PR TITLE
Restore user preferences

### DIFF
--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -791,17 +791,27 @@ void UnitConverter::InitializeSelectedUnits()
     vector<Unit> curUnits = itr->second;
     if (!curUnits.empty())
     {
+        // Units may already have been initialized through UnitConverter::RestoreUserPreferences().
+        // Check if they have been, and if so, do not override restored units.
+        bool isFromUnitValid = m_fromType != EMPTY_UNIT && find(curUnits.begin(), curUnits.end(), m_fromType) != curUnits.end();
+        bool isToUnitValid = m_toType != EMPTY_UNIT && find(curUnits.begin(), curUnits.end(), m_toType) != curUnits.end();
+
+        if (isFromUnitValid && isToUnitValid)
+        {
+            return;
+        }
+
         bool conversionSourceSet = false;
         bool conversionTargetSet = false;
         for (const Unit& cur : curUnits)
         {
-            if (!conversionSourceSet && cur.isConversionSource)
+            if (!(conversionSourceSet || isFromUnitValid) && cur.isConversionSource)
             {
                 m_fromType = cur;
                 conversionSourceSet = true;
             }
 
-            if (!conversionTargetSet && cur.isConversionTarget)
+            if (!(conversionTargetSet || isToUnitValid) && cur.isConversionTarget)
             {
                 m_toType = cur;
                 conversionTargetSet = true;
@@ -886,8 +896,8 @@ void UnitConverter::Calculate()
                 }
                 else
                 {
-					// Fewer digits are needed following the decimal if the number is large,
-					// we calculate the number of decimals necessary based on the number of digits in the integer part.
+                    // Fewer digits are needed following the decimal if the number is large,
+                    // we calculate the number of decimals necessary based on the number of digits in the integer part.
                     precision = max(0, max(OPTIMALDIGITSALLOWED, min(MAXIMUMDIGITSALLOWED, currentNumberSignificantDigits)) - numPreDecimal);
                 }
 

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -458,18 +458,15 @@ size_t CopyPasteManager::StandardScientificOperandLength(const wstring& operand)
 {
     const bool hasDecimal = operand.find('.') != wstring::npos;
 
-    if (hasDecimal)
+    if (hasDecimal && operand.length() >= 2)
     {
-        if (operand.length() >= 2)
+        if ((operand[0] == L'0') && (operand[1] == L'.'))
         {
-            if ((operand[0] == L'0') && (operand[1] == L'.'))
-            {
-                return operand.length() - 2;
-            }
-            else
-            {
-                return operand.length() - 1;
-            }
+            return operand.length() - 2;
+        }
+        else
+        {
+            return operand.length() - 1;
         }
     }
 

--- a/src/CalcViewModel/Common/KeyboardShortcutManager.cpp
+++ b/src/CalcViewModel/Common/KeyboardShortcutManager.cpp
@@ -115,9 +115,8 @@ namespace CalculatorApp
         // key have the same command
         template <typename T>
         void RunFirstEnabledButtonCommand(const T& buttons)
-        {
-            auto buttonIterator = buttons.first;
-            for (; buttonIterator != buttons.second; ++buttonIterator)
+        {  
+            for (auto buttonIterator = buttons.first; buttonIterator != buttons.second; ++buttonIterator)
             {
                 auto button = buttonIterator->second.Resolve<ButtonBase>();
                 if (button && button->IsEnabled)

--- a/src/CalcViewModel/Common/LocalizationService.cpp
+++ b/src/CalcViewModel/Common/LocalizationService.cpp
@@ -62,7 +62,7 @@ LocalizationService ^ LocalizationService::GetInstance()
 /// <remarks>
 /// Should only be used for test purpose
 /// </remarks>
-void LocalizationService::OverrideWithLanguage(_In_ const wchar_t * const language)
+void LocalizationService::OverrideWithLanguage(_In_ const wchar_t* const language)
 {
     s_singletonInstance = ref new LocalizationService(language);
 }
@@ -71,12 +71,12 @@ void LocalizationService::OverrideWithLanguage(_In_ const wchar_t * const langua
 /// Constructor
 /// </summary>
 /// <param name="overridedLanguage">RFC-5646 identifier of the language to use, if null, will use the current language of the system</param>
-LocalizationService::LocalizationService(_In_ const wchar_t * const overridedLanguage)
+LocalizationService::LocalizationService(_In_ const wchar_t* const overridedLanguage)
 {
     m_isLanguageOverrided = overridedLanguage != nullptr;
     m_language = m_isLanguageOverrided ? ref new Platform::String(overridedLanguage) : ApplicationLanguages::Languages->GetAt(0);
-    m_flowDirection = ResourceContext::GetForViewIndependentUse()->QualifierValues->Lookup(L"LayoutDirection")
-        != L"LTR" ? FlowDirection::RightToLeft : FlowDirection::LeftToRight;
+    m_flowDirection = ResourceContext::GetForViewIndependentUse()->QualifierValues->Lookup(L"LayoutDirection") != L"LTR" ? FlowDirection::RightToLeft
+                                                                                                                         : FlowDirection::LeftToRight;
     wstring localeName = wstring(m_language->Data());
     localeName += L".UTF8";
 
@@ -399,7 +399,9 @@ DateTimeFormatter ^ LocalizationService::GetRegionalSettingsAwareDateTimeFormatt
 
 // If successful, returns a formatter that respects the user's regional format settings,
 // as configured by running intl.cpl.
-DateTimeFormatter ^ LocalizationService::GetRegionalSettingsAwareDateTimeFormatter(_In_ String ^ format, _In_ String ^ calendarIdentifier, _In_ String ^ clockIdentifier) const
+DateTimeFormatter
+    ^ LocalizationService::GetRegionalSettingsAwareDateTimeFormatter(_In_ String ^ format, _In_ String ^ calendarIdentifier, _In_ String ^ clockIdentifier)
+        const
 {
     IIterable<String ^> ^ languageIdentifiers = LocalizationService::GetLanguageIdentifiers();
     if (languageIdentifiers == nullptr)

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -87,7 +87,7 @@ namespace CalculatorApp
     }
 }
 
-CurrencyDataLoader::CurrencyDataLoader(_In_ unique_ptr<ICurrencyHttpClient> client, const wchar_t * forcedResponseLanguage)
+CurrencyDataLoader::CurrencyDataLoader(_In_ unique_ptr<ICurrencyHttpClient> client, const wchar_t* forcedResponseLanguage)
     : m_client(move(client))
     , m_loadStatus(CurrencyLoadStatus::NotLoaded)
     , m_responseLanguage(L"en-US")
@@ -527,9 +527,7 @@ bool CurrencyDataLoader::TryParseStaticData(_In_ String ^ rawJson, _Inout_ vecto
         staticData[i] = CurrencyStaticData{ countryCode, countryName, currencyCode, currencyName, currencySymbol };
     }
 
-    auto sortCountryNames = [](const UCM::CurrencyStaticData & s) {
-        return ref new String(s.countryName.c_str());
-    };
+    auto sortCountryNames = [](const UCM::CurrencyStaticData& s) { return ref new String(s.countryName.c_str()); };
 
     LocalizationService::GetInstance()->Sort<UCM::CurrencyStaticData>(staticData, sortCountryNames);
 
@@ -554,7 +552,7 @@ bool CurrencyDataLoader::TryParseAllRatiosData(_In_ String ^ rawJson, _Inout_ Cu
         {
             obj = data->GetAt(i)->GetObject();
         }
-        catch (COMException^ e)
+        catch (COMException ^ e)
         {
             if (e->HResult == E_ILLEGAL_METHOD_CALL)
             {
@@ -628,7 +626,7 @@ task<void> CurrencyDataLoader::FinalizeUnits(_In_ const vector<UCM::CurrencyStat
             }
         }
 
-        if (!isConversionSourceSet || !isConversionTargetSet)
+        if (!(isConversionSourceSet && isConversionTargetSet))
         {
             GuaranteeSelectedUnits();
             defaultCurrencies = { DEFAULT_FROM_CURRENCY, DEFAULT_TO_CURRENCY };

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -772,9 +772,8 @@ void StandardCalculatorViewModel::OnPaste(String ^ pastedString)
     vector<bool> negateStack;
 
     // Iterate through each character pasted, and if it's valid, send it to the model.
-    auto it = pastedString->Begin();
 
-    while (it != pastedString->End())
+    for (auto it = pastedString->Begin(); it != pastedString->End(); ++it)
     {
         bool sendCommand = true;
         bool canSendNegate = false;
@@ -783,7 +782,6 @@ void StandardCalculatorViewModel::OnPaste(String ^ pastedString)
 
         if (mappedNumOp == NumbersAndOperatorsEnum::None)
         {
-            ++it;
             continue;
         }
 
@@ -898,8 +896,6 @@ void StandardCalculatorViewModel::OnPaste(String ^ pastedString)
             break;
             }
         }
-
-        ++it;
     }
 }
 
@@ -1683,7 +1679,7 @@ NumbersAndOperatorsEnum StandardCalculatorViewModel::ConvertIntegerToNumbersAndO
     switch (parameter)
     {
     case 321:
-     default:
+    default:
         return NumbersAndOperatorsEnum::Degree;
     case 322:
         return NumbersAndOperatorsEnum::Radians;

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -347,7 +347,7 @@ void StandardCalculatorViewModel::SetTokens(_Inout_ shared_ptr<CalculatorVector<
             }
             else
             {
-                type = currentToken.first == separator ? TokenType::Separator : TokenType::Operator
+                type = currentToken.first == separator ? TokenType::Separator : TokenType::Operator;
             }
 
             auto currentTokenString = ref new String(currentToken.first.c_str());

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -339,7 +339,7 @@ void StandardCalculatorViewModel::SetTokens(_Inout_ shared_ptr<CalculatorVector<
             bool isEditable = currentToken.second != -1;
             localizer.LocalizeDisplayValue(&(currentToken.first));
 
-            if (!isEditable)
+            if (isEditable)
             {
                 shared_ptr<IExpressionCommand> command;
                 IFTPlatformException(m_commands->GetAt(static_cast<unsigned int>(currentToken.second), &command));
@@ -1684,18 +1684,13 @@ NumbersAndOperatorsEnum StandardCalculatorViewModel::ConvertIntegerToNumbersAndO
     switch (parameter)
     {
     case 321:
-        angletype = NumbersAndOperatorsEnum::Degree;
-        break;
+     default:
+        return NumbersAndOperatorsEnum::Degree;
     case 322:
-        angletype = NumbersAndOperatorsEnum::Radians;
-        break;
+        return NumbersAndOperatorsEnum::Radians;
     case 323:
-        angletype = NumbersAndOperatorsEnum::Grads;
-        break;
-    default:
-        angletype = NumbersAndOperatorsEnum::Degree;
+        return NumbersAndOperatorsEnum::Grads;
     };
-    return angletype;
 }
 
 void StandardCalculatorViewModel::UpdateOperand(int pos, String ^ text)

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1680,7 +1680,6 @@ void StandardCalculatorViewModel::SwitchAngleType(NumbersAndOperatorsEnum num)
 
 NumbersAndOperatorsEnum StandardCalculatorViewModel::ConvertIntegerToNumbersAndOperatorsEnum(unsigned int parameter)
 {
-    NumbersAndOperatorsEnum angletype;
     switch (parameter)
     {
     case 321:

--- a/src/CalcViewModel/UnitConverterViewModel.h
+++ b/src/CalcViewModel/UnitConverterViewModel.h
@@ -311,8 +311,6 @@ namespace CalculatorApp
             std::wstring m_valueFromUnlocalized;
             std::wstring m_valueToUnlocalized;
             bool m_relocalizeStringOnSwitch;
-            // For Saving the User Preferences only if the Unit converter ViewModel is initialised for the first time
-            bool m_IsFirstTime;
 
             Platform::String ^ m_localizedValueFromFormat;
             Platform::String ^ m_localizedValueFromDecimalFormat;


### PR DESCRIPTION
## Fixes #445


### Description of the changes:
- On April 14, 2019, @TurtleShip had a bug fix that caused Calculator to fail to restore those changes. This is PR#456. Because this was not touched since then, I am making this PR now.
- Removed m_isFirstTime
- Refraining from setting default values if they already have valid values
- Refactoring to condense the code changes so it falls in line the code style of the rest of the project without any side effects.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual and Automated testing in regards to the reproduction steps in the original PR validated these changes.
-
-
