### PR TITLE
Adds zoom buttons to graph controls

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3439,6 +3439,14 @@
     <value>Home</value>
     <comment>{Locked}This is the shortcut for the zoom reset button.</comment>
   </data>
+  <data name="zoomInButton.[using:CalculatorApp.Common]KeyboardShortcutManager.VirtualKeyControlChord" xml:space="preserve">
+    <value>Add</value>
+    <comment>{Locked}This is the shortcut for the zoom in button.</comment>
+  </data>
+  <data name="zoomOutButton.[using:CalculatorApp.Common]KeyboardShortcutManager.VirtualKeyControlChord" xml:space="preserve">
+    <value>Subtract</value>
+    <comment>{Locked}This is the shortcut for the zoom out button.</comment>
+  </data>
   <data name="EquationInputButtonPlaceholderText" xml:space="preserve">
     <value>Add Equation</value>
     <comment>Placeholder text for the equation input button</comment>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3439,13 +3439,37 @@
     <value>Home</value>
     <comment>{Locked}This is the shortcut for the zoom reset button.</comment>
   </data>
+  <data name="zoomResetButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Reset View</value>
+    <comment>This is the tool tip automation name for the Calculator zoom reset button.</comment>
+  </data>
+  <data name="zoomResetButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Reset View</value>
+    <comment>Screen reader prompt for the reset zoom button.</comment>
+  </data>
   <data name="zoomInButton.[using:CalculatorApp.Common]KeyboardShortcutManager.VirtualKeyControlChord" xml:space="preserve">
     <value>Add</value>
     <comment>{Locked}This is the shortcut for the zoom in button.</comment>
   </data>
+  <data name="zoomInButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Zoom In</value>
+    <comment>This is the tool tip automation name for the Calculator zoom in button.</comment>
+  </data>
+  <data name="zoomInButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Zoom In</value>
+    <comment>Screen reader prompt for the zoom in button.</comment>
+  </data>
   <data name="zoomOutButton.[using:CalculatorApp.Common]KeyboardShortcutManager.VirtualKeyControlChord" xml:space="preserve">
     <value>Subtract</value>
     <comment>{Locked}This is the shortcut for the zoom out button.</comment>
+  </data>
+  <data name="zoomOutButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
+    <value>Zoom Out</value>
+    <comment>This is the tool tip automation name for the Calculator zoom out button.</comment>
+  </data>
+  <data name="zoomOutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Zoom Out</value>
+    <comment>Screen reader prompt for the zoom out button.</comment>
   </data>
   <data name="EquationInputButtonPlaceholderText" xml:space="preserve">
     <value>Add Equation</value>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3435,6 +3435,10 @@
     <value>^</value>
     <comment>{Locked}This is the character that should trigger this button. Note that it is a character and not a key, so it does not come from the Windows::System::VirtualKey enum.</comment>
   </data>
+  <data name="zoomResetButton.[using:CalculatorApp.Common]KeyboardShortcutManager.VirtualKeyControlChord" xml:space="preserve">
+    <value>Home</value>
+    <comment>{Locked}This is the shortcut for the zoom reset button.</comment>
+  </data>
   <data name="EquationInputButtonPlaceholderText" xml:space="preserve">
     <value>Add Equation</value>
     <comment>Placeholder text for the equation input button</comment>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -16,7 +16,6 @@
             <Setter Property="Width" Value="36"/>
             <Setter Property="Height" Value="36"/>
             <Setter Property="CornerRadius" Value="18"/>
-            <Setter Property="Background" Value="White"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="FontSize" Value="12"/>
             <Setter Property="Delay" Value="500"/>
@@ -26,16 +25,8 @@
             <Setter Property="Width" Value="36"/>
             <Setter Property="Height" Value="36"/>
             <Setter Property="CornerRadius" Value="18"/>
-            <Setter Property="Background" Value="White"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="FontSize" Value="12"/>
-        </Style>
-        <Style x:Key="ActionButtonStyle" TargetType="Button">
-            <Setter Property="Width" Value="36"/>
-            <Setter Property="Height" Value="36"/>
-            <Setter Property="Background" Value="White"/>
-            <Setter Property="BorderThickness" Value="0"/>
-            <Setter Property="FontSize" Value="18"/>
         </Style>
         <converters:BooleanToVisibilityConverter x:Name="BooleanToVisibilityConverter"/>
         <converters:BooleanToVisibilityNegationConverter x:Name="BooleanToVisibilityNegationConverter"/>
@@ -55,31 +46,6 @@
         <Grid x:Name="LeftGrid"
               Grid.Row="1"
               Grid.Column="0">
-            <Grid.Resources>
-                <SolidColorBrush x:Key="RepeatButtonBackgroundPointerOver" Color="White"/>
-                <SolidColorBrush x:Key="RepeatButtonBackgroundPressed" Color="White"/>
-                <SolidColorBrush x:Key="RepeatButtonBackgroundDisabled" Color="White"/>
-                <SolidColorBrush x:Key="RepeatButtonBorderBrush" Color="Black" Opacity="0.6"/>
-                <SolidColorBrush x:Key="RepeatButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                <SolidColorBrush x:Key="RepeatButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                <SolidColorBrush x:Key="RepeatButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
-                <SolidColorBrush x:Key="RepeatButtonForeground" Color="Black" Opacity="0.6"/>
-                <SolidColorBrush x:Key="RepeatButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                <SolidColorBrush x:Key="RepeatButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                <SolidColorBrush x:Key="RepeatButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
-                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="White"/>
-                <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White"/>
-                <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="White"/>
-                <SolidColorBrush x:Key="ButtonBorderBrush" Color="Black" Opacity="0.6"/>
-                <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
-                <SolidColorBrush x:Key="ButtonForeground" Color="Black" Opacity="0.6"/>
-                <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
-            </Grid.Resources>
-
             <graphControl:Grapher Name="GraphingControl"
                                   Margin="4,7,4,4"
                                   EquationsSource="{x:Bind ViewModel.Equations, Mode=OneWay}"
