### PR TITLE
Making string concatenations more efficent by appending wchar_ts instead of wstrings

### DIFF
--- a/src/CalcManager/ExpressionCommand.cpp
+++ b/src/CalcManager/ExpressionCommand.cpp
@@ -223,20 +223,20 @@ const wstring& COpndCommand::GetToken(wchar_t decimalSymbol)
 
         if (nOpCode == IDC_PNT)
         {
-            m_token.append(wstring{ decimalSymbol });
+            m_token += decimalSymbol;
         }
         else if (nOpCode == IDC_EXP)
         {
-            m_token.append(&chExp);
+            m_token += chExp;
             int nextOpCode = m_commands->at(i + 1);
             if (nextOpCode != IDC_SIGN)
             {
-                m_token.append(&chPlus);
+                m_token += chPlus;
             }
         }
         else if (nOpCode == IDC_SIGN)
         {
-            m_token.append(&chNegate);
+            m_token += chNegate;
         }
         else
         {
@@ -261,15 +261,14 @@ const wstring& COpndCommand::GetToken(wchar_t decimalSymbol)
 
             if (m_fNegative)
             {
-                m_token.insert(0, &chNegate);
+                m_token.insert(0, 1, chNegate);
             }
 
             return m_token;
         }
     }
 
-    m_token.clear();
-    m_token.append(&chZero);
+    m_token = chZero;
 
     return m_token;
 }

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1324,8 +1324,7 @@ void StandardCalculatorViewModel::SaveEditedCommand(_In_ unsigned int tokenPosit
         }
         if ((token.first.length() > 0) && (token.first[token.first.length() - 1] == L'('))
         {
-            wstring chOpenBrace = L"(";
-            updatedToken.append(chOpenBrace);
+            updatedToken += L'(';
         }
     }
     else if (IsBinOp(nOpCode))


### PR DESCRIPTION
## Fixes #759.

### Description of the changes:
- Improve efficiency of building strings by appending `wchar_t`s instead of temporary `wstring`s.
- Fix places where `constexpr wchar_t`'s were incorrectly being treated as null-terminated strings.

### How changes were validated:
- Manual testing

