### PR TITLE
add tau to shift toggle

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -153,6 +153,7 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
             IsOpInRange(wParam, IDM_QWORD, IDM_BYTE) ||
             IsOpInRange(wParam, IDM_DEG, IDM_GRAD) ||
             IsOpInRange(wParam, IDC_BINEDITSTART, IDC_BINEDITEND) ||
+            (IDC_TAU == wParam) ||
             (IDC_INV == wParam) ||
             (IDC_SIGN == wParam && 10 != m_radix) ||
             (IDC_RAND == wParam) ||
@@ -737,6 +738,17 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
 
             DisplayNum();
             m_bInv = false;
+            break;
+        }
+        HandleErrorCommand(wParam);
+        break;
+    case IDC_TAU:
+        if (!m_fIntegerMode)
+        {
+            CheckAndAddLastBinOpToHistory(); // tau is like entering the number
+            m_currentVal = Rational{ two_pi };
+
+            DisplayNum();
             break;
         }
         HandleErrorCommand(wParam);

--- a/src/CalcManager/Command.h
+++ b/src/CalcManager/Command.h
@@ -120,6 +120,7 @@ namespace CalculationManager
 
         CommandFE = 119,
         CommandPI = 120,
+        CommandTAU = 148, // 2 * PI
         CommandEQU = 121,
 
         CommandMCLEAR = 122,

--- a/src/CalcManager/Header Files/CCommand.h
+++ b/src/CalcManager/Header Files/CCommand.h
@@ -105,6 +105,7 @@
 
 #define IDC_FE 119
 #define IDC_PI 120
+#define IDC_TAU 148
 #define IDC_EQU 121
 
 #define IDC_MCLEAR 122

--- a/src/CalcViewModel/Common/CalculatorButtonUser.h
+++ b/src/CalcViewModel/Common/CalculatorButtonUser.h
@@ -42,6 +42,7 @@ public
         OpenParenthesis = (int)CM::Command::CommandOPENP,
         CloseParenthesis = (int)CM::Command::CommandCLOSEP,
         Pi = (int)CM::Command::CommandPI,
+        Tau = (int)CM::Command::CommandTAU,
         Sin = (int)CM::Command::CommandSIN,
         Cos = (int)CM::Command::CommandCOS,
         Tan = (int)CM::Command::CommandTAN,

--- a/src/Calculator/Resources/af-ZA/Resources.resw
+++ b/src/Calculator/Resources/af-ZA/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/am-ET/Resources.resw
+++ b/src/Calculator/Resources/am-ET/Resources.resw
@@ -937,6 +937,10 @@
     <value>ፓይ</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>ሳይን</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ar-SA/Resources.resw
+++ b/src/Calculator/Resources/ar-SA/Resources.resw
@@ -937,6 +937,10 @@
     <value>pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>جيب الزاوية</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/az-Latn-AZ/Resources.resw
+++ b/src/Calculator/Resources/az-Latn-AZ/Resources.resw
@@ -937,6 +937,10 @@
     <value>pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/be-BY/Resources.resw
+++ b/src/Calculator/Resources/be-BY/Resources.resw
@@ -929,6 +929,10 @@
     <value>Пі</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Сінус</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/bg-BG/Resources.resw
+++ b/src/Calculator/Resources/bg-BG/Resources.resw
@@ -937,6 +937,10 @@
     <value>Пи</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Синус</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/bn-BD/Resources.resw
+++ b/src/Calculator/Resources/bn-BD/Resources.resw
@@ -929,6 +929,10 @@
     <value>পাই</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>সাইন</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ca-ES/Resources.resw
+++ b/src/Calculator/Resources/ca-ES/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/cs-CZ/Resources.resw
+++ b/src/Calculator/Resources/cs-CZ/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pí</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/da-DK/Resources.resw
+++ b/src/Calculator/Resources/da-DK/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/de-DE/Resources.resw
+++ b/src/Calculator/Resources/de-DE/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/el-GR/Resources.resw
+++ b/src/Calculator/Resources/el-GR/Resources.resw
@@ -937,6 +937,10 @@
     <value>π</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>τ</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Ημίτονο</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/en-GB/Resources.resw
