### PR TITLE
Fix the right arrow button of CalculationResult not disappearing in some cases

### DIFF
--- a/src/Calculator/Controls/CalculationResult.cpp
+++ b/src/Calculator/Controls/CalculationResult.cpp
@@ -91,6 +91,12 @@ void CalculationResult::OnApplyTemplate()
         }
     }
 
+    if (m_textBlock != nullptr && m_textBlockSizeChangedToken.Value != 0)
+    {
+        m_textBlock->SizeChanged -= m_textBlockSizeChangedToken;
+        m_textBlockSizeChangedToken.Value = 0;
+    }
+
     if (m_scrollLeft != nullptr && m_scrollLeftClickToken.Value != 0)
     {
         m_scrollLeft->Click -= m_scrollLeftClickToken;
@@ -132,6 +138,7 @@ void CalculationResult::OnApplyTemplate()
         if (m_textBlock)
         {
             m_textBlock->Visibility = ::Visibility::Visible;
+            m_textBlockSizeChangedToken = m_textBlock->SizeChanged += ref new SizeChangedEventHandler(this, &CalculationResult::OnTextBlockSizeChanged);
         }
     }
     UpdateVisualState();
@@ -418,6 +425,11 @@ void CalculationResult::RaiseSelectedEvent()
 }
 
 void CalculationResult::OnTextContainerOnViewChanged(Object ^ /*sender*/, ScrollViewerViewChangedEventArgs ^ e)
+{
+    UpdateScrollButtons();
+}
+
+void CalculationResult::OnTextBlockSizeChanged(Object ^ /*sender*/, SizeChangedEventArgs ^ /*e*/)
 {
     UpdateScrollButtons();
 }

--- a/src/Calculator/Controls/CalculationResult.h
+++ b/src/Calculator/Controls/CalculationResult.h
@@ -56,6 +56,7 @@ namespace CalculatorApp
             void OnMinFontSizePropertyChanged(double oldValue, double newValue);
             void OnMaxFontSizePropertyChanged(double oldValue, double newValue);
             void OnTextContainerSizeChanged(Object ^ sender, Windows::UI::Xaml::SizeChangedEventArgs ^ e);
+            void OnTextBlockSizeChanged(Object ^ sender, Windows::UI::Xaml::SizeChangedEventArgs ^ e);
             void OnTextContainerLayoutUpdated(Object ^ sender, Object ^ e);
             void OnTextContainerOnViewChanged(Object ^ sender, Windows::UI::Xaml::Controls::ScrollViewerViewChangedEventArgs ^ e);
             void UpdateVisualState();
@@ -82,6 +83,7 @@ namespace CalculatorApp
             Windows::Foundation::EventRegistrationToken m_textContainerSizeChangedToken;
             Windows::Foundation::EventRegistrationToken m_scrollRightClickToken;
             Windows::Foundation::EventRegistrationToken m_scrollLeftClickToken;
+            Windows::Foundation::EventRegistrationToken m_textBlockSizeChangedToken;            
         };
     }
 }


### PR DESCRIPTION
## Fixes #735 

The right arrow button didn't become collapsed when the value changed from a long number to a short one when Scrollviewer.HorizontalOffset was equal to 0

### Description of the changes:
- call UpdateScrollButtons when the size of the text changes to check if we need to display/hide the scroll buttons

### How changes were validated:
- Tested manually
