### PR TITLE
Updating CalculatorHistory to use a default destructor.

### DIFF
--- a/src/CalcManager/CalculatorHistory.cpp
+++ b/src/CalcManager/CalculatorHistory.cpp
@@ -69,11 +69,6 @@ shared_ptr<HISTORYITEM> const& CalculatorHistory::GetHistoryItem(_In_ unsigned i
     return m_historyItems.at(uIdx);
 }
 
-CalculatorHistory::~CalculatorHistory(void)
-{
-    ClearHistory();
-}
-
 void CalculatorHistory::ClearHistory()
 {
     m_historyItems.clear();

--- a/src/CalcManager/CalculatorHistory.h
+++ b/src/CalcManager/CalculatorHistory.h
@@ -43,7 +43,6 @@ namespace CalculationManager
         {
             return m_maxHistorySize;
         }
-        ~CalculatorHistory(void);
 
     private:
         std::vector<std::shared_ptr<HISTORYITEM>> m_historyItems;


### PR DESCRIPTION
Its memory will be cleaned up by std::vector's destructor.

## Fixes #719

### Description of the changes:
- Removed CalculatorDestructor code so the compiler would default it.

### How changes were validated:
- Manually tested.
- Ran existing unit tests