### PR TITLE
Updating code to append a wchar_t instead of const wchar_t

### DIFF
--- a/src/CalcManager/CEngine/CalcInput.cpp
+++ b/src/CalcManager/CEngine/CalcInput.cpp
@@ -179,7 +179,7 @@ bool CalcInput::TryAddDecimalPt()
 
     if (m_base.IsEmpty())
     {
-        m_base.value += L"0"; // Add a leading zero
+        m_base.value += L'0'; // Add a leading zero
     }
 
     m_decPtIndex = m_base.value.size();

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -640,9 +640,9 @@ namespace CalculationManager
         if (pHistory)
         {
             pHistory->ClearHistory();
-            for (unsigned int i = 0; i < history.size(); ++i)
+            for (auto const& historyItem : history)
             {
-                pHistory->AddItem(history[i]);
+                pHistory->AddItem(historyItem);
             }
         }
     }

--- a/src/CalcManager/ExpressionCommand.cpp
+++ b/src/CalcManager/ExpressionCommand.cpp
@@ -275,14 +275,12 @@ const wstring& COpndCommand::GetToken(wchar_t decimalSymbol)
 
 wstring COpndCommand::GetString(uint32_t radix, int32_t precision)
 {
-    wstring result{};
-
     if (m_fInitialized)
     {
-        result = m_value.ToString(radix, eNUMOBJ_FMT::FMT_FLOAT, precision);
+        return m_value.ToString(radix, eNUMOBJ_FMT::FMT_FLOAT, precision);
     }
 
-    return result;
+    return wstring{};
 }
 
 void COpndCommand::Accept(_In_ ISerializeCommandVisitor& commandVisitor)

--- a/src/CalcManager/NumberFormattingUtils.cpp
+++ b/src/CalcManager/NumberFormattingUtils.cpp
@@ -16,8 +16,7 @@ namespace CalcManager::NumberFormattingUtils
             return;
         }
 
-        wstring::iterator iter;
-        for (iter = number.end() - 1;; iter--)
+        for (auto iter = number.end() - 1;; iter--)
         {
             if (*iter != L'0')
             {
@@ -25,9 +24,9 @@ namespace CalcManager::NumberFormattingUtils
                 break;
             }
         }
