### PR TITLE
Switch to RichEdit math mode in EquationTextBox

### DIFF
--- a/src/CalcManager/CalcManager.vcxproj
+++ b/src/CalcManager/CalcManager.vcxproj
@@ -45,7 +45,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.18970.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/CalcViewModel/CalcViewModel.vcxproj
+++ b/src/CalcViewModel/CalcViewModel.vcxproj
@@ -42,7 +42,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18970.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -1628,6 +1628,7 @@
                                 <Button x:Name="EquationButton"
                                         MinWidth="44"
                                         MinHeight="44"
+                                        VerticalAlignment="Stretch"
                                         Background="{TemplateBinding EquationColor}"
                                         Foreground="{StaticResource SystemChromeWhiteColor}"
                                         Content="ƒₓ">
@@ -1651,7 +1652,7 @@
                                             <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
                                         <RichEditBox x:Name="EquationTextBox"
-                                                     MinHeight="42"
+                                                     MinHeight="44"
                                                      Padding="{TemplateBinding Padding}"
                                                      VerticalAlignment="Stretch"
                                                      Style="{StaticResource EquationTextBoxStyle}"

--- a/src/Calculator/Calculator.vcxproj
+++ b/src/Calculator/Calculator.vcxproj
@@ -8,7 +8,7 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.18970.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.18362.0</WindowsTargetPlatformMinVersion>
     <!-- We want to manually control the MinVersion/MaxVersionTested in the manifest so turn of the replacement. -->
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>

--- a/src/Calculator/Controls/EquationTextBox.h
+++ b/src/Calculator/Controls/EquationTextBox.h
@@ -21,7 +21,8 @@ namespace CalculatorApp
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::UIElement^, KeyGraphFeaturesContent);
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Controls::Flyout^, ColorChooserFlyout);
 
-            event Windows::UI::Xaml::RoutedEventHandler^ RemoveButtonClicked;
+            event Windows::UI::Xaml::RoutedEventHandler ^ RemoveButtonClicked;
+            event Windows::UI::Xaml::RoutedEventHandler ^ EquationSubmitted;
 
             Platform::String^ GetEquationText();
             void SetEquationText(Platform::String^ equationText);