@@ -102,8 +68,7 @@
                     FontFamily="{StaticResource SymbolThemeFontFamily}"
                     FontSize="18"
                     Content="&#xE70F;"
-                    RequestedTheme="Light"
-                    Background="White">
+                    RequestedTheme="Light">
                 <Button.Flyout>
                     <Flyout Placement="TopEdgeAlignedRight">
                         <Flyout.FlyoutPresenterStyle>
@@ -266,122 +231,128 @@
                 </Button.Flyout>
             </Button>
 
-            <Button Margin="0,12,60,0"
-                    x:Uid="settingsButton"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Top"
-                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    Content="&#xE713;"
-                    RequestedTheme="Light"
-                    Style="{ThemeResource ActionButtonStyle}">
-                <Button.Flyout>
-                    <Flyout Placement="BottomEdgeAlignedRight">
-                        <Flyout.FlyoutPresenterStyle>
-                            <Style TargetType="FlyoutPresenter">
-                                <Setter Property="RequestedTheme" Value="Default"/>
-                                <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled"/>
-                                <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
-                                <Setter Property="Margin" Value="0,0,12,0"/>
-                            </Style>
-                        </Flyout.FlyoutPresenterStyle>
-                        <StackPanel>
-                            <TextBlock Text="Grid"/>
-                            <Grid HorizontalAlignment="Stretch">
-                                <Grid.RowDefinitions>
-                                    <RowDefinition/>
-                                    <RowDefinition/>
-                                    <RowDefinition/>
-                                    <RowDefinition/>
-                                </Grid.RowDefinitions>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-                                <TextBlock Margin="0,0,4,0"
-                                           Grid.Column="0"
-                                           Grid.Row="0"
-                                           Text="X-Min"/>
-                                <TextBlock Margin="4,0,0,0"
-                                           Grid.Column="1"
-                                           Grid.Row="0"
-                                           Text="X-Max"/>
-                                <TextBox Margin="0,0,4,0"
-                                         Grid.Column="0"
-                                         Grid.Row="1"/>
-                                <TextBox Margin="4,0,0,0"
-                                         Grid.Column="1"
-                                         Grid.Row="1"/>
-                                <TextBlock Margin="0,0,4,0"
-                                           Grid.Column="0"
-                                           Grid.Row="2"
-                                           Text="Y-Min"/>
-                                <TextBlock Margin="4,0,0,0"
-                                           Grid.Column="1"
-                                           Grid.Row="2"
-                                           Text="Y-Max"/>
-                                <TextBox Margin="0,0,4,0"
-                                         Grid.Column="0"
-                                         Grid.Row="3"/>
-                                <TextBox Margin="4,0,0,0"
-                                         Grid.Column="1"
-                                         Grid.Row="3"/>
-                            </Grid>
-                            <TextBlock Text="Axes"/>
-                            <TextBox PlaceholderText="X-Axis Label"/>
-                            <TextBox PlaceholderText="Y-Axis Label"/>
-                            <TextBlock Text="Units"/>
-                            <Grid HorizontalAlignment="Stretch">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="Auto"/>
-                                </Grid.ColumnDefinitions>
-                                <Button Margin="0,0,4,0"
-                                        Grid.Column="0"
-                                        Background="Transparent"
-                                        Content="Degrees"/>
-                                <Button Margin="4,0,0,0"
-                                        Grid.Column="1"
-                                        Background="Transparent"
-                                        Content="Radians"/>
-                            </Grid>
-                        </StackPanel>
-                    </Flyout>
-                </Button.Flyout>
-            </Button>
+            <Grid>
+                <Grid.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <SolidColorBrush x:Key="RepeatButtonBackground" Color="White"/>
+                                <SolidColorBrush x:Key="RepeatButtonBackgroundPointerOver" Color="White"/>
+                                <SolidColorBrush x:Key="RepeatButtonBackgroundPressed" Color="White"/>
+                                <SolidColorBrush x:Key="RepeatButtonBackgroundDisabled" Color="White"/>
+                                <SolidColorBrush x:Key="RepeatButtonBorderBrush"
+                                                 Opacity="0.6"
+                                                 Color="Black"/>
+                                <SolidColorBrush x:Key="RepeatButtonBorderBrushPointerOver"
+                                                 Opacity="0.8"
+                                                 Color="{ThemeResource SystemAccentColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonBorderBrushPressed"
+                                                 Opacity="1.0"
+                                                 Color="{ThemeResource SystemAccentColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonBorderBrushDisabled"
+                                                 Opacity="0.2"
+                                                 Color="Black"/>
+                                <SolidColorBrush x:Key="RepeatButtonForeground"
+                                                 Opacity="0.6"
+                                                 Color="Black"/>
+                                <SolidColorBrush x:Key="RepeatButtonForegroundPointerOver"
+                                                 Opacity="0.8"
+                                                 Color="{ThemeResource SystemAccentColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonForegroundPressed"
+                                                 Opacity="1.0"
+                                                 Color="{ThemeResource SystemAccentColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonForegroundDisabled"
+                                                 Opacity="0.2"
+                                                 Color="Black"/>
+                                <SolidColorBrush x:Key="ButtonBackground" Color="White"/>
+                                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="White"/>
+                                <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White"/>
+                                <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="White"/>
+                                <SolidColorBrush x:Key="ButtonBorderBrush"
+                                                 Opacity="0.6"
+                                                 Color="Black"/>
+                                <SolidColorBrush x:Key="ButtonBorderBrushPointerOver"
+                                                 Opacity="0.8"
+                                                 Color="{ThemeResource SystemAccentColor}"/>
+                                <SolidColorBrush x:Key="ButtonBorderBrushPressed"
+                                                 Opacity="1.0"
+                                                 Color="{ThemeResource SystemAccentColor}"/>
+                                <SolidColorBrush x:Key="ButtonBorderBrushDisabled"
+                                                 Opacity="0.2"
+                                                 Color="Black"/>
+                                <SolidColorBrush x:Key="ButtonForeground"
+                                                 Opacity="0.6"
+                                                 Color="Black"/>
+                                <SolidColorBrush x:Key="ButtonForegroundPointerOver"
+                                                 Opacity="0.8"
+                                                 Color="{ThemeResource SystemAccentColor}"/>
+                                <SolidColorBrush x:Key="ButtonForegroundPressed"
+                                                 Opacity="1.0"
+                                                 Color="{ThemeResource SystemAccentColor}"/>
+                                <SolidColorBrush x:Key="ButtonForegroundDisabled"
+                                                 Opacity="0.2"
+                                                 Color="Black"/>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <SolidColorBrush x:Key="RepeatButtonBackground" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonBackgroundPointerOver" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonBackgroundPressed" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonBackgroundDisabled" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonBorderBrush" Color="{ThemeResource SystemColorWindowTextColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonBorderBrushPointerOver" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonBorderBrushPressed" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonBorderBrushDisabled" Color="{ThemeResource SystemColorGrayTextColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonForeground" Color="{ThemeResource SystemColorWindowTextColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonForegroundPointerOver" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonForegroundPressed" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                <SolidColorBrush x:Key="RepeatButtonForegroundDisabled" Color="{ThemeResource SystemColorGrayTextColor}"/>
+                                <SolidColorBrush x:Key="ButtonBackground" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                <SolidColorBrush x:Key="ButtonBorderBrush" Color="{ThemeResource SystemColorWindowTextColor}"/>
+                                <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="{ThemeResource SystemColorGrayTextColor}"/>
+                                <SolidColorBrush x:Key="ButtonForeground" Color="{ThemeResource SystemColorWindowTextColor}"/>
+                                <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemColorHighlightColor}"/>
+                                <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="{ThemeResource SystemColorGrayTextColor}"/>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </Grid.Resources>
 
