### PR TITLE
Prevent the history panel to be displayed when using the Programmer mode

### DIFF
--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -554,21 +554,21 @@ void Calculator::SetDefaultFocus()
 
 void Calculator::ToggleHistoryFlyout(Object ^ /*parameter*/)
 {
-    String ^ viewState = App::GetAppViewState();
-    // If app starts correctly in snap mode and shortcut is used for history then we need to load history if not yet initialized.
-    if (viewState != ViewState::DockedView)
+    if (Model->IsProgrammer || App::GetAppViewState() == ViewState::DockedView)
     {
-        if (m_fIsHistoryFlyoutOpen)
-        {
-            HistoryFlyout->Hide();
-        }
-        else
-        {
-            HistoryFlyout->Content = m_historyList;
-            m_historyList->RowHeight = NumpadPanel->ActualHeight;
-            FlyoutBase::ShowAttachedFlyout(HistoryButton);
-        }
+        return;
     }
+    
+    if (m_fIsHistoryFlyoutOpen)
+    {
+        HistoryFlyout->Hide();
+    }
+    else
+    {
+        HistoryFlyout->Content = m_historyList;
+        m_historyList->RowHeight = NumpadPanel->ActualHeight;
+        FlyoutBase::ShowAttachedFlyout(HistoryButton);
+    }   
 }
 
 void Calculator::ToggleMemoryFlyout()


### PR DESCRIPTION
## Fixes #665

### Description of the changes:
- be sure we don't display the panel when the current view is the Programmer mode.

Bonus:
- remove obsolete comment

### How changes were validated:
- Manually

