### PR TITLE
Add KeyboardAccelerators for AlwaysOnTop

### DIFF
--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -178,7 +178,11 @@
                         AutomationProperties.AutomationId="NormalAlwaysOnTopButton"
                         Click="AlwaysOnTopButtonClick"
                         Content="&#xEE49;"
-                        Visibility="{x:Bind Model.DisplayNormalAlwaysOnTopOption, Mode=OneWay}"/>
+                        Visibility="{x:Bind Model.DisplayNormalAlwaysOnTopOption, Mode=OneWay}">
+                    <Button.KeyboardAccelerators>
+                        <KeyboardAccelerator Modifiers="Control, Shift" Key="O"/>
+                    </Button.KeyboardAccelerators>
+                </Button>
             </Grid>
         </muxc:NavigationView>
     </Grid>

--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -180,7 +180,7 @@
                         Content="&#xEE49;"
                         Visibility="{x:Bind Model.DisplayNormalAlwaysOnTopOption, Mode=OneWay}">
                     <Button.KeyboardAccelerators>
-                        <KeyboardAccelerator Modifiers="Control, Shift" Key="O"/>
+                        <KeyboardAccelerator Modifiers="Menu" Key="Up"/>
                     </Button.KeyboardAccelerators>
                 </Button>
             </Grid>

--- a/src/Calculator/Views/TitleBar.xaml
+++ b/src/Calculator/Views/TitleBar.xaml
@@ -56,7 +56,7 @@
                 Content="&#xEE47;"
                 Visibility="Collapsed">
             <Button.KeyboardAccelerators>
-                <KeyboardAccelerator Modifiers="Control, Shift" Key="O"/>
+                <KeyboardAccelerator Modifiers="Menu" Key="Down"/>
             </Button.KeyboardAccelerators>
         </Button>
     </Grid>

--- a/src/Calculator/Views/TitleBar.xaml
+++ b/src/Calculator/Views/TitleBar.xaml
@@ -54,6 +54,10 @@
                 AutomationProperties.AutomationId="ExitAlwaysOnTopButton"
                 Click="AlwaysOnTopButton_Click"
                 Content="&#xEE47;"
-                Visibility="Collapsed"/>
+                Visibility="Collapsed">
+            <Button.KeyboardAccelerators>
+                <KeyboardAccelerator Modifiers="Control, Shift" Key="O"/>
+            </Button.KeyboardAccelerators>
+        </Button>
     </Grid>
 </UserControl>


### PR DESCRIPTION
### Fixes #732
### Description of the changes:
Added a keyboard accelerator to switch in and out of On-Top mode.
  * <kbd>Alt</kbd>+<kbd>Up</kbd> = Enter Always-on-Top Mode
  * <kbd>Alt</kbd>+<kbd>Down</kbd> = Exit Always-on-Top Mode

### How changes were validated:
Manually.