### PR TITLE
Do not hide expression when user presses Enter or =

### DIFF
--- a/src/CalcManager/CEngine/History.cpp
+++ b/src/CalcManager/CEngine/History.cpp
@@ -301,17 +301,6 @@ void CHistoryCollector::AddUnaryOpToHistory(int nOpCode, bool fInv, ANGLE_TYPE a
 // history of equations
 void CHistoryCollector::CompleteHistoryLine(wstring_view numStr)
 {
-    std::wstring expressionSuffix{};
-    HRESULT hr = m_spTokens->GetExpressionSuffix(&expressionSuffix);
-    if (SUCCEEDED(hr))
-    {
-        // Add only '=' token and not add EQU command, because
-        // EQU command breaks loading from history (it duplicate history entries).
-        IchAddSzToEquationSz(expressionSuffix, -1);
-    }
-
-    SetExpressionDisplay();
-
     if (nullptr != m_pHistoryDisplay)
     {
         unsigned int addedItemIndex = m_pHistoryDisplay->AddToHistory(m_spTokens, m_spCommands, numStr);
@@ -322,6 +311,16 @@ void CHistoryCollector::CompleteHistoryLine(wstring_view numStr)
     m_spCommands = nullptr;
     m_iCurLineHistStart = -1; // It will get recomputed at the first Opnd
     ReinitHistory();
+}
+
+void CHistoryCollector::CompleteEquation(std::wstring_view numStr)
+{
+    // Add only '=' token and not add EQU command, because
+    // EQU command breaks loading from history (it duplicate history entries).
+    IchAddSzToEquationSz(CCalcEngine::OpCodeToString(IDC_EQU), -1);
+
+    SetExpressionDisplay();
+    CompleteHistoryLine(numStr);
 }
 
 void CHistoryCollector::ClearHistoryLine(wstring_view errStr)

--- a/src/CalcManager/CEngine/History.cpp
+++ b/src/CalcManager/CEngine/History.cpp
@@ -301,11 +301,16 @@ void CHistoryCollector::AddUnaryOpToHistory(int nOpCode, bool fInv, ANGLE_TYPE a
 // history of equations
 void CHistoryCollector::CompleteHistoryLine(wstring_view numStr)
 {
-    if (nullptr != m_pCalcDisplay)
+    std::wstring expressionSuffix{};
+    HRESULT hr = m_spTokens->GetExpressionSuffix(&expressionSuffix);
+    if (SUCCEEDED(hr))
     {
-        m_pCalcDisplay->SetExpressionDisplay(
-            std::make_shared<CalculatorVector<std::pair<std::wstring, int>>>(), std::make_shared<CalculatorVector<std::shared_ptr<IExpressionCommand>>>());
+        // Add only '=' token and not add EQU command, because
+        // EQU command breaks loading from history (it duplicate history entries).
+        IchAddSzToEquationSz(expressionSuffix, -1);
     }
+
+    SetExpressionDisplay();
 
     if (nullptr != m_pHistoryDisplay)
     {

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -475,11 +475,6 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         {
             wstring groupedString = GroupDigitsPerRadix(m_numberString, m_radix);
             m_HistoryCollector.CompleteHistoryLine(groupedString);
-            if (nullptr != m_pCalcDisplay)
-            {
-                m_pCalcDisplay->SetExpressionDisplay(
-                    make_shared<CalculatorVector<pair<wstring, int>>>(), make_shared<CalculatorVector<shared_ptr<IExpressionCommand>>>());
-            }
         }
 
         m_bChangeOp = false;

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -76,6 +76,15 @@ void CCalcEngine::ClearTemporaryValues()
     m_bError = false;
 }
 
+void CCalcEngine::ClearDisplay()
+{
+    if (nullptr != m_pCalcDisplay)
+    {
+        m_pCalcDisplay->SetExpressionDisplay(
+            make_shared<CalculatorVector<pair<wstring, int>>>(), make_shared<CalculatorVector<shared_ptr<IExpressionCommand>>>());
+    }
+}
+
 void CCalcEngine::ProcessCommand(OpCode wParam)
 {
     if (wParam == IDC_SET_RESULT)
@@ -104,11 +113,9 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
     }
 
     // Clear expression shown after = sign, when user do any action.
-    static bool afterEQUCommand = false;
-    if (afterEQUCommand)
+    if (!m_bNoPrevEqu)
     {
-        afterEQUCommand = false;
-        m_HistoryCollector.ClearHistoryLine(wstring());
+        ClearDisplay();
     }
 
     if (m_bError)
@@ -391,8 +398,7 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         if (nullptr != m_pCalcDisplay)
         {
             m_pCalcDisplay->SetParenthesisNumber(0);
-            m_pCalcDisplay->SetExpressionDisplay(
-                make_shared<CalculatorVector<pair<wstring, int>>>(), make_shared<CalculatorVector<shared_ptr<IExpressionCommand>>>());
+            ClearDisplay();
         }
 
         m_HistoryCollector.ClearHistoryLine(wstring());
@@ -482,8 +488,7 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         if (!m_bError)
         {
             wstring groupedString = GroupDigitsPerRadix(m_numberString, m_radix);
-            m_HistoryCollector.CompleteHistoryLine(groupedString);
-            afterEQUCommand = true;
+            m_HistoryCollector.CompleteEquation(groupedString);
         }
 
         m_bChangeOp = false;

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -103,6 +103,14 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         m_nTempCom = (int)wParam;
     }
 
+    // Clear expression shown after = sign, when user do any action.
+    static bool afterEQUCommand = false;
+    if (afterEQUCommand)
+    {
+        afterEQUCommand = false;
+        m_HistoryCollector.ClearHistoryLine(wstring());
+    }
+
     if (m_bError)
     {
         if (wParam == IDC_CLEAR)
@@ -475,6 +483,7 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         {
             wstring groupedString = GroupDigitsPerRadix(m_numberString, m_radix);
             m_HistoryCollector.CompleteHistoryLine(groupedString);
+            afterEQUCommand = true;
         }
 
         m_bChangeOp = false;

--- a/src/CalcManager/CalculatorVector.h
+++ b/src/CalcManager/CalculatorVector.h
@@ -133,13 +133,6 @@ public:
                     }
                 }
             }
-
-            std::wstring expressionSuffix{};
-            hr = GetExpressionSuffix(&expressionSuffix);
-            if (SUCCEEDED(hr))
-            {
-                expression->append(expressionSuffix);
-            }
         }
 
         return hr;
