### PR TITLE
Migrate TraceLogger to runtime class

### DIFF
--- a/src/CalcViewModel/ApplicationViewModel.cpp
+++ b/src/CalcViewModel/ApplicationViewModel.cpp
@@ -85,7 +85,7 @@ void ApplicationViewModel::Initialize(ViewMode mode)
     }
     catch (const std::exception& e)
     {
-        TraceLogger::GetInstance().LogStandardException(mode, __FUNCTIONW__, e);
+        TraceLogger::GetInstance()->LogStandardException(mode, __FUNCTIONW__, e);
         if (!TryRecoverFromNavigationModeFailure())
         {
             // Could not navigate to standard mode either.
@@ -95,7 +95,7 @@ void ApplicationViewModel::Initialize(ViewMode mode)
     }
     catch (Exception ^ e)
     {
-        TraceLogger::GetInstance().LogPlatformException(mode, __FUNCTIONW__, e);
+        TraceLogger::GetInstance()->LogPlatformException(mode, __FUNCTIONW__, e);
         if (!TryRecoverFromNavigationModeFailure())
         {
             // Could not navigate to standard mode either.
@@ -162,11 +162,11 @@ void ApplicationViewModel::OnModeChanged()
     // Log ModeChange event when not first launch, log WindowCreated on first launch
     if (NavCategory::IsValidViewMode(m_PreviousMode))
     {
-        TraceLogger::GetInstance().LogModeChange(m_mode);
+        TraceLogger::GetInstance()->LogModeChange(m_mode);
     }
     else
     {
-        TraceLogger::GetInstance().LogWindowCreated(m_mode, ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread()));
+        TraceLogger::GetInstance()->LogWindowCreated(m_mode, ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread()));
     }
 
     RaisePropertyChanged(ClearMemoryVisibilityPropertyName);

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -108,7 +108,7 @@ String
     if (pastedText->Length() > MaxPasteableLength)
     {
         // return NoOp to indicate don't paste anything.
-        TraceLogger::GetInstance().LogError(mode, L"CopyPasteManager::ValidatePasteExpression", L"PastedExpressionSizeGreaterThanMaxAllowed");
+        TraceLogger::GetInstance()->LogError(mode, L"CopyPasteManager::ValidatePasteExpression", L"PastedExpressionSizeGreaterThanMaxAllowed");
         return PasteErrorString;
     }
 
@@ -141,7 +141,7 @@ String
     // validate each operand with patterns for different modes
     if (!ExpressionRegExMatch(operands, mode, modeType, programmerNumberBase, bitLengthType))
     {
-        TraceLogger::GetInstance().LogError(mode, L"CopyPasteManager::ValidatePasteExpression", L"InvalidExpressionForPresentMode");
+        TraceLogger::GetInstance()->LogError(mode, L"CopyPasteManager::ValidatePasteExpression", L"InvalidExpressionForPresentMode");
         return PasteErrorString;
     }
 
@@ -187,7 +187,7 @@ vector<wstring> CopyPasteManager::ExtractOperands(const wstring& pasteExpression
 
         if (operands.size() >= MaxOperandCount)
         {
-            TraceLogger::GetInstance().LogError(mode, L"CopyPasteManager::ExtractOperands", L"OperandCountGreaterThanMaxCount");
+            TraceLogger::GetInstance()->LogError(mode, L"CopyPasteManager::ExtractOperands", L"OperandCountGreaterThanMaxCount");
             operands.clear();
             return operands;
         }
@@ -201,7 +201,7 @@ vector<wstring> CopyPasteManager::ExtractOperands(const wstring& pasteExpression
                 // to disallow pasting of 1e+12345 as 1e+1234, max exponent that can be pasted is 9999.
                 if (expLength > MaxExponentLength)
                 {
-                    TraceLogger::GetInstance().LogError(mode, L"CopyPasteManager::ExtractOperands", L"ExponentLengthGreaterThanMaxLength");
+                    TraceLogger::GetInstance()->LogError(mode, L"CopyPasteManager::ExtractOperands", L"ExponentLengthGreaterThanMaxLength");
                     operands.clear();
                     return operands;
                 }

--- a/src/CalcViewModel/Common/TraceLogger.h
+++ b/src/CalcViewModel/Common/TraceLogger.h
@@ -28,33 +28,31 @@ namespace CalculatorApp
         }
     };
 
-    class TraceLogger
+public
+    ref class TraceLogger sealed
     {
     public:
-        TraceLogger(_In_ TraceLogger const&) = delete;
-        TraceLogger const& operator=(_In_ TraceLogger const&) = delete;
-        ~TraceLogger();
-        static TraceLogger& GetInstance();
-        bool GetTraceLoggingProviderEnabled() const;
-
-        void LogModeChange(CalculatorApp::Common::ViewMode mode) const;
-        void LogHistoryItemLoad(CalculatorApp::Common::ViewMode mode, int historyListSize, int loadedIndex) const;
-        void LogMemoryItemLoad(CalculatorApp::Common::ViewMode mode, int memoryListSize, int loadedIndex) const;
+        static TraceLogger ^ GetInstance();
+        bool GetTraceLoggingProviderEnabled();
+        void LogModeChange(CalculatorApp::Common::ViewMode mode);
+        void LogHistoryItemLoad(CalculatorApp::Common::ViewMode mode, int historyListSize, int loadedIndex);
+        void LogMemoryItemLoad(CalculatorApp::Common::ViewMode mode, int memoryListSize, int loadedIndex);
         void UpdateButtonUsage(CalculatorApp::NumbersAndOperatorsEnum button, CalculatorApp::Common::ViewMode mode);
         void LogButtonUsage();
         void LogDateCalculationModeUsed(bool AddSubtractMode);
-        void UpdateWindowCount(size_t windowCount = 0);
+        void UpdateWindowCount(uint64 windowCount);
+        void DecreaseWindowCount();
         bool IsWindowIdInLog(int windowId);
-        void LogVisualStateChanged(CalculatorApp::Common::ViewMode mode, std::wstring_view state, bool isAlwaysOnTop = false) const;
+        void LogVisualStateChanged(CalculatorApp::Common::ViewMode mode, Platform::String ^ state, bool isAlwaysOnTop);
         void LogWindowCreated(CalculatorApp::Common::ViewMode mode, int windowId);
-        void LogConverterInputReceived(CalculatorApp::Common::ViewMode mode) const;
-        void LogNavBarOpened() const;
-
-        void LogError(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, std::wstring_view errorString);
-        void LogStandardException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ const std::exception& e) const;
-        void LogWinRTException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ winrt::hresult_error const& e) const;
-        void LogPlatformException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ Platform::Exception ^ e) const;
-        void LogInputPasted(CalculatorApp::Common::ViewMode mode) const;
+        void LogConverterInputReceived(CalculatorApp::Common::ViewMode mode);
+        void LogNavBarOpened();
+        void LogError(CalculatorApp::Common::ViewMode mode, Platform::String ^ functionName, Platform::String ^ errorString);
+    internal :
+        void LogStandardException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ const std::exception& e);
+        void LogWinRTException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ winrt::hresult_error const& e);
+        void LogPlatformException(CalculatorApp::Common::ViewMode mode, std::wstring_view functionName, _In_ Platform::Exception ^ e);
+        void LogInputPasted(CalculatorApp::Common::ViewMode mode);
 
     private:
         // Create an instance of TraceLogger
