### PR TITLE
Fix titlebar changing color based off window focus state

### DIFF
--- a/src/Calculator/Views/TitleBar.xaml
+++ b/src/Calculator/Views/TitleBar.xaml
@@ -11,19 +11,19 @@
     <Grid x:Name="LayoutRoot"
           Height="32"
           HorizontalAlignment="Stretch">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="WindowFocusStates">
+                <VisualState x:Name="WindowFocused"/>
+                <VisualState x:Name="WindowNotFocused">
+                    <VisualState.Setters>
+                        <Setter Target="AppName.Foreground" Value="{ThemeResource SystemControlForegroundChromeDisabledLowBrush}"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
         <Grid x:Name="BackgroundElement"
               Background="Transparent"
               Height="32">
-            <VisualStateManager.VisualStateGroups>
-                <VisualStateGroup x:Name="WindowFocusStates">
-                    <VisualState x:Name="WindowFocused"/>
-                    <VisualState x:Name="WindowNotFocused">
-                        <VisualState.Setters>
-                            <Setter Target="AppName.Foreground" Value="{ThemeResource SystemControlForegroundChromeDisabledLowBrush}"/>
-                        </VisualState.Setters>
-                    </VisualState>
-                </VisualStateGroup>
-            </VisualStateManager.VisualStateGroups>
             <TextBlock x:Name="AppName"
                    x:Uid="AppName"
                    Margin="12,0,12,0"


### PR DESCRIPTION
## Fixes #.
#631 

### Description of the changes:
The VisualStateManager tag associated with the visual states used for the titlebar got moved into a difference scope as part of the Always-on-Top feature by mistake. This caused the states to not function properly. Moving the XAML elements back to their original scope fixes the issue. The titlebar is still not visible when in Always-on-Top mode.

### How changes were validated:
Manual Testing
