### PR TITLE
Fix release pipeline yaml

### DIFF
--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -99,7 +99,7 @@ jobs:
       vstsFeedPackage: calculator-internals
       vstsPackageVersion: 0.0.22
 
-- powershell: |
+  - powershell: |
       # Just modify this line to indicate where your en-us PDP file is. Leave the other lines alone.
       $enUSPdpFilePath = "$(Build.SourcesDirectory)\PDP\en-US\PDP.xml"
 
@@ -138,7 +138,8 @@ jobs:
       artifactName: storeBrokerPayload
 
   - task: MS-RDX-MRO.windows-store-publish-dev.flight-task.store-flight@2
-    displayName: 'Flight StoreBroker Payload to team ring '
+    displayName: 'Flight StoreBroker Payload to team ring'
+    name: StoreBrokerFlight
     inputs:
       serviceEndpoint: StoreBrokerProxy
       appId: '$(AppId)'
@@ -158,7 +159,7 @@ jobs:
     inputs:
       ProductId: '$(ProductId)'
       FlightId: '$(FlightId)'
-      SubmissionId: '$(null.WS_SubmissionId)'
+      SubmissionId: '$(StoreBrokerFlight.WS_SubmissionId)'
       SubmissionDataPath: '$(SBPackagePath)\SBCalculator.json'
       PackagePath: '$(SBPackagePath)\SBCalculator.zip'
       AeroEnvironment: Production


### PR DESCRIPTION
There were two issues:

* The indentation for the PowerShell script task was off,
  causing a parsing error
* The flighting task needed to be named so that the Aero
  task would be able to reference its output variable.