### PR TITLE
refactor HistoryTest.cpp to test the history using HistoryViewModel

### DIFF
--- a/src/CalcViewModel/Common/Utils.cpp
+++ b/src/CalcViewModel/Common/Utils.cpp
@@ -36,17 +36,6 @@ void Utils::IFTPlatformException(HRESULT hr)
     }
 }
 
-String ^ Utils::GetStringValue(String ^ input)
-{
-    // Remove first and last " characters
-    if (input->Length() >= 3)
-    {
-        wstring out(input->Begin() + 1, input->End() - 1);
-        return ref new String(out.c_str());
-    }
-    return input;
-}
-
 double Utils::GetDoubleFromWstring(wstring input)
 {
     constexpr wchar_t unWantedChars[] = { L' ', L',', 8234, 8235, 8236, 8237 };

--- a/src/CalcViewModel/Common/Utils.h
+++ b/src/CalcViewModel/Common/Utils.h
@@ -98,7 +98,7 @@ public:
 
 #define OBSERVABLE_NAMED_PROPERTY_R(t, n)                                                                                                                      \
     OBSERVABLE_PROPERTY_R(t, n)                                                                                                                                \
-    internal:                                                                                                                                                  \
+public:                                                                                                                                                        \
     static property Platform::String ^ n##PropertyName                                                                                                         \
     {                                                                                                                                                          \
         Platform::String ^ get() { return Platform::StringReference(L#n); }                                                                                    \
@@ -108,7 +108,7 @@ public:
 
 #define OBSERVABLE_NAMED_PROPERTY_RW(t, n)                                                                                                                     \
     OBSERVABLE_PROPERTY_RW(t, n)                                                                                                                               \
-    internal:                                                                                                                                                  \
+public:                                                                                                                                                        \
     static property Platform::String ^ n##PropertyName                                                                                                         \
     {                                                                                                                                                          \
         Platform::String ^ get() { return Platform::StringReference(L#n); }                                                                                    \
@@ -373,7 +373,6 @@ namespace Utils
     }
 
     void IFTPlatformException(HRESULT hr);
-    Platform::String ^ GetStringValue(Platform::String ^ input);
     bool IsLastCharacterTarget(std::wstring const& input, wchar_t target);
 
     // Return wstring after removing characters specified by unwantedChars array

--- a/src/CalcViewModel/HistoryViewModel.cpp
+++ b/src/CalcViewModel/HistoryViewModel.cpp
@@ -6,6 +6,7 @@
 #include "Common/TraceLogger.h"
 #include "Common/LocalizationStringUtil.h"
 #include "Common/LocalizationSettings.h"
+#include "StandardCalculatorViewModel.h"
 
 using namespace CalculatorApp;
 using namespace CalculatorApp::Common;
@@ -256,6 +257,11 @@ void HistoryViewModel::ClearHistory()
 {
     ClearHistoryContainer(CalculationManager::CalculatorMode::Standard);
     ClearHistoryContainer(CalculationManager::CalculatorMode::Scientific);
+}
+
+unsigned long long HistoryViewModel::GetMaxItemSize()
+{
+    return static_cast<unsigned long long>(m_calculatorManager->MaxHistorySize());
 }
 
 void HistoryViewModel::SaveHistory()

--- a/src/CalcViewModel/HistoryViewModel.h
+++ b/src/CalcViewModel/HistoryViewModel.h
@@ -15,6 +15,8 @@ namespace CalculatorApp
 
     namespace ViewModel
     {
+        ref class StandardCalculatorViewModel;
+
     public
         delegate void HideHistoryClickedHandler();
     public
@@ -45,6 +47,7 @@ namespace CalculatorApp
             internal : HistoryViewModel(_In_ CalculationManager::CalculatorManager* calculatorManager);
             void SetCalculatorDisplay(CalculatorDisplay& calculatorDisplay);
             void ReloadHistory(_In_ CalculatorApp::Common::ViewMode currentMode);
+            unsigned long long GetMaxItemSize();
 
             void DeleteItem(_In_ CalculatorApp::ViewModel::HistoryItemViewModel ^ e);
 

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1812,3 +1812,13 @@ void StandardCalculatorViewModel::SelectHistoryItem(HistoryItemViewModel ^ item)
     SetPrimaryDisplay(item->Result, false);
     IsFToEEnabled = false;
 }
+
+void StandardCalculatorViewModel::ResetCalcManager(bool clearMemory)
+{
+    m_standardCalculatorManager.Reset(clearMemory);
+}
+
+void StandardCalculatorViewModel::SendCommandToCalcManager(int commandId)
+{
+    m_standardCalculatorManager.SendCommand(static_cast<Command>(commandId));
+}

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -242,60 +242,6 @@ namespace CalculatorApp
                 }
             }
 
-            property int TokenPosition
-            {
-                int get()
-                {
-                    return m_tokenPosition;
-                }
-                void set(int value)
-                {
-                    m_tokenPosition = value;
-                }
-            }
-
-            property Platform::String^ SelectedExpressionLastData
-            {
-                Platform::String^ get() { return m_selectedExpressionLastData; }
-                void set(Platform::String^ value) { m_selectedExpressionLastData = value; }
-            }
-
-            property bool KeyPressed
-            {
-                bool get()
-                {
-                    return m_keyPressed;
-                }
-                void set(bool value)
-                {
-                    m_keyPressed = value;
-                }
-            }
-
-            property bool IsOperandUpdatedUsingViewModel
-            {
-                bool get()
-                {
-                    return m_operandUpdated;
-                }
-                void set(bool value)
-                {
-                    m_operandUpdated = value;
-                }
-            }
-
-            property bool IsOperandTextCompletelySelected
-            {
-                bool get()
-                {
-                    return m_completeTextSelection;
-                }
-                void set(bool value)
-                {
-                    m_completeTextSelection = value;
-                }
-            }
-
             // Used by unit tests
             void ResetCalcManager(bool clearMemory);
             void SendCommandToCalcManager(int command);

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -12,11 +12,6 @@
 #include "Common/BitLength.h"
 #include "Common/NumberBase.h"
 
-namespace CalculatorFunctionalTests
-{
-    class HistoryTests;
-}
-
 namespace CalculatorUnitTests
 {
     class MultiWindowUnitTests;
@@ -247,7 +242,65 @@ namespace CalculatorApp
                 }
             }
 
-        internal :
+            property int TokenPosition
+            {
+                int get()
+                {
+                    return m_tokenPosition;
+                }
+                void set(int value)
+                {
+                    m_tokenPosition = value;
+                }
+            }
+
+            property Platform::String^ SelectedExpressionLastData
+            {
+                Platform::String^ get() { return m_selectedExpressionLastData; }
+                void set(Platform::String^ value) { m_selectedExpressionLastData = value; }
+            }
+
+            property bool KeyPressed
+            {
+                bool get()
+                {
+                    return m_keyPressed;
+                }
+                void set(bool value)
+                {
+                    m_keyPressed = value;
+                }
+            }
+
+            property bool IsOperandUpdatedUsingViewModel
+            {
+                bool get()
+                {
+                    return m_operandUpdated;
+                }
+                void set(bool value)
+                {
+                    m_operandUpdated = value;
+                }
+            }
+
+            property bool IsOperandTextCompletelySelected
+            {
+                bool get()
+                {
+                    return m_completeTextSelection;
+                }
+                void set(bool value)
+                {
+                    m_completeTextSelection = value;
+                }
+            }
+
+            // Used by unit tests
+            void ResetCalcManager(bool clearMemory);
+            void SendCommandToCalcManager(int command);
+
+        internal:
             void OnPaste(Platform::String ^ pastedString);
             void OnCopyCommand(Platform::Object ^ parameter);
             void OnPasteCommand(Platform::Object ^ parameter);
@@ -373,7 +426,6 @@ namespace CalculatorApp
             CalculatorApp::Common::ViewMode GetCalculatorMode();
 
             friend class CalculatorDisplay;
-            friend class CalculatorFunctionalTests::HistoryTests;
             friend class CalculatorUnitTests::MultiWindowUnitTests;
         };
     }

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -237,6 +237,7 @@
     <ClCompile Include="CopyPasteManagerTest.cpp" />
     <ClCompile Include="CurrencyConverterUnitTests.cpp" />
     <ClCompile Include="DateCalculatorUnitTests.cpp" />
+    <ClCompile Include="Helper.cpp" />
     <ClCompile Include="HistoryTests.cpp" />
     <ClCompile Include="LocalizationServiceUnitTests.cpp" />
     <ClCompile Include="LocalizationSettingsUnitTests.cpp" />

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
@@ -30,6 +30,7 @@
     <ClCompile Include="LocalizationServiceUnitTests.cpp" />
     <ClCompile Include="RationalTest.cpp" />
     <ClCompile Include="LocalizationSettingsUnitTests.cpp" />
+    <ClCompile Include="Helper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="DateUtils.h" />

--- a/src/CalculatorUnitTests/Helper.cpp
+++ b/src/CalculatorUnitTests/Helper.cpp
@@ -1,0 +1,14 @@
+#include "pch.h"
+#include "Helpers.h"
+using namespace Platform;
+using namespace std;
+
+String ^ GetStringValue(String ^ input) {
+    // Remove first and last " characters
+    if (input->Length() >= 3)
+    {
+        wstring out(input->Begin() + 1, input->End() - 1);
+        return ref new String(out.c_str());
+    }
+    return input;
+}

--- a/src/CalculatorUnitTests/Helpers.h
+++ b/src/CalculatorUnitTests/Helpers.h
@@ -108,3 +108,5 @@ void VERIFY_VECTORS_ARE_EQUAL(Windows::Foundation::Collections::IVector<T> ^ vec
         VERIFY_ARE_EQUAL(vecA->GetAt(i), vecB->GetAt(i), __VA_ARGS__);
     }
 };