-            <RepeatButton Margin="0,0,12,12"
-                          x:Uid="zoomOutButton"
-                          FontFamily="{StaticResource SymbolThemeFontFamily}"
-                          Content="&#xE738;"
-                          RequestedTheme="Light"
-                          Command="{x:Bind ZoomOutButtonPressed, Mode=OneTime}"
-                          Style="{ThemeResource ZoomRepeatButtonStyle}"
-                          VerticalAlignment="Bottom"
-                          HorizontalAlignment="Right">
-            </RepeatButton>
+                <RepeatButton x:Uid="zoomInButton"
+                              Margin="0,0,12,108"
+                              HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
+                              Style="{ThemeResource ZoomRepeatButtonStyle}"
+                              FontFamily="{StaticResource SymbolThemeFontFamily}"
+                              AutomationProperties.AutomationId="zoomInButton"
+                              Command="{x:Bind ZoomInButtonPressed, Mode=OneTime}"
+                              Content="&#xE710;"/>
 
-            <RepeatButton Margin="0,0,12,60"
-                          x:Uid="zoomInButton"
-                          FontFamily="{StaticResource SymbolThemeFontFamily}"
-                          Content="&#xE710;"
-                          RequestedTheme="Light"
-                          Command="{x:Bind ZoomInButtonPressed, Mode=OneTime}"
-                          Style="{ThemeResource ZoomRepeatButtonStyle}"
-                          VerticalAlignment="Bottom"
-                          HorizontalAlignment="Right">  
-            </RepeatButton>
+                <RepeatButton x:Uid="zoomOutButton"
+                              Margin="0,0,12,60"
+                              HorizontalAlignment="Right"
+                              VerticalAlignment="Bottom"
+                              Style="{ThemeResource ZoomRepeatButtonStyle}"
+                              FontFamily="{StaticResource SymbolThemeFontFamily}"
+                              AutomationProperties.AutomationId="zoomOutButton"
+                              Command="{x:Bind ZoomOutButtonPressed, Mode=OneTime}"
+                              Content="&#xE738;"/>
 
-            <Button Margin="0,0,12,108"
-                    x:Uid="zoomResetButton"
-                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    Content="&#xE895;"
-                    RequestedTheme="Light"
-                    Command="{x:Bind ZoomResetButtonPressed, Mode=OneTime}"
-                    Style="{ThemeResource ZoomButtonStyle}"
-                    VerticalAlignment="Bottom"
-                    HorizontalAlignment="Right">
-            </Button>
+                <Button x:Uid="zoomResetButton"
+                        Margin="0,0,12,12"
+                        HorizontalAlignment="Right"
+                        VerticalAlignment="Bottom"
+                        Style="{ThemeResource ZoomButtonStyle}"
+                        FontFamily="{StaticResource SymbolThemeFontFamily}"
+                        AutomationProperties.AutomationId="zoomResetButton"
+                        Command="{x:Bind ZoomResetButtonPressed, Mode=OneTime}"
+                        Content="&#xE895;"/>
+            </Grid>
 
         </Grid>
 

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -312,7 +312,38 @@
                                 <TextBox Margin="4,0,0,0"
                                          Grid.Column="1"
                                          Grid.Row="1"/>
