### PR TITLE
Convert DateCalculatorViewModel to runtime class

### DIFF
--- a/src/CalcViewModel/Common/DateCalculator.h
+++ b/src/CalcViewModel/Common/DateCalculator.h
@@ -29,39 +29,30 @@ namespace CalculatorApp
             };
 
             // Struct to store the difference between two Dates in the form of Years, Months , Weeks
-            struct DateDifference
+        public
+            value struct DateDifference
             {
-                int year = 0;
-                int month = 0;
-                int week = 0;
-                int day = 0;
-
-                bool operator==(const DateDifference& dd) const
-                {
-                    return year == dd.year && month == dd.month && week == dd.week && day == dd.day;
-                }
+                int year;
+                int month;
+                int week;
+                int day;
             };
 
             const DateDifference DateDifferenceUnknown{ INT_MIN, INT_MIN, INT_MIN, INT_MIN };
 
-            class DateCalculationEngine
+        public
+            ref class DateCalculationEngine sealed
             {
             public:
                 // Constructor
                 DateCalculationEngine(_In_ Platform::String ^ calendarIdentifier);
 
                 // Public Methods
-                bool __nothrow
-                AddDuration(_In_ Windows::Foundation::DateTime startDate, _In_ const DateDifference& duration, _Out_ Windows::Foundation::DateTime* endDate);
-                bool __nothrow SubtractDuration(
-                    _In_ Windows::Foundation::DateTime startDate,
-                    _In_ const DateDifference& duration,
-                    _Out_ Windows::Foundation::DateTime* endDate);
-                bool __nothrow TryGetDateDifference(
-                    _In_ Windows::Foundation::DateTime date1,
-                    _In_ Windows::Foundation::DateTime date2,
-                    _In_ DateUnit outputFormat,
-                    _Out_ DateDifference* difference);
+
+                Platform::IBox<Windows::Foundation::DateTime> ^ AddDuration(_In_ Windows::Foundation::DateTime startDate, _In_ DateDifference duration);
+                Platform::IBox<Windows::Foundation::DateTime> ^ SubtractDuration(_In_ Windows::Foundation::DateTime startDate, _In_ DateDifference duration);
+                Platform::IBox<
+                    DateDifference> ^ TryGetDateDifference(_In_ Windows::Foundation::DateTime date1, _In_ Windows::Foundation::DateTime date2, _In_ DateUnit outputFormat);
 
             private:
                 // Private Variables
@@ -76,3 +67,5 @@ namespace CalculatorApp
         }
     }
 }
+
+bool operator==(const CalculatorApp::Common::DateCalculation::DateDifference& l, const CalculatorApp::Common::DateCalculation::DateDifference& r);

--- a/src/CalcViewModel/DateCalculatorViewModel.h
+++ b/src/CalcViewModel/DateCalculatorViewModel.h
@@ -22,30 +22,9 @@ namespace CalculatorApp
             // Input Properties
             OBSERVABLE_PROPERTY_RW(bool, IsDateDiffMode);
             OBSERVABLE_PROPERTY_RW(bool, IsAddMode);
+            OBSERVABLE_PROPERTY_R(bool, IsDiffInDays); // If diff is only in days or the dates are the same,
+                                                       // then show only one result and avoid redundancy
 
-            property bool IsDiffInDays
-            {
-                bool get()
-                {
-                    return m_IsDiffInDays;
-                }
-
-            private:
-                void set(bool value)
-                {
-                    if (m_IsDiffInDays != value)
-                    {
-                        m_IsDiffInDays = value;
-                        RaisePropertyChanged(L"IsDiffInDays");
-                    }
-                }
-            }
-
-        private:
-            bool m_IsDiffInDays;
-            // OBSERVABLE_PROPERTY_R(bool, IsDiffInDays); // If diff is only in days or the dates are the same,
-            // then show only one result and avoid redundancy
-        public:
             OBSERVABLE_PROPERTY_RW(int, DaysOffset);
             OBSERVABLE_PROPERTY_RW(int, MonthsOffset);
             OBSERVABLE_PROPERTY_RW(int, YearsOffset);

