### PR TITLE
use short date

### DIFF
--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -752,7 +752,7 @@ wstring CurrencyDataLoader::GetCurrencyTimestamp()
     DateTime epoch{};
     if (m_cacheTimestamp.UniversalTime != epoch.UniversalTime)
     {
-        DateTimeFormatter ^ dateFormatter = ref new DateTimeFormatter(L"{month.abbreviated} {day.integer}, {year.full}");
+        DateTimeFormatter ^ dateFormatter = ref new DateTimeFormatter(L"shortdate");
         wstring date = dateFormatter->Format(m_cacheTimestamp)->Data();
 
         DateTimeFormatter ^ timeFormatter = ref new DateTimeFormatter(L"shorttime");


### PR DESCRIPTION
## Fixes #725 

Use short date format instead of the custom date format in the Currency Converter page. 

Take into account the user's choice in Settings > Region > Change date formats > short date.

US - mm/dd/yyyy format
![image](https://user-images.githubusercontent.com/1226538/67618595-55586900-f7a6-11e9-8aa6-ba89dce0cc82.png)

US - yyyy-mm-dd format
![image](https://user-images.githubusercontent.com/1226538/67618613-7caf3600-f7a6-11e9-8c3a-380054d5cd8a.png)

FR - dd/mm/yyyy
![image](https://user-images.githubusercontent.com/1226538/67618651-f0514300-f7a6-11e9-80dc-6c52175c8ed5.png)


### How changes were validated:
- manually, with different languages and settings