-                                
+                                <TextBlock Margin="0,0,4,0"
+                                           Grid.Column="0"
+                                           Grid.Row="2"
+                                           Text="Y-Min"/>
+                                <TextBlock Margin="4,0,0,0"
+                                           Grid.Column="1"
+                                           Grid.Row="2"
+                                           Text="Y-Max"/>
+                                <TextBox Margin="0,0,4,0"
+                                         Grid.Column="0"
+                                         Grid.Row="3"/>
+                                <TextBox Margin="4,0,0,0"
+                                         Grid.Column="1"
+                                         Grid.Row="3"/>
+                            </Grid>
+                            <TextBlock Text="Axes"/>
+                            <TextBox PlaceholderText="X-Axis Label"/>
+                            <TextBox PlaceholderText="Y-Axis Label"/>
+                            <TextBlock Text="Units"/>
+                            <Grid HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                </Grid.ColumnDefinitions>
+                                <Button Margin="0,0,4,0"
+                                        Grid.Column="0"
+                                        Background="Transparent"
+                                        Content="Degrees"/>
+                                <Button Margin="4,0,0,0"
+                                        Grid.Column="1"
+                                        Background="Transparent"
+                                        Content="Radians"/>
                             </Grid>
                         </StackPanel>
                     </Flyout>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -12,6 +12,28 @@
              mc:Ignorable="d">
 
     <UserControl.Resources>
+        <Style x:Key="ZoomRepeatButtonStyle" TargetType="RepeatButton">
+            <Setter Property="Width" Value="36"/>
+            <Setter Property="Height" Value="36"/>
+            <Setter Property="CornerRadius" Value="18"/>
+            <Setter Property="Background" Value="White"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="VerticalAlignment" Value="Bottom"/>
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+            <Setter Property="Delay" Value="500"/>
+            <Setter Property="Interval" Value="40"/>
+        </Style>
+        <Style x:Key="ZoomButtonStyle" TargetType="Button">
+            <Setter Property="Width" Value="36"/>
+            <Setter Property="Height" Value="36"/>
+            <Setter Property="CornerRadius" Value="18"/>
+            <Setter Property="Background" Value="White"/>
+            <Setter Property="BorderThickness" Value="1"/>
+            <Setter Property="FontSize" Value="12"/>
+            <Setter Property="VerticalAlignment" Value="Bottom"/>
+            <Setter Property="HorizontalAlignment" Value="Right"/>
+        </Style>
         <converters:BooleanToVisibilityConverter x:Name="BooleanToVisibilityConverter"/>
         <converters:BooleanToVisibilityNegationConverter x:Name="BooleanToVisibilityNegationConverter"/>
     </UserControl.Resources>
@@ -30,6 +52,30 @@
         <Grid x:Name="LeftGrid"
               Grid.Row="1"
               Grid.Column="0">
+            <Grid.Resources>
+                <SolidColorBrush x:Key="RepeatButtonBackgroundPointerOver" Color="White"/>
+                <SolidColorBrush x:Key="RepeatButtonBackgroundPressed" Color="White"/>
+                <SolidColorBrush x:Key="RepeatButtonBackgroundDisabled" Color="White"/>
+                <SolidColorBrush x:Key="RepeatButtonBorderBrush" Color="Black" Opacity="0.6"/>
+                <SolidColorBrush x:Key="RepeatButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                <SolidColorBrush x:Key="RepeatButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                <SolidColorBrush x:Key="RepeatButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
+                <SolidColorBrush x:Key="RepeatButtonForeground" Color="Black" Opacity="0.6"/>
+                <SolidColorBrush x:Key="RepeatButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                <SolidColorBrush x:Key="RepeatButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                <SolidColorBrush x:Key="RepeatButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
+                <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="White"/>
+                <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White"/>
+                <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="White"/>
+                <SolidColorBrush x:Key="ButtonBorderBrush" Color="Black" Opacity="0.6"/>
+                <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
+                <SolidColorBrush x:Key="ButtonForeground" Color="Black" Opacity="0.6"/>
+                <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
+            </Grid.Resources>
 
             <graphControl:Grapher Name="GraphingControl"
                                   Margin="4,7,4,4"
@@ -53,7 +99,8 @@
                     FontFamily="{StaticResource SymbolThemeFontFamily}"
                     FontSize="18"
                     Content="&#xE70F;"
-                    RequestedTheme="Light">
+                    RequestedTheme="Light"
+                    Background="White">
                 <Button.Flyout>
                     <Flyout Placement="TopEdgeAlignedRight">
                         <Flyout.FlyoutPresenterStyle>
@@ -216,88 +263,31 @@
                 </Button.Flyout>
             </Button>
 
-            <Button Margin="0,0,12,12"
-                    VerticalAlignment="Bottom"
-                    HorizontalAlignment="Right"
-                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    FontSize="12"
-                    Content="&#xE738;"
-                    RequestedTheme="Light"
-                    Click="ZoomOutButtonClick"
-                    Width="36"
-                    Height="36"
-                    CornerRadius="18"
-                    Background="White"
-                    BorderThickness="1">
-                <Button.Resources>
-                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="White"/>
-                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White"/>
-                    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="White"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrush" Color="Black" Opacity="0.6"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
-                    <SolidColorBrush x:Key="ButtonForeground" Color="Black" Opacity="0.6"/>
-                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
-                </Button.Resources>
-            </Button>
+            <RepeatButton Margin="0,0,12,12"
+                          x:Uid="zoomOutButton"
+                          FontFamily="{StaticResource SymbolThemeFontFamily}"
+                          Content="&#xE738;"
+                          RequestedTheme="Light"
+                          Click="ZoomOutButtonClick"
+                          Style="{ThemeResource ZoomRepeatButtonStyle}">
+            </RepeatButton>
 