@@ -147,7 +140,7 @@ public:
 
     ResultCode GetExpressionSuffix(_Out_ std::wstring* suffix)
     {
-        *suffix = L" =";
+        *suffix = L"=";
         return S_OK;
     }
 

--- a/src/CalcManager/CalculatorVector.h
+++ b/src/CalcManager/CalculatorVector.h
@@ -138,12 +138,6 @@ public:
         return hr;
     }
 
-    ResultCode GetExpressionSuffix(_Out_ std::wstring* suffix)
-    {
-        *suffix = L"=";
-        return S_OK;
-    }
-
 private:
     std::vector<TType> m_vector;
 };

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -165,6 +165,7 @@ private:
     void DisplayAnnounceBinaryOperator();
     void SetPrimaryDisplay(const std::wstring& szText, bool isError = false);
     void ClearTemporaryValues();
+    void ClearDisplay();
     CalcEngine::Rational TruncateNumForIntMath(CalcEngine::Rational const& rat);
     CalcEngine::Rational SciCalcFunctions(CalcEngine::Rational const& rat, uint32_t op);
     CalcEngine::Rational DoOperation(int operation, CalcEngine::Rational const& lhs, CalcEngine::Rational const& rhs);

--- a/src/CalcManager/Header Files/History.h
+++ b/src/CalcManager/Header Files/History.h
@@ -31,6 +31,7 @@ public:
     void EnclosePrecInversionBrackets();
     bool FOpndAddedToHistory();
     void CompleteHistoryLine(std::wstring_view numStr);
