### PR TITLE
Update internals package to 0.0.18

### DIFF
--- a/build/pipelines/templates/build-app-internal.yaml
+++ b/build/pipelines/templates/build-app-internal.yaml
@@ -29,7 +29,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.11
+      vstsPackageVersion: 0.0.18
 
   - template: ./build-single-architecture.yaml
     parameters:

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -91,7 +91,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.11
+      vstsPackageVersion: 0.0.18
 
   - task: PkgESStoreBrokerPackage@10
     displayName: Create StoreBroker Packages


### PR DESCRIPTION
Update the internals package to 0.0.18, which removes the internal icons which were previously removed from this repo in #644.