### PR TITLE
Update release pipeline to use newer StoreBroker tasks

### DIFF
--- a/build/pipelines/templates/build-app-internal.yaml
+++ b/build/pipelines/templates/build-app-internal.yaml
@@ -21,7 +21,7 @@ jobs:
   steps:
   - checkout: self
     clean: true
-  
+
   - task: UniversalPackages@0
     displayName: Download internals package
     inputs:
@@ -29,7 +29,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.19
+      vstsPackageVersion: 0.0.22
 
   - template: ./build-single-architecture.yaml
     parameters:

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -19,6 +19,12 @@ jobs:
     clean: outputs
   variables:
     skipComponentGovernanceDetection: true
+    SBMediaRootPath: '$(TEMP)\SBMedia'
+    SBPackagePath: '$(Build.ArtifactStagingDirectory)\storeBrokerPayload'
+    SBLogPath: '$(SBPackagePath)\StoreBroker.log'
+    FlightId: '161f0975-cb5f-475b-8ef6-26383c37621f'
+    AppId: '9WZDNCRFHVN5'
+    ProductId: '00009007199266248474'
   steps:
   - checkout: self
     clean: true
@@ -91,59 +97,71 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.19
+      vstsPackageVersion: 0.0.22
 
-  - task: PkgESStoreBrokerPackage@10
-    displayName: Create StoreBroker Packages
-    env:
-      XES_SERIALPOSTBUILDREADY: True
+- powershell: |
+      # Just modify this line to indicate where your en-us PDP file is. Leave the other lines alone.
+      $enUSPdpFilePath = "$(Build.SourcesDirectory)\PDP\en-US\PDP.xml"
+
+      # This is going to save the release value from the PDP file to $(SBMediaReleaseVersion)
+      # which you can then refer to in the UniversalPackages task.
+      $release = ([xml](Get-Content $enUSPdpFilePath)).ProductDescription.Release.Trim()
+      Write-Host "##vso[task.setvariable variable=SBMediaReleaseVersion;]$release"
+    displayName: Determine the PDP Media release version from the en-us PDP file
+
+  - task: UniversalPackages@0
+    displayName: Download PDP media (screenshots, trailers) universal package
     inputs:
-      addToFlight: false
-      configPath: tools/Build/StoreBroker/SBCalculatorConfig.json
-      PDPRootPath: $(Build.SourcesDirectory)\PDP
-      imagesRootPath: $(Build.SourcesDirectory)\PDPMediaRoot
-      appxPath: $(Build.ArtifactStagingDirectory)\appxBundleSigned\Microsoft.WindowsCalculator_8wekyb3d8bbwe.appxbundle
-      useArtifactServiceForMedia: true
-      outPath: $(Build.ArtifactStagingDirectory)\StoreBrokerPayload
-      paToken: $(System.AccessToken)
-      logRootPath: $(Build.ArtifactStagingDirectory)/StoreBrokerLogs
+      command: download
+      downloadDirectory: $(SBMediaRootPath)/$(SBMediaReleaseVersion)
+      vstsFeed: WindowsInboxApps
+      vstsFeedPackage: calculator-pdp-media
+      vstsPackageVersion: $(SBMediaReleaseVersion)
+
+  - task: MS-RDX-MRO.windows-store-publish-dev.package-task.store-package@2
+    displayName: Create StoreBroker Payload
+    inputs:
+      serviceEndpoint: StoreBrokerProxy
+      sbConfigPath: Tools/Build/StoreBroker/SBCalculatorConfig.json
+      sourceFolder: $(Build.ArtifactStagingDirectory)/appxBundleSigned
+      contents: Microsoft.WindowsCalculator_8wekyb3d8bbwe.appxbundle
+      pdpPath: '$(Build.SourcesDirectory)\PDP'
+      pdpInclude: PDP.xml
+      pdpMediaPath: '$(SBMediaRootPath)'
+      outSBPackagePath: '$(SBPackagePath)'
+      outSBName: SBCalculator
 
   - task: PublishBuildArtifacts@1
-    displayName: Publish StoreBrokerPayload artifact
+    displayName: Publish StoreBroker Payload artifact
     inputs:
+      pathtoPublish: '$(SBPackagePath)'
       artifactName: storeBrokerPayload
-      pathToPublish: $(Build.ArtifactStagingDirectory)/StoreBrokerPayload
 
-  - task: PkgESStoreBrokerFlight@10
-    name: StoreBrokerFlight
-    displayName: Flight package with StoreBroker
-    env:
-      XES_SERIALPOSTBUILDREADY: True
+  - task: MS-RDX-MRO.windows-store-publish-dev.flight-task.store-flight@2
+    displayName: 'Flight StoreBroker Payload to team ring '
     inputs:
-      packageToFlight: Custom
-      appId: 9WZDNCRFHVN5
-      flightId: 161f0975-cb5f-475b-8ef6-26383c37621f
-      submissionDataPath: $(Build.ArtifactStagingDirectory)/StoreBrokerPayload/SBCalculator.json
-      packagePath: $(Build.ArtifactStagingDirectory)/StoreBrokerPayload/SBCalculator.zip
-      updatePackageAction: AddPackages
-      logRootPath: $(Build.ArtifactStagingDirectory)/StoreBrokerLogs
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish StoreBrokerLogs artifact
-    inputs:
-      artifactName: storeBrokerLogs
-      pathToPublish: $(Build.ArtifactStagingDirectory)/StoreBrokerLogs
+      serviceEndpoint: StoreBrokerProxy
+      appId: '$(AppId)'
+      flightId: '$(FlightId)'
+      inputMethod: JsonAndZip
+      jsonPath: '$(SBPackagePath)\SBCalculator.json'
+      zipPath: '$(SBPackagePath)\SBCalculator.zip'
+      force: true
+      skipPolling: true
+      targetPublishMode: Immediate
+      logPath: '$(SBLogPath)'
 
   - task: PkgESStoreBrokerAeroUpload@10
     displayName: Upload to Aero flighting dashboard
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
-      productId: 00009007199266248474
-      flightId: 161f0975-cb5f-475b-8ef6-26383c37621f
-      submissionId: $(StoreBrokerFlight.WS_SubmissionId)
-      submissionDataPath: $(Build.ArtifactStagingDirectory)/StoreBrokerPayload/SBCalculator.json
-      packagePath: $(Build.ArtifactStagingDirectory)/StoreBrokerPayload/SBCalculator.zip
+      ProductId: '$(ProductId)'
+      FlightId: '$(FlightId)'
+      SubmissionId: '$(null.WS_SubmissionId)'
+      SubmissionDataPath: '$(SBPackagePath)\SBCalculator.json'
+      PackagePath: '$(SBPackagePath)\SBCalculator.zip'
+      AeroEnvironment: Production
 
   - task: PkgESLateTasks@10
     displayName: Run PackageES LateTasks


### PR DESCRIPTION
Updating the release pipeline to use the newer StoreBroker v2 tasks for automated deployment to the Store.

It was necessary to rev the version of the internals package in order to get the latest version of the PDP files and config file.