### PR TITLE
force a call to m_expressionContainer->Measure in UpdateScrollButtons

### DIFF
--- a/src/Calculator/Controls/OverflowTextBlock.cpp
+++ b/src/Calculator/Controls/OverflowTextBlock.cpp
@@ -197,6 +197,7 @@ void OverflowTextBlock::UpdateScrollButtons()
             m_expressionContainer->Padding = Thickness(left, 0, right, 0);
             m_expressionContent->Margin = Thickness(-left, 0, -right, 0);
             m_expressionContainer->UpdateLayout();
+            m_expressionContainer->Measure(m_expressionContainer->RenderSize);
 
             m_containerViewChangedToken = m_expressionContainer->ViewChanged +=
                 ref new EventHandler<ScrollViewerViewChangedEventArgs ^>(this, &OverflowTextBlock::OnViewChanged);

--- a/src/Calculator/Controls/OverflowTextBlock.h
+++ b/src/Calculator/Controls/OverflowTextBlock.h
@@ -21,6 +21,13 @@ namespace CalculatorApp
         {
         public:
             OverflowTextBlock()
+                : m_isAccessibilityViewControl(false)
+                , m_ignoreViewChanged(false)
+                , m_expressionContent(nullptr)
+                , m_itemsControl(nullptr)
+                , m_expressionContainer(nullptr)
+                , m_scrollLeft(nullptr)
+                , m_scrollRight(nullptr)
             {
             }
 
@@ -52,6 +59,7 @@ namespace CalculatorApp
             void ScrollRight();
 
             bool m_isAccessibilityViewControl;
+            bool m_ignoreViewChanged;
             Windows::UI::Xaml::FrameworkElement ^ m_expressionContent;
             Windows::UI::Xaml::Controls::ItemsControl ^ m_itemsControl;
             Windows::UI::Xaml::Controls::ScrollViewer ^ m_expressionContainer;


### PR DESCRIPTION
## Fixes #749 

The UpdateScrollButtons method can modify the values of `m_expressionContainer->Padding' and `m_expressionContent->Margin', these modifications can launch the event `ScrollViewer::ViewChanged' which will call UpdateScrollButtons again. 

In the current version of the code, to prevent loops, first we unregister ViewChanged events, then we modify Padding and Margin and we register again afterwards.

Based on the issue reported by the user, this is obviously not enough, ViewChanged will still be called after the end of `UpdateScrollButtons' in some cases.

To solve this problem, we will call `ScrollViewer.Measure` to be sure ScrollViewer::ViewChanged will be called before we register ViewChanged event again.

### Description of the changes:
- force a call to m_expressionContainer->Measure in UpdateScrollButtons so Scrollviewer::ViewChanged event will be called before we register again

### How changes were validated:
- manually