--- a/src/CalcViewModel/DateCalculatorViewModel.h
+++ b/src/CalcViewModel/DateCalculatorViewModel.h
@@ -22,9 +22,30 @@ namespace CalculatorApp
             // Input Properties
             OBSERVABLE_PROPERTY_RW(bool, IsDateDiffMode);
             OBSERVABLE_PROPERTY_RW(bool, IsAddMode);
-            OBSERVABLE_PROPERTY_R(bool, IsDiffInDays); // If diff is only in days or the dates are the same,
-                                                       // then show only one result and avoid redundancy
 
+            property bool IsDiffInDays
+            {
+                bool get()
+                {
+                    return m_IsDiffInDays;
+                }
+
+            private:
+                void set(bool value)
+                {
+                    if (m_IsDiffInDays != value)
+                    {
+                        m_IsDiffInDays = value;
+                        RaisePropertyChanged(L"IsDiffInDays");
+                    }
+                }
+            }
+
+        private:
+            bool m_IsDiffInDays;
+            // OBSERVABLE_PROPERTY_R(bool, IsDiffInDays); // If diff is only in days or the dates are the same,
+            // then show only one result and avoid redundancy
+        public:
             OBSERVABLE_PROPERTY_RW(int, DaysOffset);
             OBSERVABLE_PROPERTY_RW(int, MonthsOffset);
             OBSERVABLE_PROPERTY_RW(int, YearsOffset);
@@ -176,7 +197,7 @@ namespace CalculatorApp
             CalculatorApp::Common::DateCalculation::DateDifference m_dateDiffResultInDays;
 
             // Private members
-            std::shared_ptr<CalculatorApp::Common::DateCalculation::DateCalculationEngine> m_dateCalcEngine;
+            CalculatorApp::Common::DateCalculation::DateCalculationEngine ^ m_dateCalcEngine;
             CalculatorApp::Common::DateCalculation::DateUnit m_daysOutputFormat;
             CalculatorApp::Common::DateCalculation::DateUnit m_allDateUnitsOutputFormat;
             Windows::Globalization::DateTimeFormatting::DateTimeFormatter ^ m_dateTimeFormatter;

--- a/src/CalculatorUnitTests/DateCalculatorUnitTests.cpp
+++ b/src/CalculatorUnitTests/DateCalculatorUnitTests.cpp
@@ -27,8 +27,6 @@ namespace DateCalculationUnitTests
     const int c_subtractCases = 3;
     const int c_dateDiff = 14;
 