+
+Platform::String ^ GetStringValue(Platform::String ^ input);

--- a/src/CalculatorUnitTests/HistoryTests.cpp
+++ b/src/CalculatorUnitTests/HistoryTests.cpp
@@ -46,17 +46,16 @@ namespace CalculatorFunctionalTests
         {
             m_standardViewModel = ref new StandardCalculatorViewModel();
             m_standardViewModel->IsStandard = true;
-            m_historyViewModel = ref new HistoryViewModel(&(m_standardViewModel->m_standardCalculatorManager));
-            m_historyViewModel->SetCalculatorDisplay(m_standardViewModel->m_calculatorDisplay);
+            m_historyViewModel = m_standardViewModel->HistoryVM;
         }
 
         void Cleanup()
         {
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeBasic));
             m_historyViewModel->OnClearCommand(nullptr);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
             m_historyViewModel->OnClearCommand(nullptr);
-            m_standardViewModel->m_standardCalculatorManager.Reset();
+            m_standardViewModel->ResetCalcManager(false);
         }
 
         bool IsHistoryContainerEmpty(_In_ String ^ historyContainerKey)
@@ -71,64 +70,54 @@ namespace CalculatorFunctionalTests
             return String::Concat(modeValue->ToString(), L"_History");
         }
 
-        void MockOnHistoryItemClicked(CalculatorApp::ViewModel::HistoryItemViewModel^ e)
-        {
-            m_standardViewModel->SetHistoryExpressionDisplay(e->GetTokens(), e->GetCommands());
-            m_standardViewModel->SetExpressionDisplay(e->GetTokens(), e->GetCommands());
-            m_standardViewModel->SetPrimaryDisplay(e->Result, false /*IsError*/);
-            m_standardViewModel->IsFToEEnabled = false;
-        }
-
         void AddSingleHistoryItem()
         {
             Initialize();
             int initialSize = m_historyViewModel->ItemSize;
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command8);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command8));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             int sizeAfterItemAdd = m_historyViewModel->ItemSize;
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
+            auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(0));
             String ^ expression = UtfUtils::LRO + L"1   +   8 =" + UtfUtils::PDF;