+++ b/src/Calculator/Resources/en-GB/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sine</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/en-US/CEngineStrings.resw
+++ b/src/Calculator/Resources/en-US/CEngineStrings.resw
@@ -253,6 +253,10 @@
     <value>.</value>
     <comment>{Locked}The string that represents the function</comment>
   </data>
+  <data name="39" xml:space="preserve">
+    <value>Tau</value>
+    <comment>{Locked}The string that represents the function</comment>
+  </data>
   <data name="40" xml:space="preserve">
     <value>Pi</value>
     <comment>{Locked}The string that represents the function</comment>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -1349,6 +1349,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sine</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/es-ES/Resources.resw
+++ b/src/Calculator/Resources/es-ES/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Seno</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/es-MX/Resources.resw
+++ b/src/Calculator/Resources/es-MX/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Seno</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/et-EE/Resources.resw
+++ b/src/Calculator/Resources/et-EE/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pii</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Siinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/eu-ES/Resources.resw
+++ b/src/Calculator/Resources/eu-ES/Resources.resw
@@ -938,6 +938,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinua</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fa-IR/Resources.resw
+++ b/src/Calculator/Resources/fa-IR/Resources.resw
@@ -937,6 +937,10 @@
     <value>پی</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>سینوس</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fi-FI/Resources.resw
+++ b/src/Calculator/Resources/fi-FI/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pii</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sini</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fil-PH/Resources.resw
+++ b/src/Calculator/Resources/fil-PH/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sine</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fr-CA/Resources.resw
+++ b/src/Calculator/Resources/fr-CA/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/fr-FR/Resources.resw
+++ b/src/Calculator/Resources/fr-FR/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/gl-ES/Resources.resw
+++ b/src/Calculator/Resources/gl-ES/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Seno</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ha-Latn-NG/Resources.resw
+++ b/src/Calculator/Resources/ha-Latn-NG/Resources.resw
@@ -397,6 +397,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sayin</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/he-IL/Resources.resw
+++ b/src/Calculator/Resources/he-IL/Resources.resw
@@ -937,6 +937,10 @@
     <value>פיי</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>סינוס</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/hi-IN/Resources.resw
+++ b/src/Calculator/Resources/hi-IN/Resources.resw
@@ -937,6 +937,10 @@
     <value>पाई</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>ज्या</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/hr-HR/Resources.resw
+++ b/src/Calculator/Resources/hr-HR/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/hu-HU/Resources.resw
+++ b/src/Calculator/Resources/hu-HU/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Szinusz</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/id-ID/Resources.resw
+++ b/src/Calculator/Resources/id-ID/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/is-IS/Resources.resw
+++ b/src/Calculator/Resources/is-IS/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pí</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sínus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/it-IT/Resources.resw
+++ b/src/Calculator/Resources/it-IT/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi greco</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau greco</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Seno</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ja-JP/Resources.resw
+++ b/src/Calculator/Resources/ja-JP/Resources.resw
@@ -937,6 +937,10 @@
     <value>パイ</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>サイン</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/kk-KZ/Resources.resw
+++ b/src/Calculator/Resources/kk-KZ/Resources.resw
@@ -937,6 +937,10 @@
     <value>Пи</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Синус</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/km-KH/Resources.resw
+++ b/src/Calculator/Resources/km-KH/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>ស៊ីនុស</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/kn-IN/Resources.resw
+++ b/src/Calculator/Resources/kn-IN/Resources.resw
@@ -937,6 +937,10 @@
     <value>ಪೈ</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>ಸೈನ್</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ko-KR/Resources.resw
+++ b/src/Calculator/Resources/ko-KR/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>사인</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/lo-LA/Resources.resw
+++ b/src/Calculator/Resources/lo-LA/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>ຊີນ</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/lt-LT/Resources.resw
+++ b/src/Calculator/Resources/lt-LT/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinusas</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/lv-LV/Resources.resw
+++ b/src/Calculator/Resources/lv-LV/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pī</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinuss</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/mk-MK/Resources.resw
+++ b/src/Calculator/Resources/mk-MK/Resources.resw
@@ -937,6 +937,10 @@
     <value>Пи</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Синус</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ml-IN/Resources.resw