-            <Button Margin="0,0,12,60"
-                    VerticalAlignment="Bottom"
-                    HorizontalAlignment="Right"
-                    FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    FontSize="12"
-                    Content="&#xE710;"
-                    RequestedTheme="Light"
-                    Click="ZoomInButtonClick"
-                    Width="36"
-                    Height="36"
-                    CornerRadius="18"
-                    Background="White"
-                    BorderThickness="1">
-                <Button.Resources>
-                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="White"/>
-                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White"/>
-                    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="White"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrush" Color="Black" Opacity="0.6"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
-                    <SolidColorBrush x:Key="ButtonForeground" Color="Black" Opacity="0.6"/>
-                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
-                </Button.Resources>
-            </Button>
+            <RepeatButton Margin="0,0,12,60"
+                          x:Uid="zoomInButton"
+                          FontFamily="{StaticResource SymbolThemeFontFamily}"
+                          Content="&#xE710;"
+                          RequestedTheme="Light"
+                          Click="ZoomInButtonClick"
+                          Style="{ThemeResource ZoomRepeatButtonStyle}">  
+            </RepeatButton>
 
             <Button Margin="0,0,12,108"
-                    VerticalAlignment="Bottom"
-                    HorizontalAlignment="Right"
+                    x:Uid="zoomResetButton"
                     FontFamily="{StaticResource SymbolThemeFontFamily}"
-                    FontSize="12"
                     Content="&#xE895;"
                     RequestedTheme="Light"
                     Click="ZoomResetButtonClick"
-                    Width="36"
-                    Height="36"
-                    CornerRadius="18"
-                    Background="White"
-                    BorderThickness="1">
-                <Button.Resources>
-                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="White"/>
-                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White"/>
-                    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="White"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrush" Color="Black" Opacity="0.6"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
-                    <SolidColorBrush x:Key="ButtonForeground" Color="Black" Opacity="0.6"/>
-                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
-                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
-                    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
-                </Button.Resources>
+                    Style="{ThemeResource ZoomButtonStyle}">
             </Button>
 
         </Grid>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -268,7 +268,7 @@
                           FontFamily="{StaticResource SymbolThemeFontFamily}"
                           Content="&#xE738;"
                           RequestedTheme="Light"
-                          Click="ZoomOutButtonClick"
+                          Command="{x:Bind ZoomOutButtonPressed, Mode=OneTime}"
                           Style="{ThemeResource ZoomRepeatButtonStyle}">
             </RepeatButton>
 
@@ -277,7 +277,7 @@
                           FontFamily="{StaticResource SymbolThemeFontFamily}"
                           Content="&#xE710;"
                           RequestedTheme="Light"
-                          Click="ZoomInButtonClick"
+                          Command="{x:Bind ZoomInButtonPressed, Mode=OneTime}"
                           Style="{ThemeResource ZoomRepeatButtonStyle}">  
             </RepeatButton>
 
@@ -286,7 +286,7 @@
                     FontFamily="{StaticResource SymbolThemeFontFamily}"
                     Content="&#xE895;"
                     RequestedTheme="Light"
-                    Click="ZoomResetButtonClick"
+                          Command="{x:Bind ZoomResetButtonPressed, Mode=OneTime}"
                     Style="{ThemeResource ZoomButtonStyle}">
             </Button>
 

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -215,6 +215,91 @@
                     </Flyout>
                 </Button.Flyout>
             </Button>
+
+            <Button Margin="0,0,12,12"
+                    VerticalAlignment="Bottom"
+                    HorizontalAlignment="Right"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    FontSize="12"
+                    Content="&#xE738;"
+                    RequestedTheme="Light"
+                    Click="ZoomOutButtonClick"
+                    Width="36"
+                    Height="36"
+                    CornerRadius="18"
+                    Background="White"
+                    BorderThickness="1">
+                <Button.Resources>
+                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="White"/>
+                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White"/>
+                    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="White"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrush" Color="Black" Opacity="0.6"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
+                    <SolidColorBrush x:Key="ButtonForeground" Color="Black" Opacity="0.6"/>
+                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
+                </Button.Resources>
+            </Button>
+
+            <Button Margin="0,0,12,60"
+                    VerticalAlignment="Bottom"
+                    HorizontalAlignment="Right"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    FontSize="12"
+                    Content="&#xE710;"
+                    RequestedTheme="Light"
+                    Click="ZoomInButtonClick"
+                    Width="36"
+                    Height="36"
+                    CornerRadius="18"
+                    Background="White"
+                    BorderThickness="1">
+                <Button.Resources>
+                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="White"/>
+                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White"/>
+                    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="White"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrush" Color="Black" Opacity="0.6"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
+                    <SolidColorBrush x:Key="ButtonForeground" Color="Black" Opacity="0.6"/>
+                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
+                </Button.Resources>
+            </Button>
+
+            <Button Margin="0,0,12,108"
+                    VerticalAlignment="Bottom"
+                    HorizontalAlignment="Right"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    FontSize="12"
+                    Content="&#xE895;"
+                    RequestedTheme="Light"
+                    Click="ZoomResetButtonClick"
+                    Width="36"
+                    Height="36"
+                    CornerRadius="18"
+                    Background="White"
+                    BorderThickness="1">
+                <Button.Resources>
+                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="White"/>
+                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="White"/>
+                    <SolidColorBrush x:Key="ButtonBackgroundDisabled" Color="White"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrush" Color="Black" Opacity="0.6"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrushPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrushPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                    <SolidColorBrush x:Key="ButtonBorderBrushDisabled" Color="Black" Opacity="0.2"/>
+                    <SolidColorBrush x:Key="ButtonForeground" Color="Black" Opacity="0.6"/>
+                    <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{ThemeResource SystemAccentColor}" Opacity="0.8"/>
+                    <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemAccentColor}" Opacity="1.0"/>
+                    <SolidColorBrush x:Key="ButtonForegroundDisabled" Color="Black" Opacity="0.2"/>
+                </Button.Resources>
+            </Button>
+
         </Grid>
 
         <!-- Right portion of the screen -->

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -286,7 +286,7 @@
                     FontFamily="{StaticResource SymbolThemeFontFamily}"
                     Content="&#xE895;"
                     RequestedTheme="Light"