-            String ^ result = StringReference(L"9");
             VERIFY_ARE_EQUAL(initialSize + 1, sizeAfterItemAdd);
-            VERIFY_ARE_EQUAL(expression, StringReference(historyItem->historyItemVector.expression.c_str()));
-            VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
+            VERIFY_ARE_EQUAL(historyItem->Expression, expression);
+            VERIFY_ARE_EQUAL(historyItem->Result, L"9");
             Cleanup();
         }
 
         void AddMaxHistoryItems()
         {
             Initialize();
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
-            for (size_t i = 1; i < m_standardViewModel->m_standardCalculatorManager.MaxHistorySize(); i++)
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
+            for (unsigned long long i = 1; i < m_historyViewModel->GetMaxItemSize(); i++)
             {
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command2));
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             }
-            VERIFY_ARE_EQUAL((size_t)m_historyViewModel->ItemSize, m_standardViewModel->m_standardCalculatorManager.MaxHistorySize());
+            VERIFY_ARE_EQUAL((size_t)m_historyViewModel->ItemSize, m_historyViewModel->GetMaxItemSize());
             String ^ expression = UtfUtils::LRO + L"1   +   1 =" + UtfUtils::PDF;
             int output = 2;
             String ^ result = output.ToString();
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
-            VERIFY_ARE_EQUAL(expression, StringReference(historyItem->historyItemVector.expression.c_str()));
-            VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
-            VERIFY_ARE_EQUAL((size_t)m_historyViewModel->ItemSize, m_standardViewModel->m_standardCalculatorManager.MaxHistorySize());
+            auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1));
+            VERIFY_ARE_EQUAL(historyItem->Expression, expression);
+            VERIFY_ARE_EQUAL(historyItem->Result, result);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command5));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             expression = UtfUtils::LRO + L"1   +   2 =" + UtfUtils::PDF;
             output = 3;
             result = output.ToString();
-            historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
-            VERIFY_ARE_EQUAL(expression, StringReference(historyItem->historyItemVector.expression.c_str()));
-            VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
+            historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1));
+            VERIFY_ARE_EQUAL(historyItem->Expression, expression);
+            VERIFY_ARE_EQUAL(historyItem->Result, result);
             Cleanup();
         }
 
@@ -136,30 +125,30 @@ namespace CalculatorFunctionalTests
         {
             Initialize();
 
-            m_standardViewModel->m_standardCalculatorManager.Reset();
+            m_standardViewModel->ResetCalcManager(false);
             int scientificItems = 5;
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
             for (int i = 0; i < scientificItems; i++)
             {
                 Command nextCommand = Command(130 + i);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(nextCommand);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+                m_standardViewModel->SendCommandToCalcManager((int)nextCommand);
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             }
 
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeBasic));
             int standardItems = 2;
             for (int i = 0; i < standardItems; i++)
             {
                 Command nextCommand = Command(130 + i);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(nextCommand);
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+                m_standardViewModel->SendCommandToCalcManager((int)nextCommand);
+                m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             }
 
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
             m_historyViewModel->ReloadHistory(ViewMode::Scientific);
             VERIFY_ARE_EQUAL(scientificItems, m_historyViewModel->ItemSize);
             for (int i = 0; i < scientificItems; i++)
@@ -168,13 +157,13 @@ namespace CalculatorFunctionalTests
                 expr = UtfUtils::LRO + expr + UtfUtils::PDF;
                 int output = 1 + i;
                 String ^ result = output.ToString();
-                auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(i);
-                VERIFY_ARE_EQUAL(expr, historyItem->historyItemVector.expression);
-                VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
+                auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1 - i));
+                VERIFY_ARE_EQUAL(historyItem->Expression, StringReference(expr.c_str()));
+                VERIFY_ARE_EQUAL(historyItem->Result, result);
             }
 
             m_historyViewModel->ReloadHistory(ViewMode::Standard);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeBasic));
             VERIFY_ARE_EQUAL(standardItems, m_historyViewModel->ItemSize);
             for (int i = 0; i < standardItems; i++)
             {
@@ -182,9 +171,9 @@ namespace CalculatorFunctionalTests
                 expr = UtfUtils::LRO + expr + UtfUtils::PDF;
                 int output = 1 + i;
                 String ^ result = output.ToString();
-                auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(i);
-                VERIFY_ARE_EQUAL(expr, historyItem->historyItemVector.expression);
-                VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
+                auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1 - i));
+                VERIFY_ARE_EQUAL(historyItem->Expression, StringReference(expr.c_str()));
+                VERIFY_ARE_EQUAL(historyItem->Result, result);
             }
             Cleanup();
         }
