### PR TITLE
fix 505

### DIFF
--- a/src/CalcManager/Ratpack/CalcErr.h
+++ b/src/CalcManager/Ratpack/CalcErr.h
@@ -41,8 +41,8 @@ typedef int32_t ResultCode;
 // CALC_E_DIVIDEBYZERO
 //
 // The current operation would require a divide by zero to complete
-
 static constexpr uint32_t CALC_E_DIVIDEBYZERO = (uint32_t)0x80000000;
+
 // CALC_E_DOMAIN
 //
 // The given input is not within the domain of this function

--- a/src/CalcManager/Ratpack/CalcErr.h
+++ b/src/CalcManager/Ratpack/CalcErr.h
@@ -41,45 +41,45 @@ typedef int32_t ResultCode;
 // CALC_E_DIVIDEBYZERO
 //
 // The current operation would require a divide by zero to complete
-#define CALC_E_DIVIDEBYZERO ((uint32_t)0x80000000)
 
+static constexpr uint32_t CALC_E_DIVIDEBYZERO = (uint32_t)0x80000000;
 // CALC_E_DOMAIN
 //
 // The given input is not within the domain of this function
-#define CALC_E_DOMAIN ((uint32_t)0x80000001)
+static constexpr uint32_t CALC_E_DOMAIN = (uint32_t)0x80000001;
 
 // CALC_E_INDEFINITE
 //
 // The result of this function is undefined
-#define CALC_E_INDEFINITE ((uint32_t)0x80000002)
+static constexpr uint32_t CALC_E_INDEFINITE = (uint32_t)0x80000002;
 
 // CALC_E_POSINFINITY
 //
 // The result of this function is Positive Infinity.
-#define CALC_E_POSINFINITY ((uint32_t)0x80000003)
+static constexpr uint32_t CALC_E_POSINFINITY = (uint32_t)0x80000003;
 
 // CALC_E_NEGINFINITY
 //
 // The result of this function is Negative Infinity
-#define CALC_E_NEGINFINITY ((uint32_t)0x80000004)
+static constexpr uint32_t CALC_E_NEGINFINITY = (uint32_t)0x80000004;
 
 // CALC_E_INVALIDRANGE
 //
 // The given input is within the domain of the function but is beyond
 // the range for which calc can successfully compute the answer
-#define CALC_E_INVALIDRANGE ((uint32_t)0x80000006)
+static constexpr uint32_t CALC_E_INVALIDRANGE = (uint32_t)0x80000006;
 
 // CALC_E_OUTOFMEMORY
 //
 // There is not enough free memory to complete the requested function
-#define CALC_E_OUTOFMEMORY ((uint32_t)0x80000007)
+static constexpr uint32_t CALC_E_OUTOFMEMORY = (uint32_t)0x80000007;
 
 // CALC_E_OVERFLOW
 //
 // The result of this operation is an overflow
-#define CALC_E_OVERFLOW ((uint32_t)0x80000008)
+static constexpr uint32_t CALC_E_OVERFLOW = (uint32_t)0x80000008;
 
 // CALC_E_NORESULT
 //
 // The result of this operation is undefined
-#define CALC_E_NORESULT ((uint32_t)0x80000009)
+static constexpr uint32_t CALC_E_NORESULT = (uint32_t)0x80000009;


### PR DESCRIPTION
## Fixes #505 .


### Description of the changes:
- Changed all the E_CODE_* Variables located in CalcErr.h from Macros to static const expr (inline is implicite)

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual-Adhoc testing


