### PR TITLE
Updated README to note the requirement for installing WinAppDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Prerequisites:
 
 - Open [src\Calculator.sln](/src/Calculator.sln) in Visual Studio to build and run the Calculator app.
 - For a general description of the Calculator project architecture see [ApplicationArchitecture.md](docs/ApplicationArchitecture.md).
+- To run the UI Tests, you need to install
+  [Windows Application Driver (WinAppDriver)](https://github.com/microsoft/WinAppDriver#installing-and-running-windows-application-driver).
 
 ## Contributing
 Want to contribute? The team encourages community feedback and contributions. Please follow our [contributing guidelines](CONTRIBUTING.md).
@@ -55,9 +57,9 @@ Diagnostic data is disabled in development builds by default, and can be enabled
 build flag.
 
 ## Currency Converter
-Windows Calculator includes a currency converter feature that uses mock data in developer builds. The data that 
-Microsoft uses for the currency converter feature (e.g., in the retail version of the application) is not licensed 
-for your use. The mock data will be clearly identifiable as it references planets instead of countries, 
+Windows Calculator includes a currency converter feature that uses mock data in developer builds. The data that
+Microsoft uses for the currency converter feature (e.g., in the retail version of the application) is not licensed
+for your use. The mock data will be clearly identifiable as it references planets instead of countries,
 and remains static regardless of selected inputs.
 
 ## Reporting Security Issues

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ Prerequisites:
 
 - Open [src\Calculator.sln](/src/Calculator.sln) in Visual Studio to build and run the Calculator app.
 - For a general description of the Calculator project architecture see [ApplicationArchitecture.md](docs/ApplicationArchitecture.md).
-- To run the UI Tests, you need to install
-  [Windows Application Driver (WinAppDriver)](https://github.com/microsoft/WinAppDriver#installing-and-running-windows-application-driver).
+- To run the UI Tests, you need to make sure that
+  [Windows Application Driver (WinAppDriver)](https://github.com/microsoft/WinAppDriver/releases/latest)
+  is installed.
 
 ## Contributing
 Want to contribute? The team encourages community feedback and contributions. Please follow our [contributing guidelines](CONTRIBUTING.md).


### PR DESCRIPTION
## Fixes #621

### Description of the changes:
- Our documentation should make it clear to contributors what the expected developer
  environment is in order for the project to work.  In this case, a user tried to run the UI
  tests, unaware that they needed WinAppDriver installed on their machine.  This updates
  the README to indicate that requirement.
- Trailing spaces from other parts of the document were also removed as part of this change