@@ -192,16 +181,16 @@ namespace CalculatorFunctionalTests
         void ClearHistory()
         {
             Initialize();
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command2));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeBasic));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command2));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             m_historyViewModel->OnClearCommand(nullptr);
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
             VERIFY_IS_TRUE(IsHistoryContainerEmpty(GetHistoryContainerKeyHelper(CalculatorMode::Standard)));
@@ -212,53 +201,55 @@ namespace CalculatorFunctionalTests
         void SerializeDeSerializeHistoryItem()
         {
             Initialize();
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
-            auto itemBeforeSerializeDeserialize = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command2));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
+            auto itemBeforeSerializeDeserialize = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(0));
             m_historyViewModel->SaveHistory();
             m_historyViewModel->ReloadHistory(ViewMode::Scientific);
-            auto itemAfterSerializeDeserialize = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
+            auto itemAfterSerializeDeserialize = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(0));
             VERIFY_IS_TRUE(
-                (itemBeforeSerializeDeserialize->historyItemVector.expression == itemAfterSerializeDeserialize->historyItemVector.expression)
-                && (itemBeforeSerializeDeserialize->historyItemVector.result == itemAfterSerializeDeserialize->historyItemVector.result)
-                && (itemBeforeSerializeDeserialize->historyItemVector.spCommands == itemAfterSerializeDeserialize->historyItemVector.spCommands)
-                && (itemBeforeSerializeDeserialize->historyItemVector.spTokens == itemAfterSerializeDeserialize->historyItemVector.spTokens));
+                (itemBeforeSerializeDeserialize->Expression == itemAfterSerializeDeserialize->Expression)
+                && (itemBeforeSerializeDeserialize->Result == itemAfterSerializeDeserialize->Result)
+                //                && (itemBeforeSerializeDeserialize->historyItemVector.spCommands ==
+                //                itemAfterSerializeDeserialize->historyItemVector.spCommands)
+                //              && (itemBeforeSerializeDeserialize->historyItemVector.spTokens == itemAfterSerializeDeserialize->historyItemVector.spTokens)
+            );
             Cleanup();
         }
 
         void SaveAndReloadHistory()
         {
             Initialize();
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command8);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command6);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command8));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command2));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeBasic));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command6));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             int itemsBeforeSaveAndReload = m_historyViewModel->ItemSize;
             m_historyViewModel->SaveHistory();
             m_historyViewModel->ReloadHistory(ViewMode::Scientific);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
             wstring expr = L"1   +   8 =";
             // add double quotes around the expression
             expr = UtfUtils::LRO + expr + UtfUtils::PDF;
             String ^ result = StringReference(L"9");
             int itemsAfterSaveAndReload = m_historyViewModel->ItemSize;
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
 
-            VERIFY_ARE_EQUAL(expr, historyItem->historyItemVector.expression);
-            VERIFY_ARE_EQUAL(result, StringReference(historyItem->historyItemVector.result.c_str()));
+            auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1));
+            VERIFY_ARE_EQUAL(historyItem->Expression, StringReference(expr.c_str()));
+            VERIFY_ARE_EQUAL(historyItem->Result, result);
             VERIFY_ARE_NOT_EQUAL(itemsBeforeSaveAndReload, itemsAfterSaveAndReload);
             VERIFY_ARE_EQUAL(itemsBeforeSaveAndReload, itemsAfterSaveAndReload + 1);
             Cleanup();
@@ -275,21 +266,21 @@ namespace CalculatorFunctionalTests
             ResourceLoader ^ m_uiResourceLoader = ResourceLoader::GetForViewIndependentUse(L"CEngineStrings");
             int itemIndex = 0;
             int commandResource = 67;
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
             for (int index = 0; index < modes; index++)
             {
-                m_standardViewModel->m_standardCalculatorManager.SendCommand(mode[index]);
+                m_standardViewModel->SendCommandToCalcManager((int)mode[index]);
                 for (int command = 0; command < commandsSize; command++)
                 {
-                    m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-                    m_standardViewModel->m_standardCalculatorManager.SendCommand(commands[command]);
-                    m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
-                    auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(itemIndex);
+                    m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+                    m_standardViewModel->SendCommandToCalcManager(static_cast<int>(commands[command]));
+                    m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
+                    auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1 - itemIndex));
                     String ^ expression = m_uiResourceLoader->GetString(commandResource.ToString());
                     expression += L"( 1 ) =";
                     wstring expr = wstring(expression->Data());
                     expr = UtfUtils::LRO + expr + UtfUtils::PDF;
-                    VERIFY_ARE_EQUAL(historyItem->historyItemVector.expression, expr);
+                    VERIFY_ARE_EQUAL(historyItem->Expression, StringReference(expr.c_str()));
                     commandResource++;
                     itemIndex++;
                 }
