### PR TITLE
Fixed issue where UI Responsive events were not fired

### DIFF
--- a/src/CalcViewModel/ApplicationViewModel.cpp
+++ b/src/CalcViewModel/ApplicationViewModel.cpp
@@ -163,7 +163,7 @@ void ApplicationViewModel::OnModeChanged()
     }
     else
     {
-        TraceLogger::GetInstance().LogWindowCreated(m_mode);
+        TraceLogger::GetInstance().LogWindowCreated(m_mode, ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread()));
     }
 
     RaisePropertyChanged(ClearMemoryVisibilityPropertyName);

--- a/src/CalcViewModel/Common/TraceLogger.cpp
+++ b/src/CalcViewModel/Common/TraceLogger.cpp
@@ -104,24 +104,17 @@ namespace CalculatorApp
 #pragma endregion
 
     // return true if windowId is logged once else return false
-    bool TraceLogger::UpdateWindowIdLog(int windowId)
+    bool TraceLogger::IsWindowIdInLog(int windowId)
     {
         // Writer lock for the windowIdLog resource
         reader_writer_lock::scoped_lock lock(s_traceLoggerLock);
 
-        if (windowIdLog.find(windowId) == windowIdLog.end())
+        if (find(windowIdLog.begin(), windowIdLog.end(), windowId) == windowIdLog.end())
         {
             return false;
         }
-        if (windowIdLog[windowId] == false)
-        {
-            windowIdLog[windowId] = true;
-            return true;
-        }
-        else
-        {
-            return false;
-        }
+
+        return true;
     }
 
     void TraceLogger::LogVisualStateChanged(ViewMode mode, wstring_view state) const
@@ -139,8 +132,14 @@ namespace CalculatorApp
         LogLevel2Event(EVENT_NAME_VISUAL_STATE_CHANGED, fields);
     }
 
-    void TraceLogger::LogWindowCreated(ViewMode mode) const
+    void TraceLogger::LogWindowCreated(ViewMode mode, int windowId)
     {
+        // store windowId in windowIdLog which says we have logged mode for the present windowId.
+        if (find(windowIdLog.begin(), windowIdLog.end(), windowId) == windowIdLog.end())
+        {
+            windowIdLog.push_back(windowId);
+        }
+
         if (!GetTraceLoggingProviderEnabled())
             return;
 

--- a/src/CalcViewModel/Common/TraceLogger.cpp
+++ b/src/CalcViewModel/Common/TraceLogger.cpp
@@ -135,7 +135,7 @@ namespace CalculatorApp
     void TraceLogger::LogWindowCreated(ViewMode mode, int windowId)
     {
         // store windowId in windowIdLog which says we have logged mode for the present windowId.
-        if (find(windowIdLog.begin(), windowIdLog.end(), windowId) == windowIdLog.end())
+        if (!IsWindowIdInLog(windowId))
         {
             windowIdLog.push_back(windowId);
         }

--- a/src/CalcViewModel/Common/TraceLogger.h
+++ b/src/CalcViewModel/Common/TraceLogger.h
@@ -44,9 +44,9 @@ namespace CalculatorApp
         void LogButtonUsage();
         void LogDateCalculationModeUsed(bool AddSubtractMode);
         void UpdateWindowCount(size_t windowCount = 0);
-        bool UpdateWindowIdLog(int windowId);
+        bool IsWindowIdInLog(int windowId);
         void LogVisualStateChanged(CalculatorApp::Common::ViewMode mode, std::wstring_view state) const;
-        void LogWindowCreated(CalculatorApp::Common::ViewMode mode) const;
+        void LogWindowCreated(CalculatorApp::Common::ViewMode mode, int windowId);
         void LogConverterInputReceived(CalculatorApp::Common::ViewMode mode) const;
         void LogNavBarOpened() const;
 
@@ -73,7 +73,7 @@ namespace CalculatorApp
         winrt::Windows::Foundation::Diagnostics::LoggingChannel g_calculatorProvider;
 
         std::vector<ButtonLog> buttonLog;
-        std::map<int, bool> windowIdLog;
+        std::vector<int> windowIdLog;
 
         GUID sessionGuid;
         size_t currentWindowCount = 0;

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -135,7 +135,7 @@ void Calculator::OnLoaded(_In_ Object ^, _In_ RoutedEventArgs ^)
     WeakReference weakThis(this);
     this->Dispatcher->RunAsync(
         CoreDispatcherPriority::Normal, ref new DispatchedHandler([weakThis]() {
-            if (TraceLogger::GetInstance().UpdateWindowIdLog(ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread())))
+            if (TraceLogger::GetInstance().IsWindowIdInLog(ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread())))
             {
                 auto refThis = weakThis.Resolve<Calculator>();
                 if (refThis != nullptr)

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -251,7 +251,7 @@ void MainPage::OnPageLoaded(_In_ Object ^, _In_ RoutedEventArgs ^ args)
     // Delay load things later when we get a chance.
     this->Dispatcher->RunAsync(
         CoreDispatcherPriority::Normal, ref new DispatchedHandler([]() {
-            if (TraceLogger::GetInstance().UpdateWindowIdLog(ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread())))
+            if (TraceLogger::GetInstance().IsWindowIdInLog(ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread())))
             {
                 AppLifecycleLogger::GetInstance().LaunchUIResponsive();
                 AppLifecycleLogger::GetInstance().LaunchVisibleComplete();


### PR DESCRIPTION
## Fixes #602 


### Description of the changes:
- Updated the LogWindowCreated method to take in the windowId and update the WindowIdLog
- Renamed UpdateWindowIdLog to IsWindowIdInLog so that it reflects what the method is actually doing.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually using internal diagnostics tools to ensure the UI Responsive events are firing now.

