### PR TITLE
Add fallback colors to RevealBrushes missing them

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -24,8 +24,8 @@
                     <SolidColorBrush x:Key="SystemControlHighlightTransparentBrush" Color="Transparent"/>
                     <SolidColorBrush x:Key="AppBackgroundAltMediumLowBrush" Color="{ThemeResource SystemAltMediumLowColor}"/>
                     <SolidColorBrush x:Key="AppControlPageTextBaseMediumHighBrush" Color="{StaticResource SystemBaseMediumHighColor}"/>
-                    <RevealBackgroundBrush x:Key="AppControlHoverButtonFaceBrush" Color="#18FFFFFF"/>
-                    <RevealBackgroundBrush x:Key="AppControlPressedButtonFaceBrush" Color="#30FFFFFF"/>
+                    <RevealBackgroundBrush x:Key="AppControlHoverButtonFaceBrush" Color="#18FFFFFF" FallbackColor="#18FFFFFF"/>
+                    <RevealBackgroundBrush x:Key="AppControlPressedButtonFaceBrush" Color="#30FFFFFF" FallbackColor="#30FFFFFF"/>
                     <SolidColorBrush x:Key="AppControlTransparentAccentColorBrush" Color="{ThemeResource SystemAccentColor}"/>
                     <SolidColorBrush x:Key="AppControlPageTextBaseHighColorBrush" Color="{StaticResource SystemBaseHighColor}"/>
                     <SolidColorBrush x:Key="AppControlPageTextRedColorBrush" Color="Red"/>
@@ -59,8 +59,8 @@
                     <SolidColorBrush x:Key="SystemControlHighlightTransparentBrush" Color="Transparent"/>
                     <SolidColorBrush x:Key="AppBackgroundAltMediumLowBrush" Color="{ThemeResource SystemAltMediumLowColor}"/>
                     <SolidColorBrush x:Key="AppControlPageTextBaseMediumHighBrush" Color="{StaticResource SystemBaseMediumHighColor}"/>
-                    <RevealBackgroundBrush x:Key="AppControlHoverButtonFaceBrush" Color="#17000000"/>
-                    <RevealBackgroundBrush x:Key="AppControlPressedButtonFaceBrush" Color="#30000000"/>
+                    <RevealBackgroundBrush x:Key="AppControlHoverButtonFaceBrush" Color="#17000000" FallbackColor="#17000000"/>
+                    <RevealBackgroundBrush x:Key="AppControlPressedButtonFaceBrush" Color="#30000000" FallbackColor="#30000000"/>
                     <SolidColorBrush x:Key="AppControlTransparentAccentColorBrush" Color="{ThemeResource SystemAccentColor}"/>
                     <SolidColorBrush x:Key="AppControlPageTextBaseHighColorBrush" Color="{StaticResource SystemBaseHighColor}"/>
                     <SolidColorBrush x:Key="AppControlPageTextRedColorBrush" Color="Red"/>


### PR DESCRIPTION
## Fixes #684

All the following buttons don't provide UI feedback when users hover or press the following buttons:
![image](https://user-images.githubusercontent.com/1226538/65813158-225e8d80-e186-11e9-9a5b-f28b4b2a6f6a.png)

![image](https://user-images.githubusercontent.com/1226538/65813150-0ce96380-e186-11e9-84c6-44562e41a39b.png)

![image](https://user-images.githubusercontent.com/1226538/65813154-170b6200-e186-11e9-97be-6ceda7271b79.png)


### Description of the changes:
- Add fallback colors to RevealBrush missing them

### Breaking change to validate
Because buttons from the numeric pad use the same brushes than the buttons above, this change has also an impact on them.

Battery mode - before
![image](https://user-images.githubusercontent.com/1226538/65813213-e2e47100-e186-11e9-8e87-429ea338135a.png)
Battery mode - after
![image](https://user-images.githubusercontent.com/1226538/65813235-54bcba80-e187-11e9-943f-a638331552d5.png)
Acrylic enabled
![image](https://user-images.githubusercontent.com/1226538/65813227-1c1ce100-e187-11e9-9049-4e3ec5004685.png)

In my opinion, this change is positive, for 2 reasons:
- It improve the "readability" of the UI, buttons use the same background color than the app in the current version.
- Colors used for hover and press where the same gray (default fallback color) when acrylic is disabled, so it was impossible to see if a button was pressed or hovered.

### How changes were validated:
- Manually