### PR TITLE
Add copy button to history menu item context menu

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -1117,6 +1117,10 @@
     <value>Delete</value>
     <comment>Text string for the Calculator Delete swipe button in the History list</comment>
   </data>
+  <data name="CopyHistoryMenuItem.Text" xml:space="preserve"> 
+     <value>Copy</value> 
+     <comment>Text string for the Calculator Copy option in the History list context menu</comment> 
+  </data>
   <data name="DeleteHistoryMenuItem.Text" xml:space="preserve">
     <value>Delete</value>
     <comment>Text string for the Calculator Delete option in the History list context menu</comment>

--- a/src/Calculator/Views/HistoryList.xaml
+++ b/src/Calculator/Views/HistoryList.xaml
@@ -50,8 +50,7 @@
             </muxc:SwipeItems>
 
             <MenuFlyout x:Name="HistoryContextMenu">
-                <MenuFlyoutItem x:Name="CopyHistoryMenuItem"
-                                x:Uid="CopyHistoryMenuItem"
+                <MenuFlyoutItem x:Uid="CopyHistoryMenuItem"
                                 Click="OnCopyMenuItemClicked"
                                 Icon="Copy"/>
                 <MenuFlyoutItem x:Uid="DeleteHistoryMenuItem"

--- a/src/Calculator/Views/HistoryList.xaml
+++ b/src/Calculator/Views/HistoryList.xaml
@@ -50,6 +50,10 @@
             </muxc:SwipeItems>
 
             <MenuFlyout x:Name="HistoryContextMenu">
+                <MenuFlyoutItem x:Name="CopyHistoryMenuItem"
+                                x:Uid="CopyHistoryMenuItem"
+                                Click="OnCopyMenuItemClicked"
+                                Icon="Copy"/>
                 <MenuFlyoutItem x:Uid="DeleteHistoryMenuItem"
                                 Click="OnDeleteMenuItemClicked"
                                 Icon="Delete"/>

--- a/src/Calculator/Views/HistoryList.xaml.cpp
+++ b/src/Calculator/Views/HistoryList.xaml.cpp
@@ -38,8 +38,6 @@ HistoryList::HistoryList()
 {
     InitializeComponent();
 
-    CopyHistoryMenuItem->Text = AppResourceProvider::GetInstance().GetResourceString(L"copyMenuItem");
-
     HistoryEmpty->FlowDirection = LocalizationService::GetInstance()->GetFlowDirection();
 }
 

--- a/src/Calculator/Views/HistoryList.xaml.cpp
+++ b/src/Calculator/Views/HistoryList.xaml.cpp
@@ -8,6 +8,7 @@
 
 #include "pch.h"
 #include "HistoryList.xaml.h"
+#include "CalcViewModel/Common/CopyPasteManager.h"
 #include "CalcViewModel/Common/LocalizationService.h"
 
 using namespace CalculatorApp;
@@ -37,6 +38,8 @@ HistoryList::HistoryList()
 {
     InitializeComponent();
 
+    CopyHistoryMenuItem->Text = AppResourceProvider::GetInstance().GetResourceString(L"copyMenuItem");
+
     HistoryEmpty->FlowDirection = LocalizationService::GetInstance()->GetFlowDirection();
 }
 
@@ -49,6 +52,16 @@ void HistoryList::ListView_ItemClick(_In_ Object ^ sender, _In_ ItemClickEventAr
     if (clickedItem != nullptr && historyVM != nullptr)
     {
         historyVM->ShowItem(clickedItem);
+    }
+}
+
+void HistoryList::OnCopyMenuItemClicked(_In_ Object ^ sender, _In_ RoutedEventArgs ^ e)
+{
+    auto listViewItem = HistoryContextMenu->Target;
+    auto itemViewModel = dynamic_cast<HistoryItemViewModel ^>(HistoryListView->ItemFromContainer(listViewItem));
+    if (itemViewModel != nullptr)
+    {
+        CopyPasteManager::CopyToClipboard(itemViewModel->Result);
     }
 }
 

--- a/src/Calculator/Views/HistoryList.xaml.h
+++ b/src/Calculator/Views/HistoryList.xaml.h
@@ -34,6 +34,7 @@ namespace CalculatorApp
         Windows::Foundation::Rect m_visibleBounds;
         Windows::Foundation::Rect m_coreBounds;
         void ListView_ItemClick(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::Controls::ItemClickEventArgs ^ e);
+        void OnCopyMenuItemClicked(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);
         void OnDeleteMenuItemClicked(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);
         void OnDeleteSwipeInvoked(_In_ Microsoft::UI::Xaml::Controls::SwipeItem ^ sender, _In_ Microsoft::UI::Xaml::Controls::SwipeItemInvokedEventArgs ^ e);
     };


### PR DESCRIPTION
## Fixes #429 

### Description of the changes:
Added a Copy button to the context menu for history menu items located above the delete button in the menu. Copy only copies the result and not the entire content of the history item (equation and result).

### How changes were validated:
Manual Testing
