### PR TITLE
Make ControlSizeTrigger consistent with AdaptiveTrigger + fix conditional

### DIFF
--- a/src/Calculator/Views/StateTriggers/ControlSizeTrigger.cpp
+++ b/src/Calculator/Views/StateTriggers/ControlSizeTrigger.cpp
@@ -23,58 +23,50 @@ ControlSizeTrigger::~ControlSizeTrigger()
     UnregisterSizeChanged(Source);
 }
 
-void ControlSizeTrigger::OnSourcePropertyChanged(FrameworkElement^ oldValue, FrameworkElement^ newValue)
+void ControlSizeTrigger::OnSourcePropertyChanged(FrameworkElement ^ oldValue, FrameworkElement ^ newValue)
 {
     UnregisterSizeChanged(oldValue);
     RegisterSizeChanged(newValue);
 }
 
-void ControlSizeTrigger::RegisterSizeChanged(FrameworkElement^ element)
+void ControlSizeTrigger::RegisterSizeChanged(FrameworkElement ^ element)
 {
-    if (element == nullptr) { return; }
+    if (element == nullptr)
+    {
+        return;
+    }
 
     if (element != Source)
     {
         UnregisterSizeChanged(Source);
     }
 
-    m_sizeChangedToken =
-        element->SizeChanged += ref new SizeChangedEventHandler(this, &ControlSizeTrigger::OnSizeChanged);
+    m_sizeChangedToken = element->SizeChanged += ref new SizeChangedEventHandler(this, &ControlSizeTrigger::OnSizeChanged);
+    UpdateIsActive(element->RenderSize);
 }
 
-void ControlSizeTrigger::UnregisterSizeChanged(FrameworkElement^ element)
+void ControlSizeTrigger::UnregisterSizeChanged(FrameworkElement ^ element)
 {
-    if ((element != nullptr) && (m_sizeChangedToken.Value != 0))
+    if (element != nullptr && m_sizeChangedToken.Value != 0)
     {
         element->SizeChanged -= m_sizeChangedToken;
         m_sizeChangedToken.Value = 0;
     }
 }
 
-void ControlSizeTrigger::OnSizeChanged(Object^ sender, SizeChangedEventArgs^ e)
+void ControlSizeTrigger::OnSizeChanged(Object ^ sender, SizeChangedEventArgs ^ e)
 {
     UpdateIsActive(e->NewSize);
 }
 
 void ControlSizeTrigger::UpdateIsActive(Size sourceSize)
 {
-    if (Source != nullptr && MinWidth > 0 || MinHeight > 0)
+    if (MinHeight >= 0)
     {
-        if (MinHeight > 0 && MinWidth > 0)
-        {
-            SetActive((sourceSize.Height >= MinHeight) && (sourceSize.Width >= MinWidth));
-        }
-        else if (MinHeight > 0)
-        {
-            SetActive(sourceSize.Height >= MinHeight);
-        }
-        else
-        {
-            SetActive(sourceSize.Width >= MinWidth);
-        }
+        SetActive(sourceSize.Height >= MinHeight && (MinWidth < 0 || sourceSize.Width >= MinWidth));
     }
     else
     {
-        SetActive(false);
+        SetActive(MinWidth >= 0 && sourceSize.Width >= MinWidth);
     }
 }

--- a/src/Calculator/Views/StateTriggers/ControlSizeTrigger.h
+++ b/src/Calculator/Views/StateTriggers/ControlSizeTrigger.h
@@ -16,9 +16,9 @@ namespace CalculatorApp::Views::StateTriggers
 
         DEPENDENCY_PROPERTY_WITH_CALLBACK(Windows::UI::Xaml::FrameworkElement^, Source);
 
-        DEPENDENCY_PROPERTY_WITH_DEFAULT(double, MinHeight, 0.0);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT(double, MinHeight, -1);
 
-        DEPENDENCY_PROPERTY_WITH_DEFAULT(double, MinWidth, 0.0);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT(double, MinWidth, -1);
 
     private:
         ~ControlSizeTrigger();


### PR DESCRIPTION
## Fixes #737

### Description of the changes:
- fix conditional
- make `MinWidth` and `MinHeight` equal to -1 by default (same than AdaptiveTrigger)
- support Visual State trigger with `MinWidth="0"` or `MinHeight="0"`
- decrease the number of conditionals in `ControlSizeTrigger::UpdateIsActive`
- make ControlSizeTrigger works even if the control is already loaded (SizeChanged not called)

### How changes were validated:
- manually with the Calculator + a test app