+++ b/src/Calculator/Resources/ml-IN/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>സൈൻ</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ms-MY/Resources.resw
+++ b/src/Calculator/Resources/ms-MY/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/nb-NO/Resources.resw
+++ b/src/Calculator/Resources/nb-NO/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/nl-NL/Resources.resw
+++ b/src/Calculator/Resources/nl-NL/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/pl-PL/Resources.resw
+++ b/src/Calculator/Resources/pl-PL/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/pt-BR/Resources.resw
+++ b/src/Calculator/Resources/pt-BR/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Seno</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/pt-PT/Resources.resw
+++ b/src/Calculator/Resources/pt-PT/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Seno</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ro-RO/Resources.resw
+++ b/src/Calculator/Resources/ro-RO/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ru-RU/Resources.resw
+++ b/src/Calculator/Resources/ru-RU/Resources.resw
@@ -937,6 +937,10 @@
     <value>Пи</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Синус</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sk-SK/Resources.resw
+++ b/src/Calculator/Resources/sk-SK/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pí</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sínus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sl-SI/Resources.resw
+++ b/src/Calculator/Resources/sl-SI/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sq-AL/Resources.resw
+++ b/src/Calculator/Resources/sq-AL/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sr-Latn-RS/Resources.resw
+++ b/src/Calculator/Resources/sr-Latn-RS/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sv-SE/Resources.resw
+++ b/src/Calculator/Resources/sv-SE/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/sw-KE/Resources.resw
+++ b/src/Calculator/Resources/sw-KE/Resources.resw
@@ -929,6 +929,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sine</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/ta-IN/Resources.resw
+++ b/src/Calculator/Resources/ta-IN/Resources.resw
@@ -937,6 +937,10 @@
     <value>பை</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>சைன்</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/te-IN/Resources.resw
+++ b/src/Calculator/Resources/te-IN/Resources.resw
@@ -937,6 +937,10 @@
     <value>పై</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>సైన్</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/th-TH/Resources.resw
+++ b/src/Calculator/Resources/th-TH/Resources.resw
@@ -937,6 +937,10 @@
     <value>พาย</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>ไซน์</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/tr-TR/Resources.resw
+++ b/src/Calculator/Resources/tr-TR/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinüs</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/uk-UA/Resources.resw
+++ b/src/Calculator/Resources/uk-UA/Resources.resw
@@ -937,6 +937,10 @@
     <value>Пі</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Синус</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/uz-Latn-UZ/Resources.resw
+++ b/src/Calculator/Resources/uz-Latn-UZ/Resources.resw
@@ -929,6 +929,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sinus</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/vi-VN/Resources.resw
+++ b/src/Calculator/Resources/vi-VN/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Sin</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/zh-CN/Resources.resw
+++ b/src/Calculator/Resources/zh-CN/Resources.resw
@@ -937,6 +937,10 @@
     <value>π</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>正弦</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Resources/zh-TW/Resources.resw
+++ b/src/Calculator/Resources/zh-TW/Resources.resw
@@ -937,6 +937,10 @@
     <value>Pi</value>
     <comment>Screen reader prompt for the Calculator pi button  on the scientific operator keypad</comment>
   </data>
+  <data name="tauButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Tau</value>
+    <comment>Screen reader prompt for the Calculator tau button  on the scientific operator keypad</comment>
+  </data>
   <data name="sinButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>正弦</value>
     <comment>Screen reader prompt for the Calculator sin button  on the scientific operator keypad</comment>

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -81,6 +81,7 @@
                         <Setter Target="PlusButton.IsEnabled" Value="False"/>
 
                         <Setter Target="PiButton.IsEnabled" Value="False"/>
+                        <Setter Target="TauButton.IsEnabled" Value="False"/>
                         <Setter Target="FactorialButton.IsEnabled" Value="False"/>
                         <Setter Target="NegateButton.IsEnabled" Value="False"/>
                         <Setter Target="OpenParenthesisButton.IsEnabled" Value="False"/>