@@ -301,20 +292,20 @@ namespace CalculatorFunctionalTests
         {
             Initialize();
             ResourceLoader ^ m_uiResourceLoader = ResourceLoader::GetForViewIndependentUse(L"CEngineStrings");
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandDEG);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandSIN);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandRAD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandSIN);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandGRAD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandSIN);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandDEG));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandSIN));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandRAD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandSIN));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandGRAD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandSIN));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
+            auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1));
             String ^ expression = m_uiResourceLoader->GetString(L"67");
             expression += L"( 1 )   +   ";
             expression += m_uiResourceLoader->GetString(L"73");
@@ -323,7 +314,7 @@ namespace CalculatorFunctionalTests
             expression += L"( 1 ) =";
             wstring expr = wstring(expression->Data());
             expr = UtfUtils::LRO + expr + UtfUtils::PDF;
-            VERIFY_ARE_EQUAL(historyItem->historyItemVector.expression, expr);
+            VERIFY_ARE_EQUAL(historyItem->Expression, StringReference(expr.c_str()));
 
             Cleanup();
         }
@@ -331,19 +322,15 @@ namespace CalculatorFunctionalTests
         void HistoryItemClicked()
         {
             Initialize();
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command3);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
-            String ^ expression = StringReference(historyItem->historyItemVector.expression.c_str());
-            String ^ result = StringReference(historyItem->historyItemVector.result.c_str());
-            HistoryItemViewModel ^ item =
-                ref new HistoryItemViewModel(expression, result, historyItem->historyItemVector.spTokens, historyItem->historyItemVector.spCommands);
-            MockOnHistoryItemClicked(item);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command5));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command3));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
+            auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1));
+            m_standardViewModel->SelectHistoryItem(historyItem);
             VERIFY_ARE_EQUAL(StringReference(L"9"), m_standardViewModel->DisplayValue);
             VERIFY_ARE_EQUAL(StringReference(L"1"), m_standardViewModel->ExpressionTokens->GetAt(0)->Token);
             VERIFY_ARE_EQUAL(StringReference(L" "), m_standardViewModel->ExpressionTokens->GetAt(1)->Token);
@@ -359,37 +346,27 @@ namespace CalculatorFunctionalTests
         void HistoryItemLoadAndContinueCalculation()
         {
             Initialize();
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeBasic);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command3);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeBasic));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command5));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command3));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
 
-            auto historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
-            String ^ expression = StringReference(historyItem->historyItemVector.expression.c_str());
-            String ^ result = StringReference(historyItem->historyItemVector.result.c_str());
-            HistoryItemViewModel ^ item =
-                ref new HistoryItemViewModel(expression, result, historyItem->historyItemVector.spTokens, historyItem->historyItemVector.spCommands);
-            MockOnHistoryItemClicked(item);
+            auto historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1));
+            m_standardViewModel->SelectHistoryItem(historyItem);
 
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command5));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             VERIFY_ARE_EQUAL(StringReference(L"14"), m_standardViewModel->DisplayValue);
-            historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(0);
-            expression = StringReference(historyItem->historyItemVector.expression.c_str());
-            result = StringReference(historyItem->historyItemVector.result.c_str());
-            item = ref new HistoryItemViewModel(expression, result, historyItem->historyItemVector.spTokens, historyItem->historyItemVector.spCommands);
-            MockOnHistoryItemClicked(item);
+            historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 1));
+            m_standardViewModel->SelectHistoryItem(historyItem);
             VERIFY_ARE_EQUAL(StringReference(L"9"), m_standardViewModel->DisplayValue);
 
-            historyItem = m_standardViewModel->m_standardCalculatorManager.GetHistoryItem(1);
-            expression = StringReference(historyItem->historyItemVector.expression.c_str());
-            result = StringReference(historyItem->historyItemVector.result.c_str());
-            item = ref new HistoryItemViewModel(expression, result, historyItem->historyItemVector.spTokens, historyItem->historyItemVector.spCommands);
-            MockOnHistoryItemClicked(item);
+            historyItem = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(m_historyViewModel->ItemSize - 2));
+            m_standardViewModel->SelectHistoryItem(historyItem);
             VERIFY_ARE_EQUAL(StringReference(L"14"), m_standardViewModel->DisplayValue);
             Cleanup();
         }
@@ -397,26 +374,26 @@ namespace CalculatorFunctionalTests
         void DisplayValueAutomationNames()
         {
             Initialize();
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command8);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command8));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             String ^ expression = StringReference(L"Display is 9");
             VERIFY_ARE_EQUAL(expression, m_standardViewModel->CalculationResultAutomationName);
 
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command5);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command5));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             expression = StringReference(L"Display is 6");
             VERIFY_ARE_EQUAL(expression, m_standardViewModel->CalculationResultAutomationName);
 
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeProgrammer);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command2);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeProgrammer));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command2));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             expression = StringReference(L"Display is 3");
             VERIFY_ARE_EQUAL(expression, m_standardViewModel->CalculationResultAutomationName);
 
@@ -426,20 +403,20 @@ namespace CalculatorFunctionalTests
         void RadixAutomationName()
         {
             Initialize();
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeProgrammer);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeProgrammer));
             m_standardViewModel->IsProgrammer = true;
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command1);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandADD);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::Command7);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command1));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandADD));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::Command7));
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             String ^ expression = L"HexaDecimal" + L" 8";
-            String ^ result = L"HexaDecimal " + Utils::GetStringValue(m_standardViewModel->HexDisplayValue);
+            String ^ result = L"HexaDecimal " + GetStringValue(m_standardViewModel->HexDisplayValue);
             VERIFY_ARE_EQUAL(expression, result);
             expression = StringReference(L"Octal 10");
