### PR TITLE
Fix focus with AlwaysOnTop mode

### DIFF
--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -403,12 +403,12 @@
                         <Setter Target="MemMinus.IsEnabled" Value="False"/>
                         <Setter Target="MemButton.IsEnabled" Value="False"/>
                     </VisualState.Setters>
-                    <Storyboard Completed="OnErrorLayoutCompleted"/>
+                    <Storyboard Completed="OnErrorVisualStateCompleted"/>
                 </VisualState>
             </VisualStateGroup>
             <!-- Always-on-Top specific -->
-            <VisualStateGroup x:Name="AlwaysOnTopStates">
-                <VisualState x:Name="AlwaysOnTop">
+            <VisualStateGroup x:Name="DisplayModeVisualStates">
+                <VisualState x:Name="DisplayModeAlwaysOnTop">
                     <VisualState.Setters>
                         <Setter Target="ClearMemoryButton.IsEnabled" Value="False"/>
                         <Setter Target="MemRecall.IsEnabled" Value="False"/>
@@ -419,19 +419,21 @@
                         <Setter Target="RowHamburger.Height" Value="0"/>
                         <Setter Target="RowMemoryControls.Height" Value="0*"/>
                     </VisualState.Setters>
+                    <Storyboard Completed="OnDisplayVisualStateCompleted"/>
                 </VisualState>
-                <VisualState x:Name="Normal">
+                <VisualState x:Name="DisplayModeNormal">
                     <VisualState.Setters>
                         <Setter Target="RowExpression.Height" Value="20*"/>
                         <Setter Target="RowHamburger.Height" Value="{StaticResource HamburgerHeightGridLength}"/>
                         <Setter Target="RowMemoryControls.Height" Value="32*"/>
                     </VisualState.Setters>
+                    <Storyboard Completed="OnDisplayVisualStateCompleted"/>
                 </VisualState>
             </VisualStateGroup>
             <!-- Mode specific -->
-            <VisualStateGroup x:Name="Mode">
+            <VisualStateGroup x:Name="ModeVisualStates">
                 <VisualState x:Name="Standard">
-                    <Storyboard Completed="OnStoryboardCompleted"/>
+                    <Storyboard Completed="OnModeVisualStateCompleted"/>
                 </VisualState>
                 <VisualState x:Name="Scientific">
                     <VisualState.Setters>
@@ -439,7 +441,7 @@
                         <Setter Target="RowDisplayControls.MinHeight" Value="32"/>
                         <Setter Target="RowNumPad.Height" Value="276*"/>
                     </VisualState.Setters>
-                    <Storyboard Completed="OnStoryboardCompleted"/>
+                    <Storyboard Completed="OnModeVisualStateCompleted"/>
                 </VisualState>
                 <VisualState x:Name="Programmer">
                     <VisualState.Setters>
@@ -454,11 +456,11 @@
                         <Setter Target="MemoryButton.(Grid.Column)" Value="6"/>
                         <Setter Target="HistoryButton.Visibility" Value="Collapsed"/>
                     </VisualState.Setters>
-                    <Storyboard Completed="OnStoryboardCompleted"/>
+                    <Storyboard Completed="OnModeVisualStateCompleted"/>
                 </VisualState>
             </VisualStateGroup>
             <!-- Layout specific -->
-            <VisualStateGroup CurrentStateChanged="OnVisualStateChanged">
+            <VisualStateGroup x:Name="LayoutVisualStates" CurrentStateChanged="OnVisualStateChanged">
                 <VisualState x:Name="Portrait768x1366">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowHeight="1366" MinWindowWidth="768"/>
@@ -468,7 +470,7 @@
                         <Setter Target="DockPanel.Visibility" Value="Visible"/>
                         <Setter Target="M6.Width" Value="0"/>
                     </VisualState.Setters>
-                    <Storyboard Completed="OnLayoutStateChanged"/>
+                    <Storyboard Completed="OnLayoutVisualStateCompleted"/>
                 </VisualState>
                 <VisualState x:Name="LargeWideView">
                     <VisualState.StateTriggers>