-                          Command="{x:Bind ZoomResetButtonPressed, Mode=OneTime}"
+                    Command="{x:Bind ZoomResetButtonPressed, Mode=OneTime}"
                     Style="{ThemeResource ZoomButtonStyle}">
             </Button>
 

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -19,8 +19,6 @@
             <Setter Property="Background" Value="White"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="FontSize" Value="12"/>
-            <Setter Property="VerticalAlignment" Value="Bottom"/>
-            <Setter Property="HorizontalAlignment" Value="Right"/>
             <Setter Property="Delay" Value="500"/>
             <Setter Property="Interval" Value="40"/>
         </Style>
@@ -31,8 +29,13 @@
             <Setter Property="Background" Value="White"/>
             <Setter Property="BorderThickness" Value="1"/>
             <Setter Property="FontSize" Value="12"/>
-            <Setter Property="VerticalAlignment" Value="Bottom"/>
-            <Setter Property="HorizontalAlignment" Value="Right"/>
+        </Style>
+        <Style x:Key="ActionButtonStyle" TargetType="Button">
+            <Setter Property="Width" Value="36"/>
+            <Setter Property="Height" Value="36"/>
+            <Setter Property="Background" Value="White"/>
+            <Setter Property="BorderThickness" Value="0"/>
+            <Setter Property="FontSize" Value="18"/>
         </Style>
         <converters:BooleanToVisibilityConverter x:Name="BooleanToVisibilityConverter"/>
         <converters:BooleanToVisibilityNegationConverter x:Name="BooleanToVisibilityNegationConverter"/>
@@ -263,13 +266,68 @@
                 </Button.Flyout>
             </Button>
 
+            <Button Margin="0,12,60,0"
+                    x:Uid="settingsButton"
+                    HorizontalAlignment="Right"
+                    VerticalAlignment="Top"
+                    FontFamily="{StaticResource SymbolThemeFontFamily}"
+                    Content="&#xE713;"
+                    RequestedTheme="Light"
+                    Style="{ThemeResource ActionButtonStyle}">
+                <Button.Flyout>
+                    <Flyout Placement="BottomEdgeAlignedRight">
+                        <Flyout.FlyoutPresenterStyle>
+                            <Style TargetType="FlyoutPresenter">
+                                <Setter Property="RequestedTheme" Value="Default"/>
+                                <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled"/>
+                                <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
+                                <Setter Property="Margin" Value="0,0,12,0"/>
+                            </Style>
+                        </Flyout.FlyoutPresenterStyle>
+                        <StackPanel>
+                            <TextBlock Text="Grid"/>
+                            <Grid HorizontalAlignment="Stretch">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition/>
+                                    <RowDefinition/>
+                                    <RowDefinition/>
+                                    <RowDefinition/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <TextBlock Margin="0,0,4,0"
+                                           Grid.Column="0"
+                                           Grid.Row="0"
+                                           Text="X-Min"/>
+                                <TextBlock Margin="4,0,0,0"
+                                           Grid.Column="1"
+                                           Grid.Row="0"
+                                           Text="X-Max"/>
+                                <TextBox Margin="0,0,4,0"
+                                         Grid.Column="0"
+                                         Grid.Row="1"/>
+                                <TextBox Margin="4,0,0,0"
+                                         Grid.Column="1"
+                                         Grid.Row="1"/>
+                                
+                            </Grid>
+                        </StackPanel>
+                    </Flyout>
+                </Button.Flyout>
+            </Button>
+
             <RepeatButton Margin="0,0,12,12"
                           x:Uid="zoomOutButton"
                           FontFamily="{StaticResource SymbolThemeFontFamily}"
                           Content="&#xE738;"
                           RequestedTheme="Light"
                           Command="{x:Bind ZoomOutButtonPressed, Mode=OneTime}"
-                          Style="{ThemeResource ZoomRepeatButtonStyle}">
+                          Style="{ThemeResource ZoomRepeatButtonStyle}"
+                          VerticalAlignment="Bottom"
+                          HorizontalAlignment="Right">
             </RepeatButton>
 
             <RepeatButton Margin="0,0,12,60"
@@ -278,7 +336,9 @@
                           Content="&#xE710;"
                           RequestedTheme="Light"
                           Command="{x:Bind ZoomInButtonPressed, Mode=OneTime}"
-                          Style="{ThemeResource ZoomRepeatButtonStyle}">  
+                          Style="{ThemeResource ZoomRepeatButtonStyle}"
+                          VerticalAlignment="Bottom"
+                          HorizontalAlignment="Right">  
             </RepeatButton>
 
             <Button Margin="0,0,12,108"
@@ -287,7 +347,9 @@
                     Content="&#xE895;"
                     RequestedTheme="Light"
                     Command="{x:Bind ZoomResetButtonPressed, Mode=OneTime}"
-                    Style="{ThemeResource ZoomButtonStyle}">
+                    Style="{ThemeResource ZoomButtonStyle}"
+                    VerticalAlignment="Bottom"
+                    HorizontalAlignment="Right">
             </Button>
 
         </Grid>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -119,24 +119,17 @@ void GraphingCalculator::TextBoxGotFocus(TextBox^ sender, RoutedEventArgs^ e)
     sender->SelectAll();
 }
 
