### PR TITLE
Support high contrast for color picker and fix crashing bug

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -150,23 +150,11 @@
                     <SolidColorBrush x:Key="EquationBoxHoverButtonForegroundBrush" Color="{ThemeResource SystemColorButtonTextColor}"/>
                     <SolidColorBrush x:Key="AppControlTransparentButtonBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
 
-                    <!-- TODO: Add high contrast colors mapping -->
-                    <SolidColorBrush x:Key="EquationBrush1" Color="#FFFF0000"/>
-                    <SolidColorBrush x:Key="EquationBrush2" Color="#FFFFB900"/>
-                    <SolidColorBrush x:Key="EquationBrush3" Color="#FFFF8C00"/>
-                    <SolidColorBrush x:Key="EquationBrush4" Color="#FFF7630C"/>
-                    <SolidColorBrush x:Key="EquationBrush5" Color="#FFCA5010"/>
-                    <SolidColorBrush x:Key="EquationBrush6" Color="#FFE3008C"/>
-                    <SolidColorBrush x:Key="EquationBrush7" Color="#FFBF0077"/>
-                    <SolidColorBrush x:Key="EquationBrush8" Color="#FFC239B3"/>
-                    <SolidColorBrush x:Key="EquationBrush9" Color="#FF0063B1"/>
-                    <SolidColorBrush x:Key="EquationBrush10" Color="#FF2D7D9A"/>
-                    <SolidColorBrush x:Key="EquationBrush11" Color="#FF00B7C3"/>
-                    <SolidColorBrush x:Key="EquationBrush12" Color="#FF00CC6A"/>
-                    <SolidColorBrush x:Key="EquationBrush13" Color="#FF00B294"/>
-                    <SolidColorBrush x:Key="EquationBrush14" Color="#FF018574"/>
-                    <SolidColorBrush x:Key="EquationBrush15" Color="#FF10893E"/>
-                    <SolidColorBrush x:Key="EquationBrush16" Color="#FF000000"/>
+                    <!-- TODO: Figure out what colors we can use in high contrast -->
+                    <SolidColorBrush x:Key="EquationBrush1" Color="{ThemeResource SystemColorGrayTextColor}"/>
+                    <SolidColorBrush x:Key="EquationBrush2" Color="{ThemeResource SystemColorHighlightColor}"/>
+                    <SolidColorBrush x:Key="EquationBrush3" Color="{ThemeResource SystemColorHotlightColor}"/>
+                    <SolidColorBrush x:Key="EquationBrush4" Color="{ThemeResource SystemColorWindowColor}"/>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 

--- a/src/Calculator/EquationStylePanelControl.xaml.cpp
+++ b/src/Calculator/EquationStylePanelControl.xaml.cpp
@@ -21,33 +21,11 @@ using namespace Windows::UI::Xaml::Navigation;
 using namespace Windows::UI::Xaml::Shapes;
 
 DEPENDENCY_PROPERTY_INITIALIZATION(EquationStylePanelControl, SelectedColor);
+DEPENDENCY_PROPERTY_INITIALIZATION(EquationStylePanelControl, AvailableColors);
 
 EquationStylePanelControl::EquationStylePanelControl()
 {
     InitializeComponent();
-    InitializeAvailableColors();
-}
-
-void EquationStylePanelControl::InitializeAvailableColors()
-{
-    // TODO: Handle dynamically switching these to high contrast equivalents
-    m_AvailableColors = ref new Vector<SolidColorBrush ^>();
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush1")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush2")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush3")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush4")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush5")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush6")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush7")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush8")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush9")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush10")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush11")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush12")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush13")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush14")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush15")));
-    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush16")));
 }
 
 void EquationStylePanelControl::SelectionChanged(Object ^ /*sender */, SelectionChangedEventArgs ^ e)