@@ -64,11 +62,11 @@ namespace CalculatorApp
         // sampling is involved in Microsoft's diagnostic data collection process.
         // These keywords provide additional input into how frequently an event might be sampled.
         // The lower the level of the keyword, the higher the possibility that the corresponding event may be sampled.
-        void LogLevel1Event(std::wstring_view eventName, winrt::Windows::Foundation::Diagnostics::LoggingFields fields) const;
-        void LogLevel2Event(std::wstring_view eventName, winrt::Windows::Foundation::Diagnostics::LoggingFields fields) const;
-        void LogLevel3Event(std::wstring_view eventName, winrt::Windows::Foundation::Diagnostics::LoggingFields fields) const;
+        void LogLevel1Event(std::wstring_view eventName, winrt::Windows::Foundation::Diagnostics::LoggingFields fields);
+        void LogLevel2Event(std::wstring_view eventName, winrt::Windows::Foundation::Diagnostics::LoggingFields fields);
+        void LogLevel3Event(std::wstring_view eventName, winrt::Windows::Foundation::Diagnostics::LoggingFields fields);
 
-        std::unique_ptr<TraceActivity> CreateTraceActivity(std::wstring_view activityName, winrt::Windows::Foundation::Diagnostics::LoggingFields fields) const;
+        std::unique_ptr<TraceActivity> CreateTraceActivity(std::wstring_view activityName, winrt::Windows::Foundation::Diagnostics::LoggingFields fields);
 
         winrt::Windows::Foundation::Diagnostics::LoggingChannel g_calculatorProvider;
 
