### PR TITLE
Fixes Always-on-Top crashes in release

### DIFF
--- a/src/CalcViewModel/ApplicationViewModel.cpp
+++ b/src/CalcViewModel/ApplicationViewModel.cpp
@@ -213,6 +213,7 @@ void ApplicationViewModel::ToggleAlwaysOnTop(float width, float height)
     HandleToggleAlwaysOnTop(width, height);
 }
 
+#pragma optimize("", off)
 task<void> ApplicationViewModel::HandleToggleAlwaysOnTop(float width, float height)
 {
     if (ApplicationView::GetForCurrentView()->ViewMode == ApplicationViewMode::CompactOverlay)
@@ -257,7 +258,8 @@ task<void> ApplicationViewModel::HandleToggleAlwaysOnTop(float width, float heig
         IsAlwaysOnTop = success;
     }
     SetDisplayNormalAlwaysOnTopOption();
-}
+};
+#pragma optimize("", on)
 
 void ApplicationViewModel::SetDisplayNormalAlwaysOnTopOption()
 {


### PR DESCRIPTION
### Description of the changes:
- Always-on-Top currently crashes in release due to a compiler optimization bug related to co_await's. I've fixed this by turning off compiler optimization for parts of the code that uses co_await's.

### How changes were validated:
- Manual testing.

Related to Issue #560