@@ -32,14 +33,18 @@ namespace CalculatorApp
             virtual void OnPointerExited(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
             virtual void OnPointerCanceled(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
             virtual void OnPointerCaptureLost(Windows::UI::Xaml::Input::PointerRoutedEventArgs^ e) override;
+            virtual void OnKeyDown(Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e) override;
+            virtual void OnLostFocus(Windows::UI::Xaml::RoutedEventArgs^ e) override;
 
         private:
             void UpdateCommonVisualState();
             void UpdateDeleteButtonVisualState();
             bool ShouldDeleteButtonBeVisible();
 
+            void OnRichEditBoxLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
             void OnRichEditBoxGotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
             void OnRichEditBoxLostFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+            void OnRichEditBoxLosingFocus(Windows::UI::Xaml::UIElement ^ sender, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ e);
             void OnRichEditBoxTextChanged(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 
             void OnDeleteButtonClicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -45,8 +45,8 @@
                                                   Grid.Column="1"
                                                   Margin="0,0,3,0"
                                                   Style="{StaticResource EquationTextBoxStyle}"
+                                                  EquationSubmitted="InputTextBox_Submitted"
                                                   GotFocus="InputTextBox_GotFocus"
-                                                  KeyUp="InputTextBox_KeyUp"
                                                   LostFocus="InputTextBox_LostFocus"
                                                   RemoveButtonClicked="EquationTextBox_RemoveButtonClicked">
                             <controls:EquationTextBox.EquationColor>

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -78,22 +78,13 @@ void EquationInputArea::InputTextBox_GotFocus(Object^ sender, RoutedEventArgs^ e
 void EquationInputArea::InputTextBox_LostFocus(Object^ sender, RoutedEventArgs^ e)
 {
     KeyboardShortcutManager::HonorShortcuts(true);
-    
-    auto tb = static_cast<EquationTextBox^>(sender);
-    auto eq = static_cast<EquationViewModel^>(tb->DataContext);
-    tb->SetEquationText(eq->Expression);
 }
 
-void EquationInputArea::InputTextBox_KeyUp(Object^ sender, KeyRoutedEventArgs^ e)
+void EquationInputArea::InputTextBox_Submitted(Object ^ sender, RoutedEventArgs ^ e)
 {
-    if (e->Key == VirtualKey::Enter)
-    {
-        auto tb = static_cast<EquationTextBox^>(sender);
-        auto eq = static_cast<EquationViewModel^>(tb->DataContext);
-        eq->Expression = tb->GetEquationText();
-
-        e->Handled = true;
-    }
+    auto tb = static_cast<EquationTextBox^>(sender);
+    auto eq = static_cast<EquationViewModel^>(tb->DataContext);
+    eq->Expression = tb->GetEquationText();
 }
 
 Color EquationInputArea::GetNextLineColor()

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
@@ -23,7 +23,7 @@ namespace CalculatorApp
 
         void InputTextBox_GotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void InputTextBox_LostFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-        void InputTextBox_KeyUp(Platform::Object^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs^ e);
+        void InputTextBox_Submitted(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 
         Windows::UI::Color GetNextLineColor();
 

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18970.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">15.0</UnitTestPlatformVersion>

--- a/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
+++ b/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
@@ -274,7 +274,7 @@ namespace CalculatorUnitTests
     void NavCategoryUnitTests::GetPosition()
     {
         // Position is the 1-based ordering of modes
-        vector<ViewMode> orderedModes = { ViewMode::Standard, ViewMode::Scientific, ViewMode::Programmer, ViewMode::Date,     ViewMode::Graphing
+        vector<ViewMode> orderedModes = { ViewMode::Standard, ViewMode::Scientific, ViewMode::Programmer, ViewMode::Date,     ViewMode::Graphing,
                                           ViewMode::Currency, ViewMode::Volume,   ViewMode::Length,     ViewMode::Weight,     ViewMode::Temperature,
                                           ViewMode::Energy,   ViewMode::Area,     ViewMode::Speed,      ViewMode::Time,       ViewMode::Power,
                                           ViewMode::Data,     ViewMode::Pressure, ViewMode::Angle };

--- a/src/GraphControl/Control/Equation.cpp
+++ b/src/GraphControl/Control/Equation.cpp
@@ -9,6 +9,8 @@ using namespace Windows::UI::Xaml;
 
 namespace GraphControl
 {
+    static constexpr wstring_view s_mathPrefix = L"mml:";
+
     DependencyProperty^ Equation::s_expressionProperty;
     static constexpr auto s_propertyName_Expression = L"Expression";
 
@@ -74,7 +76,7 @@ namespace GraphControl
         ss  << GetRequestHeader()
             << GetExpression()
             << GetLineColor()
-            << L")";
+            << L"</mfenced></mrow>";
 
         return ss.str();
     }
@@ -82,19 +84,28 @@ namespace GraphControl
     wstring Equation::GetRequestHeader()
     {
         wstring expr{ Expression->Data() };
-        if (expr.find(L"=") != wstring::npos)
+        if (expr.find(L">=<") != wstring::npos)
         {
-            return L"plotEq2d("s;
+            return L"<mrow><mi>plotEq2d</mi><mfenced separators=\"\">"s;
         }
         else
         {
-            return L"plot2d("s;
+            return L"<mrow><mi>plot2d</mi><mfenced separators=\"\">"s;
         }
     }
 
     wstring Equation::GetExpression()
     {
-        return Expression->Data();
+        wstring mathML = Expression->Data();
+
+        size_t mathPrefix = 0;
+        while ((mathPrefix = mathML.find(s_mathPrefix, mathPrefix)) != std::string::npos)
+        {
+            mathML.replace(mathPrefix, s_mathPrefix.length(), L"");
+            mathPrefix += s_mathPrefix.length();
+        }
+
+        return mathML;
     }
 
     wstring Equation::GetLineColor()

--- a/src/GraphControl/Control/Equation.cpp
+++ b/src/GraphControl/Control/Equation.cpp
@@ -9,6 +9,7 @@ using namespace Windows::UI::Xaml;
 
 namespace GraphControl
 {
+    // Remove mml: formatting specific to RichEditBox control, which is not understood by the graph engine.
     static constexpr wstring_view s_mathPrefix = L"mml:";
 
     DependencyProperty^ Equation::s_expressionProperty;

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -55,7 +55,7 @@ namespace GraphControl
         : m_solver{ IMathSolver::CreateMathSolver() }
         , m_graph{ m_solver->CreateGrapher() }
     {
-        m_solver->ParsingOptions().SetFormatType(FormatType::Linear);
+        m_solver->ParsingOptions().SetFormatType(FormatType::MathML);
 
         DefaultStyleKey = StringReference(s_defaultStyleKey);
 
@@ -365,20 +365,20 @@ namespace GraphControl
             if (!validEqs.empty())
             {
                 wstringstream ss{};
-                ss << L"show2d(";
+                ss << L"<math xmlns=\"http://www.w3.org/1998/Math/MathML\"><mrow><mi>show2d</mi><mfenced separators=\"\">";
 
                 int numValidEquations = 0;
                 for (Equation^ eq : validEqs)
                 {
                     if (numValidEquations++ > 0)
                     {
-                        ss << L",";
+                        ss << L"<mo>,</mo>";
                     }
 
                     ss << eq->GetRequest();
                 }
 
-                ss << L")";
+                ss << L"</mfenced></mrow></math>";
 
                 wstring request = ss.str();
                 unique_ptr<IExpression> graphExpression;

--- a/src/GraphControl/GraphControl.vcxproj
+++ b/src/GraphControl/GraphControl.vcxproj
@@ -42,7 +42,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.18970.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.18362.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/src/MockGraphingImpl/MockGraphingImpl.vcxproj
+++ b/src/MockGraphingImpl/MockGraphingImpl.vcxproj
@@ -42,7 +42,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18970.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.18362.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>


### PR DESCRIPTION
## Part of #338 

### Description of the changes:
- Switch to using math mode in the rich edit control in EquationTextBox
- Switch GraphControl to use MathML instead of plain text

### How changes were validated:
- Manual testing
