### PR TITLE
Disable ProgrammerRadixOperators when not visible

### DIFF
--- a/src/Calculator/Views/OperatorsPanel.xaml
+++ b/src/Calculator/Views/OperatorsPanel.xaml
@@ -22,10 +22,12 @@
 
         <local:CalculatorProgrammerBitFlipPanel x:Name="BitFlipPanel"
                                                 x:Load="False"
+                                                IsEnabled="{x:Bind Model.IsBinaryBitFlippingEnabled, Mode=OneWay}"
                                                 Visibility="{x:Bind Model.IsBinaryBitFlippingEnabled, Mode=OneWay}"/>
 
         <local:CalculatorProgrammerRadixOperators x:Name="ProgrammerRadixOperators"
                                                   x:Load="False"
+                                                  IsEnabled="{x:Bind Model.AreProgrammerRadixOperatorsEnabled, Mode=OneWay}"
                                                   TabIndex="16"
                                                   Visibility="{x:Bind Model.AreProgrammerRadixOperatorsEnabled, Mode=OneWay}"/>
 


### PR DESCRIPTION
## Fixes #678


### Description of the changes:
Calculator validates keyboard hotkeys by checking if the button is enabled. Since the binding to disable CalculatorProgrammerRadixOperators was removed, the buttons were always enabled allowing the hotkeys to be used from any mode. This PR does the simple solution of adding the binding back.

### How changes were validated:
- Manual tests