@@ -76,7 +74,7 @@ namespace CalculatorApp
         std::vector<int> windowIdLog;
 
         GUID sessionGuid;
-        size_t currentWindowCount = 0;
+        uint64 currentWindowCount = 0;
 
         winrt::Windows::Foundation::Diagnostics::LoggingActivity m_appLaunchActivity;
     };

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -351,12 +351,12 @@ future<bool> CurrencyDataLoader::TryLoadDataFromCacheAsync()
     }
     catch (Exception ^ ex)
     {
-        TraceLogger::GetInstance().LogPlatformException(ViewMode::Currency, __FUNCTIONW__, ex);
+        TraceLogger::GetInstance()->LogPlatformException(ViewMode::Currency, __FUNCTIONW__, ex);
         co_return false;
     }
     catch (const exception& e)
     {
-        TraceLogger::GetInstance().LogStandardException(ViewMode::Currency, __FUNCTIONW__, e);
+        TraceLogger::GetInstance()->LogStandardException(ViewMode::Currency, __FUNCTIONW__, e);
         co_return false;
     }
     catch (...)
@@ -461,12 +461,12 @@ future<bool> CurrencyDataLoader::TryLoadDataFromWebAsync()
     }
     catch (Exception ^ ex)
     {
-        TraceLogger::GetInstance().LogPlatformException(ViewMode::Currency, __FUNCTIONW__, ex);
+        TraceLogger::GetInstance()->LogPlatformException(ViewMode::Currency, __FUNCTIONW__, ex);
         co_return false;
     }
     catch (const exception& e)
     {
-        TraceLogger::GetInstance().LogStandardException(ViewMode::Currency, __FUNCTIONW__, e);
+        TraceLogger::GetInstance()->LogStandardException(ViewMode::Currency, __FUNCTIONW__, e);
         co_return false;
     }
     catch (...)
@@ -482,7 +482,7 @@ future<bool> CurrencyDataLoader::TryLoadDataFromWebOverrideAsync()
     if (!didLoad)
     {
         m_loadStatus = CurrencyLoadStatus::FailedToLoad;
-        TraceLogger::GetInstance().LogError(ViewMode::Currency, L"CurrencyDataLoader::TryLoadDataFromWebOverrideAsync", L"UserRequestedRefreshFailed");
+        TraceLogger::GetInstance()->LogError(ViewMode::Currency, L"CurrencyDataLoader::TryLoadDataFromWebOverrideAsync", L"UserRequestedRefreshFailed");
     }
 
     co_return didLoad;

--- a/src/CalcViewModel/HistoryViewModel.cpp
+++ b/src/CalcViewModel/HistoryViewModel.cpp
@@ -120,7 +120,7 @@ void HistoryViewModel::ShowItem(_In_ HistoryItemViewModel ^ e)
 {
     unsigned int index;
     Items->IndexOf(e, &index);
-    TraceLogger::GetInstance().LogHistoryItemLoad((ViewMode)m_currentMode, ItemSize, (int)(index));
+    TraceLogger::GetInstance()->LogHistoryItemLoad((ViewMode)m_currentMode, ItemSize, (int)(index));
     HistoryItemClicked(e);
 }
 

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -674,7 +674,7 @@ void StandardCalculatorViewModel::OnButtonPressed(Object ^ parameter)
                 m_isLastOperationHistoryLoad = false;
             }
 
-            TraceLogger::GetInstance().UpdateButtonUsage(numOpEnum, GetCalculatorMode());
+            TraceLogger::GetInstance()->UpdateButtonUsage(numOpEnum, GetCalculatorMode());
             m_standardCalculatorManager.SendCommand(cmdenum);
         }
     }
@@ -753,7 +753,7 @@ void StandardCalculatorViewModel::OnPaste(String ^ pastedString)
         return;
     }
 
