### PR TITLE
Fix regression bug with application title no longer grayed out.

### DIFF
--- a/src/Calculator/Views/TitleBar.xaml
+++ b/src/Calculator/Views/TitleBar.xaml
@@ -11,19 +11,19 @@
     <Grid x:Name="LayoutRoot"
           Height="32"
           HorizontalAlignment="Stretch">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="WindowFocusStates">
+                <VisualState x:Name="WindowFocused"/>
+                <VisualState x:Name="WindowNotFocused">
+                    <VisualState.Setters>
+                        <Setter Target="AppName.Foreground" Value="{ThemeResource SystemControlForegroundChromeDisabledLowBrush}"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
         <Grid x:Name="BackgroundElement"
               Background="Transparent"
               Height="32">
-            <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="WindowFocusStates">
-                    <VisualState x:Name="WindowFocused"/>
-                    <VisualState x:Name="WindowNotFocused">
-                        <VisualState.Setters>
-                            <Setter Target="AppName.Foreground" Value="{ThemeResource SystemControlForegroundChromeDisabledLowBrush}"/>
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateManager.VisualStateGroups>
             <TextBlock x:Name="AppName"
                    x:Uid="AppName"
                    Margin="12,0,12,0"


### PR DESCRIPTION
## Fixes #631 

### Description of the changes:
- Move back the VisualStateManager node to the root XAML element to fix visual states of the titlebar.

### How changes were validated:
- Manually