@@ -106,6 +107,7 @@
                     <VisualState.Setters>
                         <Setter Target="NegateButton.FontSize" Value="{StaticResource CalcStandardOperatorCaptionSizeExtraLarge}"/>
                         <Setter Target="PiButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="TauButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
                         <Setter Target="FactorialButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
                         <Setter Target="OpenParenthesisButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
                         <Setter Target="CloseParenthesisButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
@@ -202,6 +204,7 @@
                     <VisualState.Setters>
                         <Setter Target="NegateButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSizeLarge}"/>
                         <Setter Target="PiButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="TauButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
                         <Setter Target="FactorialButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
                         <Setter Target="OpenParenthesisButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
                         <Setter Target="CloseParenthesisButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
@@ -295,6 +298,7 @@
                     <VisualState.Setters>
                         <Setter Target="NegateButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
                         <Setter Target="PiButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="TauButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
                         <Setter Target="FactorialButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
                         <Setter Target="OpenParenthesisButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
                         <Setter Target="CloseParenthesisButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
@@ -884,15 +888,42 @@
                       IsEnabledChanged="ShiftButton_IsEnabledChanged"
                       Unchecked="ShiftButton_Check"/>
 
-        <controls:CalculatorButton x:Name="PiButton"
-                                   x:Uid="piButton"
-                                   Grid.Row="1"
-                                   Grid.Column="1"
-                                   Style="{StaticResource SymbolOperatorButtonStyle}"
-                                   FontSize="14"
-                                   AutomationProperties.AutomationId="piButton"
-                                   ButtonId="Pi"
-                                   Content="&#xf7cf;"/>
+        <Grid x:Uid="CircleRatios"
+              Grid.Row="1"
+              Grid.Column="1"
+              AutomationProperties.HeadingLevel="Level1">
+            <!-- Circle Ratio Pi -->
+            <Grid x:Name="CirclePi">
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <controls:CalculatorButton x:Name="PiButton"
+                                           x:Uid="piButton"
+                                           Grid.Row="1"
+                                           Grid.Column="1"
+                                           Style="{StaticResource SymbolOperatorButtonStyle}"
+                                           FontSize="14"
+                                           AutomationProperties.AutomationId="piButton"
+                                           ButtonId="Pi"
+                                           Content="&#xf7cf;"/>
+            </Grid>
+
+            <!-- Circle Ratio Tau -->
+            <Grid x:Name="CircleTau" Visibility="Collapsed">
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <controls:CalculatorButton x:Name="TauButton"
+                                           x:Uid="tauButton"
+                                           Grid.Row="1"
+                                           Grid.Column="1"
+                                           Style="{StaticResource OperatorButtonStyle}"
+                                           FontSize="14"
+                                           AutomationProperties.AutomationId="tauButton"
+                                           ButtonId="Tau"
+                                           Content="&#x03C4;"/>
+            </Grid>
+        </Grid>
 
         <controls:CalculatorButton x:Name="EulerButton"
                                    x:Uid="eulerButton"

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
@@ -129,6 +129,8 @@ void CalculatorScientificOperators::SetOperatorRowVisibility()
 
     Row1->Visibility = rowVis;
     InvRow1->Visibility = invRowVis;
+    CirclePi->Visibility = rowVis;
+    CircleTau->Visibility = invRowVis;
 }
 
 void CalculatorScientificOperators::OpenParenthesisButton_GotFocus(Object ^ sender, RoutedEventArgs ^ e)


### PR DESCRIPTION
## Fixes #763 


### Description of the changes:
- Add a new Tau button and wrap it and existing Pi button in grids
- Modify shift toggle button to affect the new grids
- Add handler for new Tau button. Due to compact numbering of existing elements, needed to code an exception because outside of `IsOpInRange(wParam, IDC_FE, IDC_MMINUS)`
- Pasted in tau entry in resource files for all countries, but these may need nonEnglish translation
  - am-ET, be-BY, be-BG, bn-BD, el-GR, et-EE, fa-IR, fi-FI, he-IL, hi-IN, ja-JP, kk-KZ, kn-IN, lv-LV, mk-MK, ru-RU, ta-IN, te-IN, th-TH, uk-UA, zh-CN

### How changes were validated:
- Manually
- Click 2nd and click tau, number shows up.

