### PR TITLE
Prevent Dev title from showing up on Store builds

### DIFF
--- a/src/Calculator/Calculator.vcxproj
+++ b/src/Calculator/Calculator.vcxproj
@@ -216,7 +216,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(IsStoreBuild)' == 'True'">
     <ClCompile>
-      <AdditionalOptions>/DSEND_DIAGNOSTICS %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/DSEND_DIAGNOSTICS /DIS_STORE_BUILD %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
   </ItemDefinitionGroup>
   <PropertyGroup>

--- a/src/Calculator/Views/TitleBar.xaml.cpp
+++ b/src/Calculator/Views/TitleBar.xaml.cpp
@@ -36,11 +36,11 @@ namespace CalculatorApp
 
         Loaded += ref new RoutedEventHandler(this, &TitleBar::OnLoaded);
         Unloaded += ref new RoutedEventHandler(this, &TitleBar::OnUnloaded);
-#ifdef IsStoreBuild
+#ifdef IS_STORE_BUILD
         AppName->Text = AppResourceProvider::GetInstance().GetResourceString(L"AppName");
 #else
         AppName->Text = AppResourceProvider::GetInstance().GetResourceString(L"DevAppName");
-#endif //IsStoreBuild
+#endif //IS_STORE_BUILD
     }
 
     void TitleBar::OnLoaded(_In_ Object ^ /*sender*/, _In_ RoutedEventArgs ^ /*e*/)


### PR DESCRIPTION
Commit 0722781fc updated the app to use `DevAppName` for the app's window title when it was a non-official build, based on the state of `IsStoreBuild`.

Unfortunately, `IsStoreBuild` is a _project_ level variable defined in [build-app-internal.yaml](https://github.com/microsoft/calculator/blob/0722781fc60565938da42ea252766b30d02e5fb5/build/pipelines/templates/build-app-internal.yaml#L36), but not a _compile-time_ defined value.

To solve this, we are now defining `IS_STORE_BUILD` in `Calculator.vcxproj` when `IsStoreBuild='True'`, the same way that we set `SEND_DIAGNOSTICS` for official builds, and we'll change the window title based on that new `#define`.

Using this new `#define` can lead us down a slippery slope.  We need to limit the amount of divergent code that we have between dev/official builds.  This should be hopefully one of very few instances where this value is ever used.

### Description of the changes:
- Sets a new `#define` named `IS_STORE_BUILD` when the _project_ flag `IsStoreBuild` is set to `True` for the `Calculator` project.
- Updated the check for `IsStoreBuild` when determining the window title name to instead check against `IS_STORE_BUILD`

### How changes were validated:
- Launched via the debugger and verified both `IS_STORE_BUILD` and `SEND_DIAGNOSTICS` were not set.  Then, modified the project file and changed the check to be `IsStoreBuild != 'True'` and ran the same checks again, and verified that this time both `IS_STORE_BUILD` and `SEND_DIAGNOSTICS` were set.