-            result = L"Octal " + Utils::GetStringValue(m_standardViewModel->OctalDisplayValue);
+            result = L"Octal " + GetStringValue(m_standardViewModel->OctalDisplayValue);
             VERIFY_ARE_EQUAL(expression, result);
             expression = StringReference(L"Binary 1000");
-            result = L"Binary " + Utils::GetStringValue(m_standardViewModel->BinaryDisplayValue);
+            result = L"Binary " + GetStringValue(m_standardViewModel->BinaryDisplayValue);
             VERIFY_ARE_EQUAL(expression, result);
             Cleanup();
         }
@@ -448,7 +425,7 @@ namespace CalculatorFunctionalTests
         {
             Initialize();
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
             Cleanup();
         }
@@ -457,7 +434,7 @@ namespace CalculatorFunctionalTests
         {
             Initialize();
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
-            m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::ModeScientific);
+            m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::ModeScientific));
             m_historyViewModel->OnClearCommand(nullptr);
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
             Cleanup();

--- a/src/CalculatorUnitTests/HistoryTests.cpp
+++ b/src/CalculatorUnitTests/HistoryTests.cpp
@@ -211,12 +211,8 @@ namespace CalculatorFunctionalTests
             m_historyViewModel->ReloadHistory(ViewMode::Scientific);
             auto itemAfterSerializeDeserialize = static_cast<HistoryItemViewModel ^>(m_historyViewModel->Items->GetAt(0));
             VERIFY_IS_TRUE(
-                (itemBeforeSerializeDeserialize->Expression == itemAfterSerializeDeserialize->Expression)
-                && (itemBeforeSerializeDeserialize->Result == itemAfterSerializeDeserialize->Result)
-                //                && (itemBeforeSerializeDeserialize->historyItemVector.spCommands ==
-                //                itemAfterSerializeDeserialize->historyItemVector.spCommands)
-                //              && (itemBeforeSerializeDeserialize->historyItemVector.spTokens == itemAfterSerializeDeserialize->historyItemVector.spTokens)
-            );
+                itemBeforeSerializeDeserialize->Expression == itemAfterSerializeDeserialize->Expression
+                && itemBeforeSerializeDeserialize->Result == itemAfterSerializeDeserialize->Result);
             Cleanup();
         }
 

--- a/src/CalculatorUnitTests/MultiWindowUnitTests.cpp
+++ b/src/CalculatorUnitTests/MultiWindowUnitTests.cpp
@@ -369,7 +369,7 @@ TEST_METHOD(MultipleModesHistoryAddItemTest)
         ChangeMode(viewModels[i], i);
 
         // Validate that the history items list is initially empty
-        VERIFY_IS_TRUE(0 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
+        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemSize);
     }
 
     // Perform Calculations on both the instances and check that the History items work independently
@@ -390,24 +390,24 @@ TEST_METHOD(MultipleModesHistoryAddItemTest)
     ValidateViewModelByCommands(viewModels[1], scientificModeTestItems, true);
 
     // Assert for the history list items of 1st instance
-    VERIFY_IS_TRUE(1 == viewModels[0]->m_standardCalculatorManager.GetHistoryItems().size());
+    VERIFY_IS_TRUE(1 == viewModels[0]->HistoryVM->ItemSize);
 
-    auto item1 = viewModels[0]->m_standardCalculatorManager.GetHistoryItem(0);
+    auto item1 = static_cast<HistoryItemViewModel^>(viewModels[0]->HistoryVM->Items->GetAt(0));
     String ^ expression1 = UtfUtils::LRO + L"1   +   2 =" + UtfUtils::PDF;
     String ^ result1 = L"3";
 
-    VERIFY_ARE_EQUAL(expression1, StringReference(item1->historyItemVector.expression.c_str()));
-    VERIFY_ARE_EQUAL(result1, StringReference(item1->historyItemVector.result.c_str()));
+    VERIFY_ARE_EQUAL(expression1, item1->Expression);
+    VERIFY_ARE_EQUAL(result1, item1->Result);
 
     // Assert for the history list items of 2nd instance
-    VERIFY_IS_TRUE(1 == viewModels[1]->m_standardCalculatorManager.GetHistoryItems().size());
+    VERIFY_IS_TRUE(1 == viewModels[1]->HistoryVM->ItemSize);
 
-    auto item2 = viewModels[1]->m_standardCalculatorManager.GetHistoryItem(0);
+    auto item2 = static_cast<HistoryItemViewModel^>(viewModels[1]->HistoryVM->Items->GetAt(0));
     String ^ expression2 = UtfUtils::LRO + L"1   +   2   " + UtfUtils::MUL + L"   3 =" + UtfUtils::PDF;
     String ^ result2 = L"7";
 
-    VERIFY_ARE_EQUAL(expression2, StringReference(item2->historyItemVector.expression.c_str()));
-    VERIFY_ARE_EQUAL(result2, StringReference(item2->historyItemVector.result.c_str()));
+    VERIFY_ARE_EQUAL(expression2, item2->Expression);
+    VERIFY_ARE_EQUAL(result2, item2->Result);
 }
 
 // Perform calculations on 2 separate instances of Standard Modes and verify that their History list items are maintained separately
@@ -424,7 +424,7 @@ TEST_METHOD(MultipleStandardModesHistoryAddItemTest)
         ChangeMode(viewModels[i], 0);
 
         // Validate that the history items list is initially empty