@@ -479,7 +481,7 @@
                         <Setter Target="DockPanel.Visibility" Value="Visible"/>
                         <Setter Target="M6.Width" Value="0"/>
                     </VisualState.Setters>
-                    <Storyboard Completed="OnLayoutStateChanged"/>
+                    <Storyboard Completed="OnLayoutVisualStateCompleted"/>
                 </VisualState>
                 <VisualState x:Name="DockVisible">
                     <VisualState.StateTriggers>
@@ -491,13 +493,13 @@
                         <Setter Target="DockPanel.Visibility" Value="Visible"/>
                         <Setter Target="M6.Width" Value="0"/>
                     </VisualState.Setters>
-                    <Storyboard Completed="OnLayoutStateChanged"/>
+                    <Storyboard Completed="OnLayoutVisualStateCompleted"/>
                 </VisualState>
                 <VisualState x:Name="MinSizeLayout">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowHeight="{StaticResource AppMinWindowHeight}" MinWindowWidth="{StaticResource AppMinWindowWidth}"/>
                     </VisualState.StateTriggers>
-                    <Storyboard Completed="OnLayoutStateChanged"/>
+                    <Storyboard Completed="OnLayoutVisualStateCompleted"/>
                 </VisualState>
                 <VisualState x:Name="DefaultLayout">
                     <VisualState.StateTriggers>
@@ -505,7 +507,6 @@
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="RowMemoryControls.MinHeight" Value="0"/>
-
                         <Setter Target="ClearMemoryButton.Style" Value="{StaticResource CaptionButtonStyle}"/>
                         <Setter Target="MemRecall.Style" Value="{StaticResource CaptionButtonStyle}"/>
                         <Setter Target="MemPlus.Style" Value="{StaticResource CaptionButtonStyle}"/>
@@ -513,7 +514,7 @@
                         <Setter Target="MemButton.Style" Value="{StaticResource CaptionButtonStyle}"/>
                         <Setter Target="MemoryButton.MinHeight" Value="0"/>
                     </VisualState.Setters>
-                    <Storyboard Completed="OnLayoutStateChanged"/>
+                    <Storyboard Completed="OnLayoutVisualStateCompleted"/>
                 </VisualState>
             </VisualStateGroup>
             <!-- Results display specific -->

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -209,7 +209,7 @@ void Calculator::AnimateCalculator(bool resultAnimate)
             // We are forcing the animation here
             // It's because if last animation was in standard, then go to unit converter, then comes back to standard
             // The state for the calculator does not change and the animation would not get run.
-            this->OnStoryboardCompleted(nullptr, nullptr);
+            this->OnModeVisualStateCompleted(nullptr, nullptr);
         }
     }
 }
@@ -239,7 +239,7 @@ void Calculator::OnContextCanceled(UIElement ^ sender, RoutedEventArgs ^ e)
     m_displayFlyout->Hide();
 }
 
-void Calculator::OnLayoutStateChanged(_In_ Object ^ sender, _In_ Object ^ e)
+void Calculator::OnLayoutVisualStateCompleted(_In_ Object ^ sender, _In_ Object ^ e)
 {
     UpdatePanelViewState();
 }