-    DateCalculationEngine m_DateCalcEngine(CalendarIdentifiers::Gregorian);
-
     typedef struct
     {
         SYSTEMTIME startDate;
@@ -45,10 +43,20 @@ namespace DateCalculationUnitTests
     DateTimeTestCase datetimeSubtractCase[c_subtractCases];
 
     // Test Class
-    TEST_CLASS(DateCalculatorUnitTests){ public: TEST_CLASS_INITIALIZE(TestClassSetup){ /* Test Case Data */
+    TEST_CLASS(DateCalculatorUnitTests)
+    {
+        static DateCalculationEngine ^ m_DateCalcEngine;
 
-                                                                                        // Dates - DD.MM.YYYY
-                                                                                        /*31.12.9999*/ date[0].wYear = 9999;
+    public:
+    TEST_CLASS_INITIALIZE(TestClassSetup)
+    {
+    m_DateCalcEngine = ref new DateCalculationEngine(CalendarIdentifiers::Gregorian);
+
+    /* Test Case Data */
+
+    // Dates - DD.MM.YYYY
+    /*31.12.9999*/
+    date[0].wYear = 9999;
     date[0].wMonth = 12;
     date[0].wDayOfWeek = 5;
     date[0].wDay = 31;
@@ -300,7 +308,7 @@ TEST_METHOD(TestDateDiff)
     //    }
 
     //    // Calculate the difference
-    //    m_DateCalcEngine.TryGetDateDifference(DateUtils::SystemTimeToDateTime(datetimeDifftest[testIndex].startDate),
+    //    m_DateCalcEngine->TryGetDateDifference(DateUtils::SystemTimeToDateTime(datetimeDifftest[testIndex].startDate),
     //    DateUtils::SystemTimeToDateTime(datetimeDifftest[testIndex].endDate), dateOutputFormat, &diff);
 
     //    // Assert for the result
@@ -327,7 +335,7 @@ TEST_METHOD(TestAddOob)
     //    DateTime endDate;
 
     //    // Add Duration
-    //    bool isValid = m_DateCalcEngine.AddDuration(DateUtils::SystemTimeToDateTime(datetimeBoundAdd[testIndex].startDate),
+    //    bool isValid = m_DateCalcEngine->AddDuration(DateUtils::SystemTimeToDateTime(datetimeBoundAdd[testIndex].startDate),
     //    datetimeBoundAdd[testIndex].dateDiff, &endDate);
 
     //    // Assert for the result
@@ -340,14 +348,12 @@ TEST_METHOD(TestSubtractOob)
 {
     for (int testIndex = 0; testIndex < c_numSubtractOobDate; testIndex++)
     {
-        DateTime endDate;
-
         // Subtract Duration
-        bool isValid = m_DateCalcEngine.SubtractDuration(
-            DateUtils::SystemTimeToDateTime(datetimeBoundSubtract[testIndex].startDate), datetimeBoundSubtract[testIndex].dateDiff, &endDate);
+        auto endDate = m_DateCalcEngine->SubtractDuration(
+            DateUtils::SystemTimeToDateTime(datetimeBoundSubtract[testIndex].startDate), datetimeBoundSubtract[testIndex].dateDiff);
 
         // Assert for the result
-        VERIFY_IS_FALSE(isValid);
+        VERIFY_IS_NULL(endDate);
     }
 }
 
@@ -361,7 +367,7 @@ TEST_METHOD(TestAddition)
     //    DateTime endDate;
 
     //    // Add Duration
-    //    bool isValid = m_DateCalcEngine.AddDuration(DateUtils::SystemTimeToDateTime(datetimeAddCase[testIndex].startDate),
+    //    bool isValid = m_DateCalcEngine->AddDuration(DateUtils::SystemTimeToDateTime(datetimeAddCase[testIndex].startDate),
     //    datetimeAddCase[testIndex].dateDiff, &endDate);
 
     //    // Assert for the result
@@ -390,7 +396,7 @@ TEST_METHOD(TestSubtraction)
     //    DateTime endDate;
 
     //    // Subtract Duration
-    //    bool isValid = m_DateCalcEngine.SubtractDuration(DateUtils::SystemTimeToDateTime(datetimeSubtractCase[testIndex].startDate),
+    //    bool isValid = m_DateCalcEngine->SubtractDuration(DateUtils::SystemTimeToDateTime(datetimeSubtractCase[testIndex].startDate),
     //    datetimeSubtractCase[testIndex].dateDiff, &endDate);
 
     //    // assert for the result
@@ -408,13 +414,9 @@ TEST_METHOD(TestSubtraction)
     //    VERIFY_IS_TRUE(isValid);
     //}
 }
-
-private:
-}
-;
+};
 
 TEST_CLASS(DateCalculatorViewModelTests){ public: TEST_CLASS_INITIALIZE(TestClassSetup){ /* Test Case Data */
-
                                                                                          // Dates - DD.MM.YYYY
                                                                                          /*31.12.9999*/ date[0].wYear = 9999;
 date[0].wMonth = 12;
@@ -657,7 +659,7 @@ TEST_METHOD(DateCalcViewModelInitializationTest)
 
 TEST_METHOD(DateCalcViewModelAddSubtractInitTest)
 {
-    auto viewModel = ref new DateCalculatorViewModel();
+    DateCalculatorViewModel ^ viewModel = ref new DateCalculatorViewModel();
     viewModel->IsDateDiffMode = false;
 
     // Check for the initialized values
@@ -682,8 +684,7 @@ TEST_METHOD(DateCalcViewModelAddSubtractInitTest)
 
 TEST_METHOD(DateCalcViewModelDateDiffDaylightSavingTimeTest)
 {
-    auto viewModel = ref new DateCalculatorViewModel();
-
+    DateCalculatorViewModel ^ viewModel = ref new DateCalculatorViewModel();
     viewModel->IsDateDiffMode = true;
     VERIFY_IS_TRUE(viewModel->IsDateDiffMode);
 
@@ -922,8 +923,6 @@ TEST_METHOD(DateCalcViewModelDateDiffFromDateHigherThanToDate)
 // contains the DayOfWeek, Day, Month, and Year
 TEST_METHOD(DateCalcViewModelAddSubtractResultAutomationNameTest)
 {
-    auto viewModel = ref new DateCalculatorViewModel();
-
     auto cal = ref new Calendar();
     cal->Year = 2007;
     cal->Month = 5;
@@ -934,6 +933,8 @@ TEST_METHOD(DateCalcViewModelAddSubtractResultAutomationNameTest)
     cal->Second = 0;
 
     DateTime startDate = cal->GetDateTime();
+    auto viewModel = ref new DateCalculatorViewModel();
+
     viewModel->StartDate = startDate;
 
     viewModel->IsDateDiffMode = false;
@@ -955,7 +956,7 @@ TEST_METHOD(DateCalcViewModelAddSubtractResultAutomationNameTest)
 
 TEST_METHOD(JaEraTransitionAddition)
 {
-    auto viewModel = make_unique<DateCalculationEngine>(CalendarIdentifiers::Japanese);
+    auto viewModel = ref new DateCalculationEngine(CalendarIdentifiers::Japanese);
     auto cal = ref new Calendar();
 
     // The Showa period ended in Jan 1989.
@@ -973,10 +974,9 @@ TEST_METHOD(JaEraTransitionAddition)
     DateDifference yearDuration;
     yearDuration.year = 1;
 
-    DateTime actualYearResult;
-    viewModel->AddDuration(startTime, yearDuration, &actualYearResult);
+    auto actualYearResult = viewModel->AddDuration(startTime, yearDuration);
 
-    VERIFY_ARE_EQUAL(expectedYearResult.UniversalTime, actualYearResult.UniversalTime);
+    VERIFY_ARE_EQUAL(expectedYearResult.UniversalTime, actualYearResult->Value.UniversalTime);
 
     cal->Year = 1989;
     cal->Month = 2;
@@ -987,15 +987,14 @@ TEST_METHOD(JaEraTransitionAddition)
     DateDifference monthDuration;
     monthDuration.month = 1;
 
-    DateTime actualMonthResult;
-    viewModel->AddDuration(startTime, monthDuration, &actualMonthResult);
+    auto actualMonthResult = viewModel->AddDuration(startTime, monthDuration);
 
-    VERIFY_ARE_EQUAL(expectedMonthResult.UniversalTime, actualMonthResult.UniversalTime);
+    VERIFY_ARE_EQUAL(expectedMonthResult.UniversalTime, actualMonthResult->Value.UniversalTime);
 }
 
 TEST_METHOD(JaEraTransitionSubtraction)
 {
-    auto viewModel = make_unique<DateCalculationEngine>(CalendarIdentifiers::Japanese);
+    auto viewModel = ref new DateCalculationEngine(CalendarIdentifiers::Japanese);
     auto cal = ref new Calendar();
 
     // The Showa period ended in Jan 1989.
@@ -1013,10 +1012,9 @@ TEST_METHOD(JaEraTransitionSubtraction)
     DateDifference yearDuration;
     yearDuration.year = 1;
 
-    DateTime actualYearResult;
-    viewModel->SubtractDuration(startTime, yearDuration, &actualYearResult);
+    auto actualYearResult = viewModel->SubtractDuration(startTime, yearDuration);
 
-    VERIFY_ARE_EQUAL(expectedYearResult.UniversalTime, actualYearResult.UniversalTime);
+    VERIFY_ARE_EQUAL(expectedYearResult.UniversalTime, actualYearResult->Value.UniversalTime);
 
     cal->Year = 1989;
     cal->Month = 1;
@@ -1027,15 +1025,14 @@ TEST_METHOD(JaEraTransitionSubtraction)
     DateDifference monthDuration;
     monthDuration.month = 1;
 
-    DateTime actualMonthResult;
-    viewModel->SubtractDuration(startTime, monthDuration, &actualMonthResult);
+    auto actualMonthResult = viewModel->SubtractDuration(startTime, monthDuration);
 
-    VERIFY_ARE_EQUAL(expectedMonthResult.UniversalTime, actualMonthResult.UniversalTime);
+    VERIFY_ARE_EQUAL(expectedMonthResult.UniversalTime, actualMonthResult->Value.UniversalTime);
 }
 
 TEST_METHOD(JaEraTransitionDifference)
 {
-    auto viewModel = make_unique<DateCalculationEngine>(CalendarIdentifiers::Japanese);
+    auto viewModel = ref new DateCalculationEngine(CalendarIdentifiers::Japanese);
     auto cal = ref new Calendar();
 
     // The Showa period ended in Jan 8, 1989.  Pick 2 days across that boundary
@@ -1049,10 +1046,12 @@ TEST_METHOD(JaEraTransitionDifference)
     cal->Day = 20;
     auto endTime = cal->GetDateTime();
 
-    DateDifference diff;
-    VERIFY_IS_TRUE(viewModel->TryGetDateDifference(startTime, endTime, DateUnit::Day, &diff));
-    VERIFY_ARE_EQUAL(diff.day, 19);
+    auto diff = viewModel->TryGetDateDifference(startTime, endTime, DateUnit::Day);
+    VERIFY_IS_NOT_NULL(diff);
+    VERIFY_ARE_EQUAL(diff->Value.day, 19);
 }
 }
 ;
+
+DateCalculationEngine ^ DateCalculatorUnitTests::m_DateCalcEngine;
 }

--- a/src/CalculatorUnitTests/DateCalculatorUnitTests.cpp
+++ b/src/CalculatorUnitTests/DateCalculatorUnitTests.cpp
@@ -659,7 +659,7 @@ TEST_METHOD(DateCalcViewModelInitializationTest)
 
 TEST_METHOD(DateCalcViewModelAddSubtractInitTest)
 {
-    DateCalculatorViewModel ^ viewModel = ref new DateCalculatorViewModel();
+    auto viewModel = ref new DateCalculatorViewModel();
     viewModel->IsDateDiffMode = false;
 
     // Check for the initialized values
@@ -684,7 +684,7 @@ TEST_METHOD(DateCalcViewModelAddSubtractInitTest)
 
 TEST_METHOD(DateCalcViewModelDateDiffDaylightSavingTimeTest)
 {
-    DateCalculatorViewModel ^ viewModel = ref new DateCalculatorViewModel();
+    auto viewModel = ref new DateCalculatorViewModel();
     viewModel->IsDateDiffMode = true;
     VERIFY_IS_TRUE(viewModel->IsDateDiffMode);
 
@@ -956,7 +956,7 @@ TEST_METHOD(DateCalcViewModelAddSubtractResultAutomationNameTest)
 
 TEST_METHOD(JaEraTransitionAddition)
 {
-    auto viewModel = ref new DateCalculationEngine(CalendarIdentifiers::Japanese);
+    auto engine = ref new DateCalculationEngine(CalendarIdentifiers::Japanese);
     auto cal = ref new Calendar();
 
     // The Showa period ended in Jan 1989.
@@ -974,7 +974,7 @@ TEST_METHOD(JaEraTransitionAddition)
     DateDifference yearDuration;
     yearDuration.year = 1;
 
-    auto actualYearResult = viewModel->AddDuration(startTime, yearDuration);
+    auto actualYearResult = engine->AddDuration(startTime, yearDuration);
 
     VERIFY_ARE_EQUAL(expectedYearResult.UniversalTime, actualYearResult->Value.UniversalTime);
 
@@ -987,14 +987,14 @@ TEST_METHOD(JaEraTransitionAddition)
     DateDifference monthDuration;
     monthDuration.month = 1;
 
-    auto actualMonthResult = viewModel->AddDuration(startTime, monthDuration);
+    auto actualMonthResult = engine->AddDuration(startTime, monthDuration);
 
     VERIFY_ARE_EQUAL(expectedMonthResult.UniversalTime, actualMonthResult->Value.UniversalTime);
 }
 
 TEST_METHOD(JaEraTransitionSubtraction)
 {
-    auto viewModel = ref new DateCalculationEngine(CalendarIdentifiers::Japanese);
+    auto engine = ref new DateCalculationEngine(CalendarIdentifiers::Japanese);
     auto cal = ref new Calendar();
 
     // The Showa period ended in Jan 1989.
@@ -1012,7 +1012,7 @@ TEST_METHOD(JaEraTransitionSubtraction)
     DateDifference yearDuration;
     yearDuration.year = 1;
 
-    auto actualYearResult = viewModel->SubtractDuration(startTime, yearDuration);
+    auto actualYearResult = engine->SubtractDuration(startTime, yearDuration);
 
     VERIFY_ARE_EQUAL(expectedYearResult.UniversalTime, actualYearResult->Value.UniversalTime);
 
@@ -1025,14 +1025,14 @@ TEST_METHOD(JaEraTransitionSubtraction)
     DateDifference monthDuration;
     monthDuration.month = 1;
 
-    auto actualMonthResult = viewModel->SubtractDuration(startTime, monthDuration);
+    auto actualMonthResult = engine->SubtractDuration(startTime, monthDuration);
 
     VERIFY_ARE_EQUAL(expectedMonthResult.UniversalTime, actualMonthResult->Value.UniversalTime);
 }
 
 TEST_METHOD(JaEraTransitionDifference)
 {
-    auto viewModel = ref new DateCalculationEngine(CalendarIdentifiers::Japanese);
+    auto engine = ref new DateCalculationEngine(CalendarIdentifiers::Japanese);
     auto cal = ref new Calendar();
 
     // The Showa period ended in Jan 8, 1989.  Pick 2 days across that boundary
@@ -1046,7 +1046,7 @@ TEST_METHOD(JaEraTransitionDifference)
     cal->Day = 20;
     auto endTime = cal->GetDateTime();
 
-    auto diff = viewModel->TryGetDateDifference(startTime, endTime, DateUnit::Day);
+    auto diff = engine->TryGetDateDifference(startTime, endTime, DateUnit::Day);
     VERIFY_IS_NOT_NULL(diff);
     VERIFY_ARE_EQUAL(diff->Value.day, 19);
 }


### PR DESCRIPTION
## Fixes #770


### Description of the changes:
- Convert DateDifference, DateCalculationEngine to runtime class
   - update all DateCalculationEngine methods to not pass arguments by reference
- Convert DateCalculatorViewModel to runtime class
- Update DateCalculatorUnitTest

### How changes were validated:
- manually