@@ -70,6 +48,11 @@ void EquationStylePanelControl::ColorChooserLoaded(Object ^ sender, RoutedEventA
 
 void EquationStylePanelControl::SelectColor(SolidColorBrush ^ selectedColor)
 {
+    if (selectedColor == nullptr)
+    {
+        return;
+    }
+
     for (auto item : ColorChooser->Items->GetView())
     {
         auto brush = static_cast<SolidColorBrush ^>(item);
@@ -83,6 +66,7 @@ void EquationStylePanelControl::SelectColor(SolidColorBrush ^ selectedColor)
         if (brush->Color == selectedColor->Color)
         {
             gridViewItem->IsSelected = true;
+            return;
         }
         else
         {

--- a/src/Calculator/EquationStylePanelControl.xaml.h
+++ b/src/Calculator/EquationStylePanelControl.xaml.h
@@ -15,21 +15,12 @@ namespace CalculatorApp
         DEPENDENCY_PROPERTY_OWNER(EquationStylePanelControl);
 
         DEPENDENCY_PROPERTY_WITH_CALLBACK(Windows::UI::Xaml::Media::SolidColorBrush ^, SelectedColor);
-
-        property Windows::Foundation::Collections::IVector<Windows::UI::Xaml::Media::SolidColorBrush^>^ AvailableColors
-        {
-            Windows::Foundation::Collections::IVector<Windows::UI::Xaml::Media::SolidColorBrush^>^ get() {
-                return m_AvailableColors;
-            }
-        }
+        DEPENDENCY_PROPERTY_WITH_DEFAULT(Windows::Foundation::Collections::IVector<Windows::UI::Xaml::Media::SolidColorBrush ^> ^, AvailableColors, nullptr);
 
 	private:
-        void InitializeAvailableColors();
         void SelectionChanged(Platform::Object ^ sender, Windows::UI::Xaml::Controls::SelectionChangedEventArgs ^ e);
         void OnSelectedColorPropertyChanged(Windows::UI::Xaml::Media::SolidColorBrush ^ oldValue, Windows::UI::Xaml::Media::SolidColorBrush ^ newValue);
         void ColorChooserLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void SelectColor(Windows::UI::Xaml::Media::SolidColorBrush ^ selectedColor);
-
-        Windows::Foundation::Collections::IVector<Windows::UI::Xaml::Media::SolidColorBrush ^>^ m_AvailableColors;
     };
 }

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -6,7 +6,9 @@ using namespace CalculatorApp::Common;
 using namespace CalculatorApp::ViewModel;
 using namespace CalculatorApp::Controls;
 using namespace Platform;
+using namespace Platform::Collections;
 using namespace std;
+using namespace Windows::Foundation;
 using namespace Windows::System;
 using namespace Windows::UI;
 using namespace Windows::UI::ViewManagement;
@@ -24,11 +26,18 @@ namespace
 
 EquationInputArea::EquationInputArea()
     : m_lastLineColorIndex{ -1 }
+    , m_AvailableColors{ ref new Vector<SolidColorBrush ^>() }
+    , m_accessibilitySettings{ ref new AccessibilitySettings() }
 {
-	InitializeComponent();
+    m_accessibilitySettings->HighContrastChanged +=
+        ref new TypedEventHandler<AccessibilitySettings ^, Object ^>(this, &EquationInputArea::OnHighContrastChanged);
+
+    ReloadAvailableColors(m_accessibilitySettings->HighContrast);
+
+    InitializeComponent();
 }
 
-void EquationInputArea::OnPropertyChanged(String^ propertyName)
+void EquationInputArea::OnPropertyChanged(String ^ propertyName)
 {
     if (propertyName == EquationsPropertyName)
     {
@@ -44,7 +53,7 @@ void EquationInputArea::OnEquationsPropertyChanged()
     }
 }
 
-void EquationInputArea::AddEquationButton_Click(Object^ sender, RoutedEventArgs^ e)
+void EquationInputArea::AddEquationButton_Click(Object ^ sender, RoutedEventArgs ^ e)
 {
     AddNewEquation();
 }
@@ -52,31 +61,36 @@ void EquationInputArea::AddEquationButton_Click(Object^ sender, RoutedEventArgs^
 void EquationInputArea::AddNewEquation()
 {
     auto eq = ref new EquationViewModel();
+
+    m_lastLineColorIndex = (m_lastLineColorIndex + 1) % AvailableColors->Size;
+
+    eq->LineColor = AvailableColors->GetAt(m_lastLineColorIndex);
+
     Equations->Append(eq);
 }
 
-void EquationInputArea::InputTextBox_GotFocus(Object^ sender, RoutedEventArgs^ e)
+void EquationInputArea::InputTextBox_GotFocus(Object ^ sender, RoutedEventArgs ^ e)
 {
     KeyboardShortcutManager::HonorShortcuts(false);
 }
 
-void EquationInputArea::InputTextBox_LostFocus(Object^ sender, RoutedEventArgs^ e)
+void EquationInputArea::InputTextBox_LostFocus(Object ^ sender, RoutedEventArgs ^ e)
 {
     KeyboardShortcutManager::HonorShortcuts(true);
 }
 
 void EquationInputArea::InputTextBox_Submitted(Object ^ sender, RoutedEventArgs ^ e)
 {
-    auto tb = static_cast<EquationTextBox^>(sender);
-    auto eq = static_cast<EquationViewModel^>(tb->DataContext);
+    auto tb = static_cast<EquationTextBox ^>(sender);
+    auto eq = static_cast<EquationViewModel ^>(tb->DataContext);
     eq->Expression = tb->GetEquationText();
     FocusManager::TryMoveFocus(::FocusNavigationDirection::Left);
 }
 
-void EquationInputArea::EquationTextBox_RemoveButtonClicked(Object^ sender, RoutedEventArgs^ e)
+void EquationInputArea::EquationTextBox_RemoveButtonClicked(Object ^ sender, RoutedEventArgs ^ e)
 {
-    auto tb = static_cast<EquationTextBox^>(sender);
-    auto eq = static_cast<EquationViewModel^>(tb->DataContext);
+    auto tb = static_cast<EquationTextBox ^>(sender);
+    auto eq = static_cast<EquationViewModel ^>(tb->DataContext);
     unsigned int index;
     if (Equations->IndexOf(eq, &index))
     {
@@ -90,8 +104,57 @@ void EquationInputArea::EquationTextBoxLoaded(Object ^ sender, RoutedEventArgs ^
     auto eq = static_cast<EquationViewModel ^>(tb->DataContext);
 
     auto colorChooser = static_cast<EquationStylePanelControl ^>(tb->ColorChooserFlyout->Content);
+    colorChooser->AvailableColors = AvailableColors;
+}
 
-    m_lastLineColorIndex = (m_lastLineColorIndex + 1) % colorChooser->AvailableColors->Size;
+void EquationInputArea::OnHighContrastChanged(AccessibilitySettings ^ sender, Object ^ args)
+{
+    ReloadAvailableColors(sender->HighContrast);
+}
 
-    eq->LineColor = colorChooser->AvailableColors->GetAt(m_lastLineColorIndex);
+void EquationInputArea::ReloadAvailableColors(bool isHighContrast)
+{
+    m_AvailableColors->Clear();
+
+    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush1")));
+    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush2")));
+    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush3")));
+    m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush4")));
+
+    // If this is not high contrast, we have all 16 colors, otherwise we will restrict this to a subset of high contrast colors
+    if (!isHighContrast)
+    {
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush5")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush6")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush7")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush8")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush9")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush10")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush11")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush12")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush13")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush14")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush15")));
+        m_AvailableColors->Append(safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush16")));
+    }
+
+    // If there are no equations to reload, quit early
+    if (Equations == nullptr || Equations->Size == 0)
+    {
+        return;
+    }
+
+    // Use a blank brush to clear out the color before setting it. This is needed because going
+    // from High Contrast White -> High Contrast Black, the high contrast colors seem to be equivalent,
+    // causing the change to not take place.
+    auto blankBrush = ref new SolidColorBrush();
+
+    // Reassign colors for each equation
+    m_lastLineColorIndex = -1;
+    for (auto equationViewModel : Equations)
+    {
+        m_lastLineColorIndex = (m_lastLineColorIndex + 1) % AvailableColors->Size;
+        equationViewModel->LineColor = blankBrush;
+        equationViewModel->LineColor = AvailableColors->GetAt(m_lastLineColorIndex);
+    }
 }

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
@@ -16,6 +16,8 @@ namespace CalculatorApp
 
         OBSERVABLE_OBJECT_CALLBACK(OnPropertyChanged);
         OBSERVABLE_PROPERTY_RW(Windows::Foundation::Collections::IObservableVector< ViewModel::EquationViewModel^ >^, Equations);
+        OBSERVABLE_PROPERTY_RW(Windows::Foundation::Collections::IObservableVector<Windows::UI::Xaml::Media::SolidColorBrush ^> ^, AvailableColors);
+
 
     private:
         void OnPropertyChanged(Platform::String^ propertyName);
@@ -28,7 +30,11 @@ namespace CalculatorApp
         void InputTextBox_LostFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void InputTextBox_Submitted(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 
+        void OnHighContrastChanged(Windows::UI::ViewManagement::AccessibilitySettings ^ sender, Platform::Object ^ args);
+        void ReloadAvailableColors(bool isHighContrast);
+
     private:
+        Windows::UI::ViewManagement::AccessibilitySettings ^ m_accessibilitySettings;
         int m_lastLineColorIndex;
         void EquationTextBox_RemoveButtonClicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
         void EquationTextBoxLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);


### PR DESCRIPTION
## Part of #338

### Description of the changes:
- Allow swapping the color pallet to a different set of colors when in high contrast mode, automatically updating the equation colors on the graph
- Fixes an equation not getting a color assigned if the EquationTextBox was already loaded previously
- Keep a single reference to available colors instead of creating multiple copies

### How changes were validated:
- Manual tests