-    TraceLogger::GetInstance().LogInputPasted(GetCalculatorMode());
+    TraceLogger::GetInstance()->LogInputPasted(GetCalculatorMode());
     bool isFirstLegalChar = true;
     m_standardCalculatorManager.SendCommand(Command::CommandCENTR);
     bool sendNegate = false;
@@ -899,7 +899,7 @@ void StandardCalculatorViewModel::OnClearMemoryCommand(Object ^ parameter)
 {
     m_standardCalculatorManager.MemorizedNumberClearAll();
 
-    TraceLogger::GetInstance().UpdateButtonUsage(NumbersAndOperatorsEnum::MemoryClear, GetCalculatorMode());
+    TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::MemoryClear, GetCalculatorMode());
 
     if (m_localizedMemoryCleared == nullptr)
     {
@@ -1055,7 +1055,7 @@ void StandardCalculatorViewModel::OnMemoryButtonPressed()
 {
     m_standardCalculatorManager.MemorizeNumber();
 
-    TraceLogger::GetInstance().UpdateButtonUsage(NumbersAndOperatorsEnum::Memory, GetCalculatorMode());
+    TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::Memory, GetCalculatorMode());
 
     if (m_localizedMemorySavedAutomationFormat == nullptr)
     {
@@ -1094,7 +1094,7 @@ void StandardCalculatorViewModel::OnMemoryItemPressed(Object ^ memoryItemPositio
         HideMemoryClicked();
 
         auto mode = IsStandard ? ViewMode::Standard : IsScientific ? ViewMode::Scientific : ViewMode::Programmer;
-        TraceLogger::GetInstance().LogMemoryItemLoad(mode, MemorizedNumbers->Size, boxedPosition->Value);
+        TraceLogger::GetInstance()->LogMemoryItemLoad(mode, MemorizedNumbers->Size, boxedPosition->Value);
     }
 }
 
@@ -1105,7 +1105,7 @@ void StandardCalculatorViewModel::OnMemoryAdd(Object ^ memoryItemPosition)
     if (MemorizedNumbers)
     {
         auto boxedPosition = safe_cast<Box<int> ^>(memoryItemPosition);
-        TraceLogger::GetInstance().UpdateButtonUsage(NumbersAndOperatorsEnum::MemoryAdd, GetCalculatorMode());
+        TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::MemoryAdd, GetCalculatorMode());
         m_standardCalculatorManager.MemorizedNumberAdd(boxedPosition->Value);
     }
 }
@@ -1116,7 +1116,7 @@ void StandardCalculatorViewModel::OnMemorySubtract(Object ^ memoryItemPosition)
     if (MemorizedNumbers)
     {
         auto boxedPosition = safe_cast<Box<int> ^>(memoryItemPosition);
-        TraceLogger::GetInstance().UpdateButtonUsage(NumbersAndOperatorsEnum::MemorySubtract, GetCalculatorMode());
+        TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::MemorySubtract, GetCalculatorMode());
         m_standardCalculatorManager.MemorizedNumberSubtract(boxedPosition->Value);
     }
 }
@@ -1142,7 +1142,7 @@ void StandardCalculatorViewModel::OnMemoryClear(_In_ Object ^ memoryItemPosition
             {
                 IsMemoryEmpty = true;
             }
-            TraceLogger::GetInstance().UpdateButtonUsage(NumbersAndOperatorsEnum::MemoryClear, GetCalculatorMode());
+            TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::MemoryClear, GetCalculatorMode());
 
             wstring localizedIndex = to_wstring(boxedPosition->Value + 1);
             LocalizationSettings::GetInstance().LocalizeDisplayValue(&localizedIndex);
@@ -1189,7 +1189,7 @@ void StandardCalculatorViewModel::OnPropertyChanged(String ^ propertyname)
     }
     else if (propertyname == IsBitFlipCheckedPropertyName)
     {
-        TraceLogger::GetInstance().UpdateButtonUsage(
+        TraceLogger::GetInstance()->UpdateButtonUsage(
             IsBitFlipChecked ? NumbersAndOperatorsEnum::BitflipButton : NumbersAndOperatorsEnum::FullKeypadButton, ViewMode::Programmer);
     }
 }

