### PR TITLE
Fix certificate issue in CalculatorUnitTests

### DIFF
--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -16,6 +16,8 @@
     <!-- We want to automatic replace of MinVersion/MaxVersionTested for unit tests. -->
     <AppxOSMinVersionReplaceManifestVersion>true</AppxOSMinVersionReplaceManifestVersion>
     <AppxOSMaxVersionTestedReplaceManifestVersion>true</AppxOSMaxVersionTestedReplaceManifestVersion>
+    <PackageCertificateKeyFile>CalculatorUnitTests_TemporaryKey.pfx</PackageCertificateKeyFile>
+    <PackageCertificateThumbprint>be776c83699dbce4969de9ee730aeaf66c5d5182</PackageCertificateThumbprint>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <ItemGroup Label="ProjectConfigurations">
@@ -128,10 +130,6 @@
   <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
-  <PropertyGroup Label="UserMacros">
-    <PackageCertificateKeyFile>CalculatorUnitTests_TemporaryKey.pfx</PackageCertificateKeyFile>
-    <PackageCertificateThumbprint>3F0C32266A4D995CC08C9AEC3960CFF3EF0D1853</PackageCertificateThumbprint>
-  </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM'">
     <ClCompile>
       <AdditionalOptions>/bigobj /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 %(AdditionalOptions)</AdditionalOptions>


### PR DESCRIPTION
## Fixes #616

The problem reported by users regarding the impossibility to compile `CalculatorUnitTests` is due to a mismatch between the certificate and the certificate thumbprint value in the vcxproj.

**.vcxproj**
```xml
<PackageCertificateThumbprint>**3F0C32266A4D995CC08C9AEC3960CFF3EF0D1853</PackageCertificateThumbprint>
```

**certificate info**
![image](https://user-images.githubusercontent.com/1226538/62409776-2492da00-b591-11e9-845f-3178bcd0998a.png)

This mismatch isn't new and has always been present in this repository, but Visual Studio has ignored it so far. It seems that the certificate thumbprint verification was introduced in Visual Studio 2019 16.2. (the project compiles correctly with 16.1).

### 3 ways to fix the issue
- Remove the `<PackageCertificateThumbprint>` from .vcxproj, so Visual Studio won't verify the certificate thumbprint
- Fix the value of `<PackageCertificateThumbprint>`
- Fully remove the certificate from the project (the certificate is only necessary when we generate a msix, not when Visual Studio deploys the application)

Because this project is for Unit Tests, I assume that it is never sideloaded using a msix and that therefore solution 3 is the most suitable, but in case it breaks the CI, the 2 others are also possible.

**EDIT: Calculator-CI fails if one of these properties is missing, Solution 2 is the only fix possible.** 

### How changes were validated:
- Manually tested

