### PR TITLE
Modify how narrator names the first and last bits of a number in Bit Flip

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -549,11 +549,11 @@
     <value>%1, value %2</value>
     <comment>{Locked="%1","%2"}. String used in automation name for each bit in bit flip. %1 will be replaced by the position of the bit (1st bit, 3rd bit), %2 by a binary value (1 or 0)</comment>
   </data>
-    <data name="BitPosition" xml:space="preserve">
+  <data name="BitPosition" xml:space="preserve">
     <value>%1 bit</value>
     <comment>{Locked="%1"}. Sub-string used to indicate the position of a bit (e.g. 1st bit, 2nd bit...)</comment>
   </data>
-    <data name="63" xml:space="preserve">
+  <data name="63" xml:space="preserve">
     <value>63rd</value>
     <comment>Sub-string used in automation name for 63 bit in bit flip</comment>
   </data>
@@ -805,9 +805,9 @@
     <value>1st</value>
     <comment>Sub-string used in automation name for 1 bit in bit flip</comment>
   </data>
-  <data name="0" xml:space="preserve">
-    <value>0th</value>
-    <comment>Sub-string used in automation name for 0 bit in bit flip</comment>
+  <data name="LeastSignificantBit" xml:space="preserve">
+    <value>least significant bit</value>
+    <comment>Used to describe the first bit of a binary number. Used in bit flip</comment>
   </data>
   <data name="MemoryButton_Open" xml:space="preserve">
     <value>Open memory flyout</value>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3423,4 +3423,8 @@
     <value>Calculation failed</value>
     <comment>Text displayed when the application is not able to do a calculation</comment>
   </data>
+  <data name="MostSignificantBit" xml:space="preserve">
+    <value>most significant bit</value>
+    <comment>Used to describe the last bit of a binary number. Used in bit flip</comment>
+  </data>
 </root>