@@ -286,29 +286,23 @@ void Calculator::OnIsAlwaysOnTopPropertyChanged(bool /*oldValue*/, bool newValue
 {
     if (newValue)
     {
-        VisualStateManager::GoToState(this, L"AlwaysOnTop", false);
+        VisualStateManager::GoToState(this, L"DisplayModeAlwaysOnTop", false);
+        AlwaysOnTopResults->UpdateScrollButtons();
     }
     else
     {
-        VisualStateManager::GoToState(this, L"Normal", false);
-        if (Model->IsInError)
-        {
-            VisualStateManager::GoToState(this, L"ErrorLayout", false);
-        }
-        else
+        VisualStateManager::GoToState(this, L"DisplayModeNormal", false);
+        if (!Model->IsInError)
         {
             EnableMemoryControls(true);
         }
+        Results->UpdateTextState();
     }
 
     Model->IsMemoryEmpty = (Model->MemorizedNumbers->Size == 0) || IsAlwaysOnTop;
 
-    AlwaysOnTopResults->UpdateScrollButtons();
-    Results->UpdateTextState();
-
     UpdateViewState();
     UpdatePanelViewState();
-    SetDefaultFocus();
 }
 
 void Calculator::OnIsInErrorPropertyChanged()
@@ -336,7 +330,7 @@ void Calculator::OnIsInErrorPropertyChanged()
 
 // Once the storyboard that rearranges the buttons completed,
 // We do the animation based on the Mode or Orientation change.
-void Calculator::OnStoryboardCompleted(_In_ Object ^ sender, _In_ Object ^ e)
+void Calculator::OnModeVisualStateCompleted(_In_ Object ^ sender, _In_ Object ^ e)
 {
     m_isLastAnimatedInScientific = IsScientific;
     m_isLastAnimatedInProgrammer = IsProgrammer;
@@ -558,7 +552,7 @@ void Calculator::ToggleHistoryFlyout(Object ^ /*parameter*/)
     {
         return;
     }
-    
+
     if (m_fIsHistoryFlyoutOpen)
     {
         HistoryFlyout->Hide();
@@ -568,7 +562,7 @@ void Calculator::ToggleHistoryFlyout(Object ^ /*parameter*/)
         HistoryFlyout->Content = m_historyList;
         m_historyList->RowHeight = NumpadPanel->ActualHeight;
         FlyoutBase::ShowAttachedFlyout(HistoryButton);
-    }   
+    }
 }
 
 void Calculator::ToggleMemoryFlyout()
@@ -719,7 +713,12 @@ void Calculator::UnregisterEventHandlers()
     ExpressionText->UnregisterEventHandlers();
 }
 
-void Calculator::OnErrorLayoutCompleted(_In_ Object ^ sender, _In_ Object ^ e)
+void Calculator::OnErrorVisualStateCompleted(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e)
+{
+    SetDefaultFocus();
+}
+
+void Calculator::OnDisplayVisualStateCompleted(_In_ Object ^ sender, _In_ Object ^ e)
 {
     SetDefaultFocus();
 }

--- a/src/Calculator/Views/Calculator.xaml.h
+++ b/src/Calculator/Views/Calculator.xaml.h
@@ -84,8 +84,10 @@ public
         void OnIsAlwaysOnTopPropertyChanged(bool oldValue, bool newValue);
         void OnIsInErrorPropertyChanged();
         void OnCalcPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::Data::PropertyChangedEventArgs ^ e);
-        void OnStoryboardCompleted(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e);
-        void OnLayoutStateChanged(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e);
+        void OnLayoutVisualStateCompleted(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e);
+        void OnModeVisualStateCompleted(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e);
+        void OnErrorVisualStateCompleted(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e);
+        void OnDisplayVisualStateCompleted(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e);
         void EnsureScientific();
         void EnsureProgrammer();
         void SetFontSizeResources();
@@ -137,7 +139,6 @@ public
         void OnHistoryFlyOutTapped(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::Input::TappedRoutedEventArgs ^ e);
         bool IsValidRegularExpression(std::wstring str);
         void DockPanelTapped(_In_ Windows::UI::Xaml::Input::TappedRoutedEventArgs ^ e);
-        void OnErrorLayoutCompleted(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e);
         void OnHistoryAccessKeyInvoked(_In_ Windows::UI::Xaml::UIElement ^ sender, _In_ Windows::UI::Xaml::Input::AccessKeyInvokedEventArgs ^ args);
         void OnMemoryAccessKeyInvoked(_In_ Windows::UI::Xaml::UIElement ^ sender, _In_ Windows::UI::Xaml::Input::AccessKeyInvokedEventArgs ^ args);
         void OnVisualStateChanged(Platform::Object ^ sender, Windows::UI::Xaml::VisualStateChangedEventArgs ^ e);


### PR DESCRIPTION
## Fixes #677 


### Description of the changes:
- Make sure the user interface has been updated before setting the focus.
- Make `Storyboard::Completed` function names consistent
- slight refactoring of `Calculator::OnIsAlwaysOnTopPropertyChanged`

### How changes were validated:
- manual