-        VERIFY_IS_TRUE(0 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
+        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemSize);
     }
 
     // Perform Calculations on both the instances and check that the History items work independently
@@ -457,12 +457,12 @@ TEST_METHOD(MultipleStandardModesHistoryAddItemTest)
     // Assert for the history list items of the instances
     for (int i = 0; i < 2; i++)
     {
-        VERIFY_IS_TRUE(1 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
+        VERIFY_IS_TRUE(1 == viewModels[i]->HistoryVM->ItemSize);
 
-        auto item = viewModels[i]->m_standardCalculatorManager.GetHistoryItem(0);
+        auto item = static_cast<HistoryItemViewModel ^>(viewModels[i]->HistoryVM->Items->GetAt(0));
 
-        VERIFY_ARE_EQUAL(expression[i], StringReference(item->historyItemVector.expression.c_str()));
-        VERIFY_ARE_EQUAL(result[i], StringReference(item->historyItemVector.result.c_str()));
+        VERIFY_ARE_EQUAL(expression[i], item->Expression);
+        VERIFY_ARE_EQUAL(result[i], item->Result);
     }
 }
 
@@ -480,7 +480,7 @@ TEST_METHOD(MultipleScientificModesHistoryAddItemTest)
         ChangeMode(viewModels[i], 1);
 
         // Validate that the history items list is initially empty
-        VERIFY_IS_TRUE(0 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
+        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemSize);
     }
 
     // Perform Calculations on both the instances and check that the History items work independently
@@ -513,12 +513,12 @@ TEST_METHOD(MultipleScientificModesHistoryAddItemTest)
     // Assert for the history list items of the instances
     for (int i = 0; i < 2; i++)
     {
-        VERIFY_IS_TRUE(1 == viewModels[i]->m_standardCalculatorManager.GetHistoryItems().size());
+        VERIFY_IS_TRUE(1 == viewModels[i]->HistoryVM->ItemSize);
 
-        auto item = viewModels[i]->m_standardCalculatorManager.GetHistoryItem(0);
+        auto item = static_cast<HistoryItemViewModel^>(viewModels[i]->HistoryVM->Items->GetAt(0));
 
-        VERIFY_ARE_EQUAL(expression[i], StringReference(item->historyItemVector.expression.c_str()));
-        VERIFY_ARE_EQUAL(result[i], StringReference(item->historyItemVector.result.c_str()));
+        VERIFY_ARE_EQUAL(expression[i], item->Expression);
+        VERIFY_ARE_EQUAL(result[i], item->Result);
     }
 }
 

--- a/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
@@ -9,6 +9,7 @@
 
 #include "CalcViewModel/StandardCalculatorViewModel.h"
 #include "CalcViewModel/Common/CalculatorButtonPressedEventArgs.h"
+#include "Helpers.h"
 
 using namespace CalculationManager;
 using namespace CalculatorApp;
@@ -494,10 +495,10 @@ namespace CalculatorUnitTests
                                  { NumbersAndOperatorsEnum::F, L"F", L"" },
                                  { NumbersAndOperatorsEnum::None, L"", L"" } };
             ValidateViewModelByCommands(m_viewModel, items, false);
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->HexDisplayValue), StringReference(L"F"));
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->DecimalDisplayValue), StringReference(L"15"));
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->OctalDisplayValue), StringReference(L"17"));
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->BinaryDisplayValue), StringReference(L"1111"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->HexDisplayValue), StringReference(L"F"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->DecimalDisplayValue), StringReference(L"15"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->OctalDisplayValue), StringReference(L"17"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->BinaryDisplayValue), StringReference(L"1111"));
             auto val = ref new Platform::Collections::Vector<bool>(64, false);
             val->SetAt(0, true);
             val->SetAt(1, true);
@@ -547,10 +548,10 @@ namespace CalculatorUnitTests
                 { NumbersAndOperatorsEnum::None, L"1", L"" },
             };
             ValidateViewModelByCommands(m_viewModel, items, true);
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->HexDisplayValue), StringReference(L"75B CD15"));
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->DecimalDisplayValue), StringReference(L"123,456,789"));
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->OctalDisplayValue), StringReference(L"726 746 425"));
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->BinaryDisplayValue), StringReference(L"0111 0101 1011 1100 1101 0001 0101"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->HexDisplayValue), StringReference(L"75B CD15"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->DecimalDisplayValue), StringReference(L"123,456,789"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->OctalDisplayValue), StringReference(L"726 746 425"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->BinaryDisplayValue), StringReference(L"0111 0101 1011 1100 1101 0001 0101"));
             auto val = ref new Platform::Collections::Vector<bool>(64, false);
             val->SetAt(0, true);
             val->SetAt(2, true);
@@ -581,11 +582,11 @@ namespace CalculatorUnitTests
                                  { NumbersAndOperatorsEnum::Not, L"-2", L"~(1)" },
                                  { NumbersAndOperatorsEnum::None, L"N/A", L"N/A" } };
             ValidateViewModelByCommands(m_viewModel, items, false);
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->HexDisplayValue), StringReference(L"FFFF FFFF FFFF FFFE"));
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->DecimalDisplayValue), StringReference(L"-2"));
-            VERIFY_ARE_EQUAL(Utils::GetStringValue(m_viewModel->OctalDisplayValue), StringReference(L"1 777 777 777 777 777 777 776"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->HexDisplayValue), StringReference(L"FFFF FFFF FFFF FFFE"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->DecimalDisplayValue), StringReference(L"-2"));
+            VERIFY_ARE_EQUAL(GetStringValue(m_viewModel->OctalDisplayValue), StringReference(L"1 777 777 777 777 777 777 776"));
             VERIFY_ARE_EQUAL(
-                Utils::GetStringValue(m_viewModel->BinaryDisplayValue),
+                GetStringValue(m_viewModel->BinaryDisplayValue),
                 StringReference(L"1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1111 1110"));
             VERIFY_ARE_EQUAL(m_viewModel->DisplayValue, StringReference(L"-2"));
             auto val = ref new Platform::Collections::Vector<bool>(64, true);