-void GraphingCalculator::ZoomInButtonClick(Object ^ /* parameter */)
+void GraphingCalculator::OnZoomInCommand(Object ^ /* parameter */)
 {
-    constexpr double scrollDamper = 0.15;
-    double scale = 1.0 + (abs(zoomButtonDelta) / WHEEL_DELTA) * scrollDamper;
-    scale = 1.0 / scale;
-
-    GraphingControl->ScaleRange(0, 0, scale);
+    GraphingControl->ZoomFromCenter(zoomInScale);
 }
 
-void GraphingCalculator::ZoomOutButtonClick(Object ^ /* parameter */)
+void GraphingCalculator::OnZoomOutCommand(Object ^ /* parameter */)
 {
-    constexpr double scrollDamper = 0.15;
-    double scale = 1.0 + (abs(zoomButtonDelta) / WHEEL_DELTA) * scrollDamper;
-
-    GraphingControl->ScaleRange(0, 0, scale);
+    GraphingControl->ZoomFromCenter(zoomOutScale);
 }
 
-void GraphingCalculator::ZoomResetButtonClick(Object ^ /* parameter */)
+void GraphingCalculator::OnZoomResetCommand(Object ^ /* parameter */)
 {
     GraphingControl->ResetGrid();
 }

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -118,3 +118,25 @@ void GraphingCalculator::TextBoxGotFocus(TextBox^ sender, RoutedEventArgs^ e)
 {
     sender->SelectAll();
 }
+
+void GraphingCalculator::ZoomInButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e)
+{
+    constexpr double scrollDamper = 0.15;
+    double scale = 1.0 + (abs(zoomButtonDelta) / WHEEL_DELTA) * scrollDamper;
+    scale = 1.0 / scale;
+
+    GraphingControl->ScaleRange(0, 0, scale);
+}
+
+void GraphingCalculator::ZoomOutButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e)
+{
+    constexpr double scrollDamper = 0.15;
+    double scale = 1.0 + (abs(zoomButtonDelta) / WHEEL_DELTA) * scrollDamper;
+
+    GraphingControl->ScaleRange(0, 0, scale);
+}
+
+void GraphingCalculator::ZoomResetButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e)
+{
+    GraphingControl->ResetGrid();
+}

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -119,7 +119,7 @@ void GraphingCalculator::TextBoxGotFocus(TextBox^ sender, RoutedEventArgs^ e)
     sender->SelectAll();
 }
 
-void GraphingCalculator::ZoomInButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e)
+void GraphingCalculator::ZoomInButtonClick(Object ^ /* parameter */)
 {
     constexpr double scrollDamper = 0.15;
     double scale = 1.0 + (abs(zoomButtonDelta) / WHEEL_DELTA) * scrollDamper;
@@ -128,7 +128,7 @@ void GraphingCalculator::ZoomInButtonClick(Platform::Object ^ sender, Windows::U
     GraphingControl->ScaleRange(0, 0, scale);
 }
 
-void GraphingCalculator::ZoomOutButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e)
+void GraphingCalculator::ZoomOutButtonClick(Object ^ /* parameter */)
 {
     constexpr double scrollDamper = 0.15;
     double scale = 1.0 + (abs(zoomButtonDelta) / WHEEL_DELTA) * scrollDamper;
@@ -136,7 +136,7 @@ void GraphingCalculator::ZoomOutButtonClick(Platform::Object ^ sender, Windows::
     GraphingControl->ScaleRange(0, 0, scale);
 }
 
-void GraphingCalculator::ZoomResetButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e)
+void GraphingCalculator::ZoomResetButtonClick(Object ^ /* parameter */)
 {
     GraphingControl->ResetGrid();
 }

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -23,7 +23,7 @@ namespace CalculatorApp
         {
             double get()
             {
-                return 120;
+                return 50;
             }
         }
 

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -12,6 +12,9 @@ namespace CalculatorApp
         GraphingCalculator();
 
         OBSERVABLE_OBJECT();