--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -494,7 +494,7 @@ void UnitConverterViewModel::OnButtonPressed(Platform::Object ^ parameter)
 
     m_model->SendCommand(command);
 
-    TraceLogger::GetInstance().LogConverterInputReceived(Mode);
+    TraceLogger::GetInstance()->LogConverterInputReceived(Mode);
 }
 
 void UnitConverterViewModel::OnCopyCommand(Platform::Object ^ parameter)
@@ -887,7 +887,7 @@ void UnitConverterViewModel::OnPaste(String ^ stringToPaste)
         return;
     }
 
-    TraceLogger::GetInstance().LogInputPasted(Mode);
+    TraceLogger::GetInstance()->LogInputPasted(Mode);
     bool isFirstLegalChar = true;
     bool sendNegate = false;
     wstring accumulation = L"";

--- a/src/Calculator/App.xaml.cpp
+++ b/src/Calculator/App.xaml.cpp
@@ -118,7 +118,7 @@ void App::AddWindowToMap(_In_ WindowFrameService ^ frameService)
 {
     reader_writer_lock::scoped_lock lock(m_windowsMapLock);
     m_secondaryWindows[frameService->GetViewId()] = frameService;
-    TraceLogger::GetInstance().UpdateWindowCount(m_secondaryWindows.size());
+    TraceLogger::GetInstance()->UpdateWindowCount(m_secondaryWindows.size());
 }
 
 WindowFrameService ^ App::GetWindowFromMap(int viewId)
@@ -384,7 +384,7 @@ void App::OnAppLaunch(IActivatedEventArgs ^ args, String ^ argument)
                 }
                 else
                 {
-                    TraceLogger::GetInstance().LogError(ViewMode::None, L"App::OnAppLaunch", L"Null_ActivationViewSwitcher");
+                    TraceLogger::GetInstance()->LogError(ViewMode::None, L"App::OnAppLaunch", L"Null_ActivationViewSwitcher");
                 }
             }
             // Set the preLaunched flag to false