@@ -775,13 +776,13 @@ namespace CalculatorUnitTests
             m_viewModel->OnMemoryItemPressed(ref new Platform::Box<int>(0));
             VERIFY_ARE_EQUAL(Platform::StringReference(L"-1,001"), m_viewModel->DisplayValue);
             MemoryItemViewModel ^ memorySlotStandard = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"-1,001"), Utils::GetStringValue(memorySlotStandard->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"-1,001"), GetStringValue(memorySlotStandard->Value));
             ChangeMode(m_viewModel, 1 /*scientific*/);
             MemoryItemViewModel ^ memorySlotScientific = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"-1,001"), Utils::GetStringValue(memorySlotScientific->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"-1,001"), GetStringValue(memorySlotScientific->Value));
             ChangeMode(m_viewModel, 2 /*Programmer*/);
             MemoryItemViewModel ^ memorySlotProgrammer = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"-1,001"), Utils::GetStringValue(memorySlotProgrammer->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"-1,001"), GetStringValue(memorySlotProgrammer->Value));
         }
 
         // When decimal number is saved in memory
@@ -799,13 +800,13 @@ namespace CalculatorUnitTests
             m_viewModel->OnMemoryItemPressed(ref new Platform::Box<int>(0));
             VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001.1"), m_viewModel->DisplayValue);
             MemoryItemViewModel ^ memorySlotStandard = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001.1"), Utils::GetStringValue(memorySlotStandard->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001.1"), GetStringValue(memorySlotStandard->Value));
             ChangeMode(m_viewModel, 1 /*Scientific*/);
             MemoryItemViewModel ^ memorySlotScientific = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001.1"), Utils::GetStringValue(memorySlotScientific->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001.1"), GetStringValue(memorySlotScientific->Value));
             ChangeMode(m_viewModel, 2 /*Programmer*/);
             MemoryItemViewModel ^ memorySlotProgrammer = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001"), Utils::GetStringValue(memorySlotProgrammer->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001"), GetStringValue(memorySlotProgrammer->Value));
         }
 
         // When negative decimal number is saved in memory
@@ -864,7 +865,7 @@ namespace CalculatorUnitTests
             m_viewModel->OnMemoryItemPressed(ref new Box<int>(0));
             VERIFY_ARE_EQUAL(Platform::StringReference(L"255"), m_viewModel->DisplayValue);
             MemoryItemViewModel ^ memorySlot = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"255"), Utils::GetStringValue(memorySlot->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"255"), GetStringValue(memorySlot->Value));
         }
 
         TEST_METHOD(OnMemorySavedInHexRadixAndRadixChanges)
@@ -880,13 +881,13 @@ namespace CalculatorUnitTests
             m_viewModel->OnMemoryButtonPressed();
             m_viewModel->SwitchProgrammerModeBase(NumberBase::OctBase);
             MemoryItemViewModel ^ memorySlotOct = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"377"), Utils::GetStringValue(memorySlotOct->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"377"), GetStringValue(memorySlotOct->Value));
             m_viewModel->SwitchProgrammerModeBase(NumberBase::DecBase);
             MemoryItemViewModel ^ memorySlotDec = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"255"), Utils::GetStringValue(memorySlotDec->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"255"), GetStringValue(memorySlotDec->Value));
             m_viewModel->SwitchProgrammerModeBase(NumberBase::BinBase);
             MemoryItemViewModel ^ memorySlotBin = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"1111 1111"), Utils::GetStringValue(memorySlotBin->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"1111 1111"), GetStringValue(memorySlotBin->Value));
         }
 
         // When memory button is pressed more than max number of slots allowed,
@@ -965,7 +966,7 @@ namespace CalculatorUnitTests
             m_viewModel->OnMemoryItemPressed(1);
             m_viewModel->OnMemoryAdd(ref new Platform::Box<int>(0));
             MemoryItemViewModel ^ memorySlot = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
-            VERIFY_ARE_EQUAL(Platform::StringReference(L"3,003"), Utils::GetStringValue(memorySlot->Value));
+            VERIFY_ARE_EQUAL(Platform::StringReference(L"3,003"), GetStringValue(memorySlot->Value));
         }
 
         // Verify that raw, unformatted numbers are provided correctly


### PR DESCRIPTION
## Fixes #783 

### Description of the changes:
- Modify HistoryTest.cpp to use `HistoryViewModel` instead of `CalculatorHistory`. in order to test the full stack and not only the CalcManager part.
   - ⚠ one of the big difference is how the history items collection is ordered.

Also:
- Expose some methods from CalcManager (a native library) via StandardCalcViewModel, making them accessible from another windows runtime library.
- make PropertyNames public instead of internal so other (dynamic) libraries can use them.
- move `Utils::GetStringValue` from CalcViewModel to CalculatorUnitTests

### How changes were validated:
- Manually