--- a/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml.cpp
@@ -69,7 +69,8 @@ void CalculatorProgrammerBitFlipPanel::OnPropertyChanged(Object ^ sender, Proper
     {
         UpdateCheckedStates(false);
     }
-    else if (e->PropertyName == StandardCalculatorViewModel::IsBitFlipCheckedPropertyName
+    else if (
+        e->PropertyName == StandardCalculatorViewModel::IsBitFlipCheckedPropertyName
         || e->PropertyName == StandardCalculatorViewModel::IsProgrammerPropertyName)
     {
         if (Model->IsBitFlipChecked && Model->IsProgrammer)
@@ -233,11 +234,17 @@ bool CalculatorProgrammerBitFlipPanel::ShouldEnableBit(BitLength length, int ind
 String ^ CalculatorProgrammerBitFlipPanel::GenerateAutomationPropertiesName(int position, bool value) const
 {
     auto resourceLoader = AppResourceProvider::GetInstance();
-
-    String ^ indexName = resourceLoader.GetResourceString(ref new Platform::String(to_wstring(position).c_str()));
     String ^ automationNameTemplate = resourceLoader.GetResourceString(L"BitFlipItemAutomationName");
-    String ^ bitPositionTemplate = resourceLoader.GetResourceString(L"BitPosition");
-
-    wstring bitPosition = LocalizationStringUtil::GetLocalizedString(bitPositionTemplate->Data(), indexName->Data());
+    wstring bitPosition; 
+    if (position == 0)
+    {
+        bitPosition = wstring(resourceLoader.GetResourceString(L"LeastSignificantBit")->Data());
+    }
+    else
+    {
+        String ^ indexName = resourceLoader.GetResourceString(ref new Platform::String(to_wstring(position).c_str()));
+        String ^ bitPositionTemplate = resourceLoader.GetResourceString(L"BitPosition");
+        bitPosition = LocalizationStringUtil::GetLocalizedString(bitPositionTemplate->Data(), indexName->Data());
+    }
     return ref new String(LocalizationStringUtil::GetLocalizedString(automationNameTemplate->Data(), bitPosition.c_str(), value ? L"1" : L"0").c_str());
 }

--- a/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml.cpp
@@ -50,6 +50,7 @@ void CalculatorProgrammerBitFlipPanel::SubscribePropertyChanged()
     if (Model != nullptr)
     {
         m_propertyChangedToken = Model->PropertyChanged += ref new PropertyChangedEventHandler(this, &CalculatorProgrammerBitFlipPanel::OnPropertyChanged);
+        m_currentValueBitLength = Model->ValueBitLength;
         UpdateCheckedStates(true);
     }
 }
@@ -68,6 +69,7 @@ void CalculatorProgrammerBitFlipPanel::OnPropertyChanged(Object ^ sender, Proper
     if (e->PropertyName == StandardCalculatorViewModel::BinaryDigitsPropertyName)
     {
         UpdateCheckedStates(false);
+        m_currentValueBitLength = Model->ValueBitLength;
     }
     else if (
         e->PropertyName == StandardCalculatorViewModel::IsBitFlipCheckedPropertyName
@@ -191,10 +193,13 @@ void CalculatorProgrammerBitFlipPanel::UpdateCheckedStates(bool updateAutomation
     m_updatingCheckedStates = true;
     auto it = m_flipButtons.begin();
     int index = 0;
+    bool mustUpdateTextOfMostSignificantDigits = m_currentValueBitLength != Model->ValueBitLength;
+    int previousMSDPosition = GetIndexOfLastBit(m_currentValueBitLength);
+    int newMSDPosition = GetIndexOfLastBit(Model->ValueBitLength);
     for (bool val : Model->BinaryDigits)
     {
         FlipButtons ^ flipButton = *it;
-        if (updateAutomationPropertiesNames)
+        if (updateAutomationPropertiesNames || (mustUpdateTextOfMostSignificantDigits && (index == previousMSDPosition || index == newMSDPosition)))
         {
             flipButton->SetValue(AutomationProperties::NameProperty, GenerateAutomationPropertiesName(index, flipButton->IsChecked->Value));
         }
@@ -217,34 +222,52 @@ void CalculatorProgrammerBitFlipPanel::UpdateAutomationPropertiesNames()
 
 bool CalculatorProgrammerBitFlipPanel::ShouldEnableBit(BitLength length, int index)
 {
+    return index <= GetIndexOfLastBit(length);
+}
+
+int CalculatorProgrammerBitFlipPanel::GetIndexOfLastBit(BitLength length) const
+{
     switch (length)
     {
     case BitLength::BitLengthQWord:
-        return index <= 63;
+        return 63;
     case BitLength::BitLengthDWord:
-        return index <= 31;
+        return 31;
     case BitLength::BitLengthWord:
-        return index <= 15;
+        return 15;
     case BitLength::BitLengthByte:
-        return index <= 7;
+        return 7;
     }
-    return false;
+    return -1;
 }
 
-String ^ CalculatorProgrammerBitFlipPanel::GenerateAutomationPropertiesName(int position, bool value) const
+String ^ CalculatorProgrammerBitFlipPanel::GenerateAutomationPropertiesName(int position, bool value)
 {
     auto resourceLoader = AppResourceProvider::GetInstance();
     String ^ automationNameTemplate = resourceLoader.GetResourceString(L"BitFlipItemAutomationName");
-    wstring bitPosition; 
+    wstring bitPosition;
     if (position == 0)
     {
         bitPosition = wstring(resourceLoader.GetResourceString(L"LeastSignificantBit")->Data());
     }
     else
     {
-        String ^ indexName = resourceLoader.GetResourceString(ref new Platform::String(to_wstring(position).c_str()));
-        String ^ bitPositionTemplate = resourceLoader.GetResourceString(L"BitPosition");
-        bitPosition = LocalizationStringUtil::GetLocalizedString(bitPositionTemplate->Data(), indexName->Data());
+        int lastPosition = -1;
+        if (Model != nullptr)
+        {
+            lastPosition = GetIndexOfLastBit(Model->ValueBitLength);
+        }
+
+        if (position == lastPosition)
+        {
+            bitPosition = wstring(resourceLoader.GetResourceString(L"MostSignificantBit")->Data());
+        }
+        else
+        {
+            String ^ indexName = resourceLoader.GetResourceString(ref new Platform::String(to_wstring(position).c_str()));
+            String ^ bitPositionTemplate = resourceLoader.GetResourceString(L"BitPosition");
+            bitPosition = LocalizationStringUtil::GetLocalizedString(bitPositionTemplate->Data(), indexName->Data());
+        }
     }
     return ref new String(LocalizationStringUtil::GetLocalizedString(automationNameTemplate->Data(), bitPosition.c_str(), value ? L"1" : L"0").c_str());
 }

--- a/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml.cpp
@@ -199,11 +199,14 @@ void CalculatorProgrammerBitFlipPanel::UpdateCheckedStates(bool updateAutomation
     for (bool val : Model->BinaryDigits)
     {
         FlipButtons ^ flipButton = *it;
-        if (updateAutomationPropertiesNames || (mustUpdateTextOfMostSignificantDigits && (index == previousMSDPosition || index == newMSDPosition)))
-        {
-            flipButton->SetValue(AutomationProperties::NameProperty, GenerateAutomationPropertiesName(index, flipButton->IsChecked->Value));
-        }
+        bool hasValueChanged = flipButton->IsChecked->Value != val;
         flipButton->IsChecked = val;
+        if (updateAutomationPropertiesNames
+            || hasValueChanged
+            || (mustUpdateTextOfMostSignificantDigits && (index == previousMSDPosition || index == newMSDPosition)))
+        {
+            flipButton->SetValue(AutomationProperties::NameProperty, GenerateAutomationPropertiesName(index, val));
+        }
         ++it;
         ++index;
     }

--- a/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml.h
+++ b/src/Calculator/Views/CalculatorProgrammerBitFlipPanel.xaml.h
@@ -22,7 +22,7 @@ namespace CalculatorApp
         bool ShouldEnableBit(CalculatorApp::Common::BitLength length, int index);
 
         property CalculatorApp::ViewModel::StandardCalculatorViewModel
-            ^ Model { CalculatorApp::ViewModel::StandardCalculatorViewModel ^ get(); }
+            ^ Model { CalculatorApp::ViewModel::StandardCalculatorViewModel ^ get(); } 
 
             private : void OnLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void OnUnloaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
@@ -37,12 +37,14 @@ namespace CalculatorApp
 
     private:
         Windows::Foundation::EventRegistrationToken m_propertyChangedToken;
-        Platform::String ^ GenerateAutomationPropertiesName(int position, bool value) const;
+        Platform::String ^ GenerateAutomationPropertiesName(int position, bool value);
         void UpdateCheckedStates(bool updateAutomationPropertiesNames);
         void UpdateAutomationPropertiesNames();
+        int GetIndexOfLastBit(CalculatorApp::Common::BitLength length) const;
 
         static const unsigned int s_numBits = 64;
         std::array<CalculatorApp::Controls::FlipButtons ^, s_numBits> m_flipButtons;
         bool m_updatingCheckedStates;
+        CalculatorApp::Common::BitLength m_currentValueBitLength;
     };
 }


### PR DESCRIPTION
## Fixes #385 

### Description of the changes:
- replace "0th bit"  by "least significant bit"
- add support of  "most significant bit" and update texts when BitLength changes.
  - Note: to keep CPU usage low, we only update texts of the previous checkbox associated to the MSB and the new one.

### How changes were validated:
- Manually