### PR TITLE
Remove unnecessary dependencies from UITestFramework project

### DIFF
--- a/src/CalculatorUITestFramework/CalculatorUITestFramework.csproj
+++ b/src/CalculatorUITestFramework/CalculatorUITestFramework.csproj
@@ -6,8 +6,6 @@
 
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.0.0.6-beta" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
     <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
   </ItemGroup>
 


### PR DESCRIPTION
The CalculatorUITestFramework project does not need Microsoft.NET.Test.Sdk or MSTest.TestAdapter. These dependencies are needed only in the project which produces the actual test assembly (in our case, the CalculatorUITests project).

Removing these resolves a build warning, since the test adapter package does not target .NET Standard.