+    void CompleteEquation(std::wstring_view numStr);
     void ClearHistoryLine(std::wstring_view errStr);
     int AddCommand(_In_ const std::shared_ptr<IExpressionCommand>& spCommand);
     void UpdateHistoryExpression(uint32_t radix, int32_t precision);

--- a/src/CalcViewModel/HistoryItemViewModel.cpp
+++ b/src/CalcViewModel/HistoryItemViewModel.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #include "pch.h"
@@ -49,16 +49,6 @@ String
 
             wstring token = tokenItem.first;
             accExpression << LocalizationService::GetNarratorReadableToken(StringReference(token.c_str()))->Data();
-        }
-    }
-
-    if (SUCCEEDED(hr))
-    {
-        wstring expressionSuffix{};
-        hr = spTokens->GetExpressionSuffix(&expressionSuffix);
-        if (SUCCEEDED(hr))
-        {
-            accExpression << expressionSuffix;
         }
     }
 

--- a/src/CalculatorUITests/StandardModeFunctionalTests.cs
+++ b/src/CalculatorUITests/StandardModeFunctionalTests.cs
@@ -102,9 +102,9 @@ namespace CalculatorUITests
             page.StandardOperators.EqualButton.Click();
 
             var historyItems = page.HistoryPanel.GetAllHistoryListViewItems();
