### PR TITLE
Fully separate Calculator and CalcManager

### DIFF
--- a/src/CalcViewModel/Common/Utils.h
+++ b/src/CalcViewModel/Common/Utils.h
@@ -188,7 +188,7 @@ public:
 private:                                                                                                                                                       \
     static Windows::UI::Xaml::DependencyProperty ^ s_##n##Property;                                                                                            \
                                                                                                                                                                \
-public:
+private:
 
 // Utilities for DependencyProperties
 namespace Utils

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1903,3 +1903,11 @@ void StandardCalculatorViewModel::ValueBitLength::set(CalculatorApp::Common::Bit
         SetMemorizedNumbersString();
     }
 }
+
+void StandardCalculatorViewModel::SelectHistoryItem(HistoryItemViewModel ^ item)
+{
+    SetHistoryExpressionDisplay(item->GetTokens(), item->GetCommands());
+    SetExpressionDisplay(item->GetTokens(), item->GetCommands());
+    SetPrimaryDisplay(item->Result, false);
+    IsFToEEnabled = false;
+}

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -65,7 +65,7 @@ namespace CalculatorApp
             OBSERVABLE_PROPERTY_RW(Windows::Foundation::Collections::IVector<MemoryItemViewModel ^> ^, MemorizedNumbers);
             OBSERVABLE_NAMED_PROPERTY_RW(bool, IsMemoryEmpty);
             OBSERVABLE_PROPERTY_RW(bool, IsFToEChecked);
-            OBSERVABLE_PROPERTY_RW(bool, IsFToEEnabled);
+            OBSERVABLE_PROPERTY_R(bool, IsFToEEnabled);
             OBSERVABLE_PROPERTY_RW(bool, AreHEXButtonsEnabled);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, CalculationResultAutomationName);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, CalculationExpressionAutomationName);
@@ -340,15 +340,7 @@ namespace CalculatorApp
             void OnPinUnpinCommand(Platform::Object ^ parameter);
 
             void OnInputChanged();
-            void SetPrimaryDisplay(Platform::String ^ displayString, _In_ bool isError);
             void DisplayPasteError();
-            void SetTokens(_Inout_ std::shared_ptr<std::vector<std::pair<std::wstring, int>>> const& tokens);
-            void SetExpressionDisplay(
-                _Inout_ std::shared_ptr<std::vector<std::pair<std::wstring, int>>> const& tokens,
-                _Inout_ std::shared_ptr<std::vector<std::shared_ptr<IExpressionCommand>>> const& commands);
-            void SetHistoryExpressionDisplay(
-                _Inout_ std::shared_ptr<std::vector<std::pair<std::wstring, int>>> const& tokens,
-                _Inout_ std::shared_ptr<std::vector<std::shared_ptr<IExpressionCommand>>> const& commands);
             void SetParenthesisCount(_In_ unsigned int parenthesisCount);
             void SetOpenParenthesisCountNarratorAnnouncement();
             void OnNoRightParenAdded();
@@ -382,11 +374,19 @@ namespace CalculatorApp
             {
                 return m_CurrentAngleType;
             }
-
+            void SelectHistoryItem(HistoryItemViewModel ^ item);
         private:
             void SetMemorizedNumbers(const std::vector<std::wstring>& memorizedNumbers);
             void UpdateProgrammerPanelDisplay();
             void HandleUpdatedOperandData(CalculationManager::Command cmdenum);
+            void SetPrimaryDisplay(_In_ Platform::String ^ displayStringValue, _In_ bool isError);
+            void SetExpressionDisplay(
+                _Inout_ std::shared_ptr<std::vector<std::pair<std::wstring, int>>> const& tokens,
+                _Inout_ std::shared_ptr<std::vector<std::shared_ptr<IExpressionCommand>>> const& commands);
+            void SetHistoryExpressionDisplay(
+                _Inout_ std::shared_ptr<std::vector<std::pair<std::wstring, int>>> const& tokens,
+                _Inout_ std::shared_ptr<std::vector<std::shared_ptr<IExpressionCommand>>> const& commands);
+            void SetTokens(_Inout_ std::shared_ptr<std::vector<std::pair<std::wstring, int>>> const& tokens);
             NumbersAndOperatorsEnum ConvertIntegerToNumbersAndOperatorsEnum(unsigned int parameter);
             NumbersAndOperatorsEnum m_CurrentAngleType;
             wchar_t m_decimalSeparator;

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -470,11 +470,7 @@ void Calculator::OnHideHistoryClicked()
 
 void Calculator::OnHistoryItemClicked(_In_ HistoryItemViewModel ^ e)
 {
-    assert(e->GetTokens() != nullptr);
-    Model->SetHistoryExpressionDisplay(e->GetTokens(), e->GetCommands());
-    Model->SetExpressionDisplay(e->GetTokens(), e->GetCommands());
-    Model->SetPrimaryDisplay(e->Result, false);
-    Model->IsFToEEnabled = false;
+    Model->SelectHistoryItem(e);
 
     CloseHistoryFlyout();
     this->Focus(::FocusState::Programmatic);
@@ -718,3 +714,4 @@ void Calculator::Calculator_SizeChanged(Object ^ /*sender*/, SizeChangedEventArg
         AlwaysOnTopResults->UpdateScrollButtons();
     }
 }
+

--- a/src/Calculator/Views/Calculator.xaml.h
+++ b/src/Calculator/Views/Calculator.xaml.h
@@ -69,7 +69,6 @@ public
         void CloseMemoryFlyout();
 
         void SetDefaultFocus();
-
     private:
         void OnLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 


### PR DESCRIPTION
## Fixes #751

The only type from CalcEngine used in Calculator is CalculatorVector. We shouldn't access/use this type of object in Calculator.

### Description of the changes:
- Add a method `StandardCalculatorViewModel::SelectHistoryItem` to manage the selection of a history item in the CalcViewModel instead in Calculator.
- Make SetPrimaryDisplay, SetHistoryExpressionDisplay, SetExpressionDisplay and SetTokens private so CalculatorVector won't be used as a parameter of a public method.


### How changes were validated:
- manually