@@ -460,7 +460,7 @@ void App::OnActivated(IActivatedEventArgs ^ args)
 
 void CalculatorApp::App::OnSuspending(Object ^ sender, SuspendingEventArgs ^ args)
 {
-    TraceLogger::GetInstance().LogButtonUsage();
+    TraceLogger::GetInstance()->LogButtonUsage();
 }
 
 void App::DismissedEventHandler(SplashScreen ^ sender, Object ^ e)

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -138,7 +138,7 @@ void Calculator::OnLoaded(_In_ Object ^, _In_ RoutedEventArgs ^)
     WeakReference weakThis(this);
     this->Dispatcher->RunAsync(
         CoreDispatcherPriority::Normal, ref new DispatchedHandler([weakThis]() {
-            if (TraceLogger::GetInstance().IsWindowIdInLog(ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread())))
+            if (TraceLogger::GetInstance()->IsWindowIdInLog(ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread())))
             {
                 auto refThis = weakThis.Resolve<Calculator>();
                 if (refThis != nullptr)
@@ -709,8 +709,7 @@ void Calculator::OnMemoryAccessKeyInvoked(_In_ UIElement ^ sender, _In_ AccessKe
 void CalculatorApp::Calculator::OnVisualStateChanged(Platform::Object ^ sender, Windows::UI::Xaml::VisualStateChangedEventArgs ^ e)
 {
     auto mode = IsStandard ? ViewMode::Standard : IsScientific ? ViewMode::Scientific : ViewMode::Programmer;
-    auto state = std::wstring(e->NewState->Name->Begin());
-    TraceLogger::GetInstance().LogVisualStateChanged(mode, state, IsAlwaysOnTop);
+    TraceLogger::GetInstance()->LogVisualStateChanged(mode, e->NewState->Name, IsAlwaysOnTop);
 }
 
 void Calculator::Calculator_SizeChanged(Object ^ /*sender*/, SizeChangedEventArgs ^ /*e*/)

--- a/src/Calculator/Views/CalculatorProgrammerOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerOperators.xaml.cpp
@@ -38,7 +38,7 @@ CalculatorProgrammerOperators::CalculatorProgrammerOperators()
 
 void CalculatorProgrammerOperators::HexButtonChecked(_In_ Object ^ sender, _In_ RoutedEventArgs ^ e)
 {
-    TraceLogger::GetInstance().UpdateButtonUsage(NumbersAndOperatorsEnum::HexButton, ViewMode::Programmer);
+    TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::HexButton, ViewMode::Programmer);
     if (Model)
     {
         Model->SwitchProgrammerModeBase(RADIX_TYPE::HEX_RADIX);
@@ -47,7 +47,7 @@ void CalculatorProgrammerOperators::HexButtonChecked(_In_ Object ^ sender, _In_ 
 
 void CalculatorProgrammerOperators::DecButtonChecked(_In_ Object ^ sender, _In_ RoutedEventArgs ^ e)
 {
-    TraceLogger::GetInstance().UpdateButtonUsage(NumbersAndOperatorsEnum::DecButton, ViewMode::Programmer);
+    TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::DecButton, ViewMode::Programmer);
     if (Model)
     {
         Model->SwitchProgrammerModeBase(RADIX_TYPE::DEC_RADIX);
@@ -56,7 +56,7 @@ void CalculatorProgrammerOperators::DecButtonChecked(_In_ Object ^ sender, _In_ 
 
 void CalculatorProgrammerOperators::OctButtonChecked(_In_ Object ^ sender, _In_ RoutedEventArgs ^ e)
 {
-    TraceLogger::GetInstance().UpdateButtonUsage(NumbersAndOperatorsEnum::OctButton, ViewMode::Programmer);
+    TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::OctButton, ViewMode::Programmer);
     if (Model)
     {
         Model->SwitchProgrammerModeBase(RADIX_TYPE::OCT_RADIX);
@@ -65,7 +65,7 @@ void CalculatorProgrammerOperators::OctButtonChecked(_In_ Object ^ sender, _In_ 
 
 void CalculatorProgrammerOperators::BinButtonChecked(_In_ Object ^ sender, _In_ RoutedEventArgs ^ e)
 {
-    TraceLogger::GetInstance().UpdateButtonUsage(NumbersAndOperatorsEnum::BinButton, ViewMode::Programmer);
+    TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::BinButton, ViewMode::Programmer);
     if (Model)
     {
         Model->SwitchProgrammerModeBase(RADIX_TYPE::BIN_RADIX);

--- a/src/Calculator/Views/DateCalculator.xaml.cpp
+++ b/src/Calculator/Views/DateCalculator.xaml.cpp
@@ -103,7 +103,7 @@ void DateCalculator::FromDate_DateChanged(_In_ CalendarDatePicker ^ sender, _In_
     {
         auto dateCalcViewModel = safe_cast<DateCalculatorViewModel ^>(this->DataContext);
         dateCalcViewModel->FromDate = e->NewDate->Value;
-        TraceLogger::GetInstance().LogDateCalculationModeUsed(false /* AddSubtractMode */);
+        TraceLogger::GetInstance()->LogDateCalculationModeUsed(false /* AddSubtractMode */);
     }
     else
     {
@@ -117,7 +117,7 @@ void DateCalculator::ToDate_DateChanged(_In_ CalendarDatePicker ^ sender, _In_ C
     {
         auto dateCalcViewModel = safe_cast<DateCalculatorViewModel ^>(this->DataContext);
         dateCalcViewModel->ToDate = e->NewDate->Value;
-        TraceLogger::GetInstance().LogDateCalculationModeUsed(false /* AddSubtractMode */);
+        TraceLogger::GetInstance()->LogDateCalculationModeUsed(false /* AddSubtractMode */);
     }
     else
     {
@@ -131,7 +131,7 @@ void DateCalculator::AddSubtract_DateChanged(_In_ CalendarDatePicker ^ sender, _
     {
         auto dateCalcViewModel = safe_cast<DateCalculatorViewModel ^>(this->DataContext);
         dateCalcViewModel->StartDate = e->NewDate->Value;
-        TraceLogger::GetInstance().LogDateCalculationModeUsed(true /* AddSubtractMode */);
+        TraceLogger::GetInstance()->LogDateCalculationModeUsed(true /* AddSubtractMode */);
     }
     else
     {
@@ -145,7 +145,7 @@ void CalculatorApp::DateCalculator::OffsetValue_Changed(_In_ Platform::Object ^ 
     // do not log diagnostics for no-ops and initialization of combo boxes
     if (dateCalcViewModel->DaysOffset != 0 || dateCalcViewModel->MonthsOffset != 0 || dateCalcViewModel->YearsOffset != 0)
     {
-        TraceLogger::GetInstance().LogDateCalculationModeUsed(true /* AddSubtractMode */);
+        TraceLogger::GetInstance()->LogDateCalculationModeUsed(true /* AddSubtractMode */);
     }
 }
 
@@ -237,6 +237,5 @@ void DateCalculator::AddSubtractOption_Checked(_In_ Object ^ sender, _In_ Routed
 
 void CalculatorApp::DateCalculator::OnVisualStateChanged(Platform::Object ^ sender, Windows::UI::Xaml::VisualStateChangedEventArgs ^ e)
 {
-    auto state = std::wstring(e->NewState->Name->Begin());
-    TraceLogger::GetInstance().LogVisualStateChanged(ViewMode::Date, state);
+    TraceLogger::GetInstance()->LogVisualStateChanged(ViewMode::Date, e->NewState->Name, false);
 }

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -256,7 +256,7 @@ void MainPage::OnPageLoaded(_In_ Object ^, _In_ RoutedEventArgs ^ args)
     // Delay load things later when we get a chance.
     this->Dispatcher->RunAsync(
         CoreDispatcherPriority::Normal, ref new DispatchedHandler([]() {
-            if (TraceLogger::GetInstance().IsWindowIdInLog(ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread())))
+            if (TraceLogger::GetInstance()->IsWindowIdInLog(ApplicationView::GetApplicationViewIdForWindow(CoreWindow::GetForCurrentThread())))
             {
                 AppLifecycleLogger::GetInstance().LaunchUIResponsive();
                 AppLifecycleLogger::GetInstance().LaunchVisibleComplete();
@@ -391,7 +391,7 @@ void MainPage::OnNavPaneOpening(_In_ MUXC::NavigationView ^ sender, _In_ Object 
 void MainPage::OnNavPaneOpened(_In_ MUXC::NavigationView ^ sender, _In_ Object ^ args)
 {
     KeyboardShortcutManager::HonorShortcuts(false);
-    TraceLogger::GetInstance().LogNavBarOpened();
+    TraceLogger::GetInstance()->LogNavBarOpened();
 }
 
 void MainPage::OnNavPaneClosed(_In_ MUXC::NavigationView ^ sender, _In_ Object ^ args)

--- a/src/Calculator/Views/UnitConverter.xaml.cpp
+++ b/src/Calculator/Views/UnitConverter.xaml.cpp
@@ -377,6 +377,5 @@ void CalculatorApp::UnitConverter::SupplementaryResultsPanelInGrid_SizeChanged(P
 void CalculatorApp::UnitConverter::OnVisualStateChanged(Platform::Object ^ sender, Windows::UI::Xaml::VisualStateChangedEventArgs ^ e)
 {
     auto mode = NavCategory::Deserialize(Model->CurrentCategory->GetModelCategory().id);
-    auto state = std::wstring(e->NewState->Name->Begin());
-    TraceLogger::GetInstance().LogVisualStateChanged(mode, state);
+    TraceLogger::GetInstance()->LogVisualStateChanged(mode, e->NewState->Name, false);
 }

--- a/src/Calculator/WindowFrameService.cpp
+++ b/src/Calculator/WindowFrameService.cpp
@@ -118,7 +118,7 @@ namespace CalculatorApp
 
     void WindowFrameService::OnConsolidated(_In_ ApplicationView ^ sender, _In_ ApplicationViewConsolidatedEventArgs ^ e)
     {
-        TraceLogger::GetInstance().UpdateWindowCount();
+        TraceLogger::GetInstance()->DecreaseWindowCount();
         auto parent = m_parent.Resolve<App>();
         if (parent != nullptr)
         {


### PR DESCRIPTION
## Fixes #771 

### Description of the changes:
- Convert TraceLogger to runtime class
    - remove all `const` modifiers (not supported by runtime classes 😟) 
    - split UpdateWindowCount in 2: `UpdateWindowCount` and `DecreaseWindowCount`
    - replace wstring by Platform::String
- change the visibility to some methods
### How changes were validated:
- manually + unit tests