-        if (*(number.end() - 1) == L'.')
+        if (number.back() == L'.')
         {
-            number.erase(number.end() - 1, number.end());
+            number.pop_back();
         }
     }
 

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -401,43 +401,43 @@ void UnitConverter::SendCommand(Command command)
     switch (command)
     {
     case Command::Zero:
-        m_currentDisplay += L"0";
+        m_currentDisplay += L'0';
         break;
 
     case Command::One:
-        m_currentDisplay += L"1";
+        m_currentDisplay += L'1';
         break;
 
     case Command::Two:
-        m_currentDisplay += L"2";
+        m_currentDisplay += L'2';
         break;
 
     case Command::Three:
-        m_currentDisplay += L"3";
+        m_currentDisplay += L'3';
         break;
 
     case Command::Four:
-        m_currentDisplay += L"4";
+        m_currentDisplay += L'4';
         break;
 
     case Command::Five:
-        m_currentDisplay += L"5";
+        m_currentDisplay += L'5';
         break;
 
     case Command::Six:
-        m_currentDisplay += L"6";
+        m_currentDisplay += L'6';
         break;
 
     case Command::Seven:
-        m_currentDisplay += L"7";
+        m_currentDisplay += L'7';
         break;
 
     case Command::Eight:
-        m_currentDisplay += L"8";
+        m_currentDisplay += L'8';
         break;
 
     case Command::Nine:
-        m_currentDisplay += L"9";
+        m_currentDisplay += L'9';
         break;
 
     case Command::Decimal:
@@ -445,7 +445,7 @@ void UnitConverter::SendCommand(Command command)
         clearBack = false;
         if (!m_currentHasDecimal)
         {
-            m_currentDisplay += L".";
+            m_currentDisplay += L'.';
             m_currentHasDecimal = true;
         }
         break;

--- a/src/CalcViewModel/DateCalculatorViewModel.cpp
+++ b/src/CalcViewModel/DateCalculatorViewModel.cpp
@@ -253,7 +253,7 @@ String ^ DateCalculatorViewModel::GetDateDiffString() const
     if (yearCount > 0)
     {
         result += GetLocalizedNumberString(yearCount)->Data();
-        result += L" ";
+        result += L' ';
 
         if (yearCount > 1)
         {
@@ -281,7 +281,7 @@ String ^ DateCalculatorViewModel::GetDateDiffString() const
         }
 
         result += GetLocalizedNumberString(monthCount)->Data();
-        result += L" ";
+        result += L' ';
 
         if (monthCount > 1)
         {
@@ -306,7 +306,7 @@ String ^ DateCalculatorViewModel::GetDateDiffString() const
         }
 
         result += GetLocalizedNumberString(weekCount)->Data();
-        result += L" ";
+        result += L' ';
 
         if (weekCount > 1)
         {
@@ -331,7 +331,7 @@ String ^ DateCalculatorViewModel::GetDateDiffString() const
         }
 
         result += GetLocalizedNumberString(dayCount)->Data();
-        result += L" ";
+        result += L' ';
 
         if (dayCount > 1)
         {
@@ -349,7 +349,7 @@ String ^ DateCalculatorViewModel::GetDateDiffString() const
 String ^ DateCalculatorViewModel::GetDateDiffStringInDays() const
 {
     wstring result = GetLocalizedNumberString(m_dateDiffResultInDays.day)->Data();
-    result += L" ";
+    result += L' ';
 
     // Display the result as '1 day' or 'N days'
     if (m_dateDiffResultInDays.day > 1)

--- a/src/CalculatorUnitTests/CalcInputTest.cpp
+++ b/src/CalculatorUnitTests/CalcInputTest.cpp
@@ -309,7 +309,7 @@ namespace CalculatorEngineTests
             wstring maxStr{};
             for (size_t i = 0; i < MAX_STRLEN + 1; i++)
             {
-                maxStr += L"1";
+                maxStr += L'1';
                 m_calcInput.TryAddDigit(1, 10, false, maxStr, 64, 100);
             }
             auto result = m_calcInput.ToString(10);
@@ -323,7 +323,7 @@ namespace CalculatorEngineTests
             bool exponentCapped = false;
             for (size_t i = 0; i < MAX_STRLEN + 1; i++)
             {
-                maxStr += L"1";
+                maxStr += L'1';
                 if (!m_calcInput.TryAddDigit(1, 10, false, maxStr, 64, MAX_STRLEN + 25))
                 {
                     exponentCapped = true;

--- a/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
+++ b/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
@@ -62,7 +62,7 @@ namespace CalculatorUnitTests
                 m_CopyPasteManager.ValidatePasteExpression(StringReference(exp_TooLong.c_str()), ViewMode::Standard, CategoryGroupType::Calculator, -1, BitLength::BitLengthUnknown),
                 StringReference(exp_TooLong.c_str()),
                 L"Verify ValidatePasteExpression handles expressions up to max length");
-            exp_TooLong += L"1";
+            exp_TooLong += L'1';
             VERIFY_ARE_EQUAL(
                 m_CopyPasteManager.ValidatePasteExpression(
                     StringReference(exp_TooLong.c_str()), ViewMode::Standard, CategoryGroupType::Calculator, -1, BitLength::BitLengthUnknown),


### PR DESCRIPTION
## Fixes #777.

### Description of the changes:
- In places where a wstring was appending a single character, updated the code to use wchar_t instead of const wchar_t*.
- I also found a couple of places where a range-for could be used.  I hope it's ok to include that here.
- In COpndCommand::GetString, I found a small performance win by returning early vs. creating a return variable.  This win comes from the fact that the old code default constructed a wstring and then potentially called the assignment operator on top of that leading to the temporary string needing a destructor call.  Not using a return variable gets rid of the temporary.

### How changes were validated:
- Manual Testing