+        COMMAND_FOR_METHOD(ZoomOutButtonPressed, GraphingCalculator::ZoomOutButtonClick);
+        COMMAND_FOR_METHOD(ZoomInButtonPressed, GraphingCalculator::ZoomInButtonClick);
+        COMMAND_FOR_METHOD(ZoomResetButtonPressed, GraphingCalculator::ZoomResetButtonClick);
 
         property CalculatorApp::ViewModel::GraphingCalculatorViewModel^ ViewModel
         {
@@ -37,9 +40,9 @@ namespace CalculatorApp
         void TextBoxKeyDown(Windows::UI::Xaml::Controls::TextBox^ textbox, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
         void SubmitTextbox(Windows::UI::Xaml::Controls::TextBox^ textbox);
 
-        void ZoomInButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
-        void ZoomOutButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
-        void ZoomResetButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void ZoomInButtonClick(Object ^ parameter);
+        void ZoomOutButtonClick(Object ^ parameter);
+        void ZoomResetButtonClick(Object ^ parameter);
 
         double validateDouble(Platform::String^ value, double defaultValue);
 

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -6,28 +6,23 @@
 
 namespace CalculatorApp
 {
+    constexpr double zoomInScale = 1 / 1.0625;
+    constexpr double zoomOutScale = 1.0625;
+
     public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INotifyPropertyChanged
     {
     public:
         GraphingCalculator();
 
         OBSERVABLE_OBJECT();
-        COMMAND_FOR_METHOD(ZoomOutButtonPressed, GraphingCalculator::ZoomOutButtonClick);
-        COMMAND_FOR_METHOD(ZoomInButtonPressed, GraphingCalculator::ZoomInButtonClick);
-        COMMAND_FOR_METHOD(ZoomResetButtonPressed, GraphingCalculator::ZoomResetButtonClick);
+        COMMAND_FOR_METHOD(ZoomOutButtonPressed, GraphingCalculator::OnZoomOutCommand);
+        COMMAND_FOR_METHOD(ZoomInButtonPressed, GraphingCalculator::OnZoomInCommand);
+        COMMAND_FOR_METHOD(ZoomResetButtonPressed, GraphingCalculator::OnZoomResetCommand);
 
         property CalculatorApp::ViewModel::GraphingCalculatorViewModel^ ViewModel
         {
             CalculatorApp::ViewModel::GraphingCalculatorViewModel^ get();
             void set(CalculatorApp::ViewModel::GraphingCalculatorViewModel^ vm);
-        }
-
-        static property double zoomButtonDelta
-        {
-            double get()
-            {
-                return 50;
-            }
         }
 
     private:
@@ -40,9 +35,9 @@ namespace CalculatorApp
         void TextBoxKeyDown(Windows::UI::Xaml::Controls::TextBox^ textbox, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
         void SubmitTextbox(Windows::UI::Xaml::Controls::TextBox^ textbox);
 
-        void ZoomInButtonClick(Object ^ parameter);
-        void ZoomOutButtonClick(Object ^ parameter);
-        void ZoomResetButtonClick(Object ^ parameter);
+        void OnZoomInCommand(Object ^ parameter);
+        void OnZoomOutCommand(Object ^ parameter);
+        void OnZoomResetCommand(Object ^ parameter);
 
         double validateDouble(Platform::String^ value, double defaultValue);
 

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -19,6 +19,14 @@ namespace CalculatorApp
             void set(CalculatorApp::ViewModel::GraphingCalculatorViewModel^ vm);
         }
 
+        static property double zoomButtonDelta
+        {
+            double get()
+            {
+                return 120;
+            }
+        }
+
     private:
         void GraphingCalculator_DataContextChanged(Windows::UI::Xaml::FrameworkElement^ sender, Windows::UI::Xaml::DataContextChangedEventArgs^ args);
 
@@ -28,6 +36,10 @@ namespace CalculatorApp
         void TextBoxLosingFocus(Windows::UI::Xaml::Controls::TextBox^ textbox, Windows::UI::Xaml::Input::LosingFocusEventArgs^ args);
         void TextBoxKeyDown(Windows::UI::Xaml::Controls::TextBox^ textbox, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
         void SubmitTextbox(Windows::UI::Xaml::Controls::TextBox^ textbox);
+
+        void ZoomInButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void ZoomOutButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void ZoomResetButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 
         double validateDouble(Platform::String^ value, double defaultValue);
 

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -91,6 +91,11 @@ namespace GraphControl
         }
     }
 
+    void Grapher::ZoomFromCenter(double scale)
+    {
+        ScaleRange(0, 0, scale);
+    }
+
     void Grapher::ScaleRange(double centerX, double centerY, double scale)
     {
         if (m_graph != nullptr && m_renderMain != nullptr)

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -105,6 +105,20 @@ namespace GraphControl
         }
     }
 
+    void Grapher::ResetGrid()
+    {
+        if (m_graph != nullptr && m_renderMain != nullptr)
+        {
+            if (auto renderer = m_graph->GetRenderer())
+            {
+                if (SUCCEEDED(renderer->ResetRange()))
+                {
+                    m_renderMain->RunRenderPass();
+                }
+            }
+        }
+    }
+
     void Grapher::OnApplyTemplate()
     {
         auto swapChainPanel = dynamic_cast<SwapChainPanel^>(GetTemplateChild(StringReference(s_templateKey_SwapChainPanel)));

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -127,6 +127,8 @@ namespace GraphControl
         event Windows::Foundation::EventHandler<Windows::Foundation::Collections::IMap<Platform::String^, double>^>^ VariablesUpdated;
 
         void SetVariable(Platform::String^ variableName, double newValue);
+        void ScaleRange(double centerX, double centerY, double scale);
+        void ResetGrid();
 
     protected:
         #pragma region Control Overrides
@@ -171,8 +173,6 @@ namespace GraphControl
         void SyncEquationsWithItemsSource();
         void OnItemsAdded(int index, int count);
         void OnItemsRemoved(int index, int count);
-
-        void ScaleRange(double centerX, double centerY, double scale);
 
     private:
         DX::RenderMain^ m_renderMain = nullptr;

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -127,7 +127,7 @@ namespace GraphControl
         event Windows::Foundation::EventHandler<Windows::Foundation::Collections::IMap<Platform::String^, double>^>^ VariablesUpdated;
 
         void SetVariable(Platform::String^ variableName, double newValue);
-        void ScaleRange(double centerX, double centerY, double scale);
+        void ZoomFromCenter(double scale);
         void ResetGrid();
 
     protected:
@@ -173,6 +173,8 @@ namespace GraphControl
         void SyncEquationsWithItemsSource();
         void OnItemsAdded(int index, int count);
         void OnItemsRemoved(int index, int count);
+
+        void ScaleRange(double centerX, double centerY, double scale);
 
     private:
         DX::RenderMain^ m_renderMain = nullptr;


### PR DESCRIPTION
### Description of the changes:
- Zoom-in and zoom-out buttons have been added. When clicked or pressed, they call `GraphingControl`'s `ScaleRange` function. These buttons take advantage of `RepeatButton`'s API to allow for hold-down repeat click behavior.
- Zoom reset button has been added. When clicked or pressed, it calls `GraphingControl`'s `ResetGrid` function.
- Appropriate keyboard shortcuts and light-mode styling for these buttons have also been added.

### How changes were validated:
- Manual testing.