-            Assert.IsTrue(historyItems[0].Text.Equals("1 × 3 = 3", StringComparison.InvariantCultureIgnoreCase));
-            Assert.IsTrue(historyItems[1].Text.Equals("2 Minus ( 3 = Minus (1", StringComparison.InvariantCultureIgnoreCase));
-            Assert.IsTrue(historyItems[2].Text.Equals("-3 + -2.6 = Minus (5.6", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems[0].Text.Equals("1 × 3= 3", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems[1].Text.Equals("2 Minus ( 3= Minus (1", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems[2].Text.Equals("-3 + -2.6= Minus (5.6", StringComparison.InvariantCultureIgnoreCase));
 
         }
 

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -325,10 +325,10 @@ namespace CalculatorManagerTest
 
         Command commands4[] = { Command::Command2, Command::CommandADD, Command::Command3,   Command::CommandEQU,
                                 Command::Command4, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"7", L"", commands4);
+        TestDriver::Test(L"7", L"4 + 3=", commands4);
 
         Command commands5[] = { Command::Command4, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"4", L"", commands5);
+        TestDriver::Test(L"4", L"4=", commands5);
 
         Command commands6[] = { Command::Command2,    Command::Command5,    Command::Command6,   Command::CommandSQRT,
                                 Command::CommandSQRT, Command::CommandSQRT, Command::CommandNULL };
@@ -336,21 +336,21 @@ namespace CalculatorManagerTest
 
         Command commands7[] = { Command::Command3,   Command::CommandSUB, Command::Command6,   Command::CommandEQU,
                                 Command::CommandMUL, Command::Command3,   Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"-9", L"", commands7);
+        TestDriver::Test(L"-9", L"-3 \x00D7 3=", commands7);
 
         Command commands8[] = { Command::Command9,     Command::CommandMUL, Command::Command6,   Command::CommandSUB,
                                 Command::CommandCENTR, Command::Command8,   Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"46", L"", commands8);
+        TestDriver::Test(L"46", L"9 \x00D7 6 - 8=", commands8);
 
         Command commands9[] = { Command::Command6, Command::CommandMUL, Command::Command6, Command::CommandPERCENT, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"0.36", L"", commands9);
+        TestDriver::Test(L"0.36", L"6 \x00D7 0.06=", commands9);
 
         Command commands10[] = { Command::Command5, Command::Command0,       Command::CommandADD, Command::Command2,
                                  Command::Command0, Command::CommandPERCENT, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"60", L"", commands10);
+        TestDriver::Test(L"60", L"50 + 10=", commands10);
 
         Command commands11[] = { Command::Command4, Command::CommandADD, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"8", L"", commands11);
+        TestDriver::Test(L"8", L"4 + 4=", commands11);
 
         Command commands12[] = { Command::Command5, Command::CommandADD, Command::CommandMUL, Command::Command3, Command::CommandNULL };
         TestDriver::Test(L"3", L"5 \x00D7 ", commands12);
@@ -361,7 +361,7 @@ namespace CalculatorManagerTest
 
         Command commands14[] = { Command::Command5, Command::Command0,       Command::CommandADD, Command::Command2,
                                  Command::Command0, Command::CommandPERCENT, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"60", L"", commands14);
+        TestDriver::Test(L"60", L"50 + 10=", commands14);
 
         Command commands15[] = { Command::Command0, Command::CommandDIV, Command::Command0, Command::CommandEQU, Command::CommandNULL };
         TestDriver::Test(L"Result is undefined", L"0 \x00F7 ", commands15);
@@ -405,10 +405,10 @@ namespace CalculatorManagerTest
 
         Command commands4[] = { Command::Command1, Command::CommandADD, Command::Command0,   Command::CommandMUL,
                                 Command::Command2, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"1", L"", commands4, true, true);
+        TestDriver::Test(L"1", L"1 + 0 \x00D7 2=", commands4, true, true);
 
         Command commands5[] = { Command::Command4, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"4", L"", commands5, true, true);
+        TestDriver::Test(L"4", L"4=", commands5, true, true);
 
         Command commands6[] = { Command::Command2,    Command::Command5,    Command::Command6,   Command::CommandSQRT,
                                 Command::CommandSQRT, Command::CommandSQRT, Command::CommandNULL };
@@ -430,7 +430,7 @@ namespace CalculatorManagerTest
         TestDriver::Test(L"50.05", L"50 + 1/(20) - ", commands10, true, true);
 
         Command commands11[] = { Command::Command4, Command::CommandADD, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"8", L"", commands11, true, true);
+        TestDriver::Test(L"8", L"4 + 4=", commands11, true, true);
 
         Command commands12[] = { Command::Command5, Command::CommandADD, Command::CommandMUL, Command::Command3, Command::CommandNULL };
         TestDriver::Test(L"3", L"5 \x00D7 ", commands12, true, true);
@@ -441,7 +441,7 @@ namespace CalculatorManagerTest
 
         Command commands14[] = { Command::Command5, Command::Command0,       Command::CommandADD, Command::Command2,
                                  Command::Command0, Command::CommandPERCENT, Command::CommandEQU, Command::CommandNULL };
-        TestDriver::Test(L"60", L"", commands14, true, true);
+        TestDriver::Test(L"60", L"50 + 10=", commands14, true, true);
 
         Command commands15[] = { Command::Command0, Command::CommandDIV, Command::Command0, Command::CommandEQU, Command::CommandNULL };
         TestDriver::Test(L"Result is undefined", L"0 \x00F7 ", commands15, true, true);
@@ -576,7 +576,7 @@ namespace CalculatorManagerTest
 
         Command commands5[] = { Command::Command2,   Command::CommandOPENP, Command::Command2,   Command::CommandCLOSEP,
                                 Command::CommandADD, Command::CommandEQU,   Command::CommandNULL };
-        TestDriver::Test(L"4", L"", commands5, true, true);
+        TestDriver::Test(L"4", L"(2) + 2=", commands5, true, true);
     }
 
     void CalculatorManagerTest::CalculatorManagerTestScientificError()


### PR DESCRIPTION
## Fixes #653.
Does not hide expression, when user pressed Enter or = on keypad (issue #653).

### Description of the changes:
- updated unit tests
- clearing expression after user takes action following Enter in engine, and not when user pressed Enter

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- I have used unittests (adjusted for this change)
- I have done manual tests from https://github.com/microsoft/calculator/blob/master/docs/ManualTests.md: From begining to Always-on-Top section
- I have done few manual test checking, than after Enter/= expression is displayed and it dissapears after entering a number. For example I used actions: 1, +, 2, = (expression is 1+2, result is 3), 2 (expression is empty, result is 2).

