### PR TITLE
Fix focus for EquationTextBox

### DIFF
--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -144,7 +144,7 @@ void EquationTextBox::OnRichEditBoxTextChanged(Object ^ sender, RoutedEventArgs 
 
 void EquationTextBox::OnRichEditBoxGotFocus(Object ^ sender, RoutedEventArgs ^ e)
 {
-    m_isFocused = true;
+    m_HasFocus = true;
     UpdateCommonVisualState();
     UpdateDeleteButtonVisualState();
 }
@@ -153,7 +153,7 @@ void EquationTextBox::OnRichEditBoxLostFocus(Object ^ sender, RoutedEventArgs ^ 
 {
     if (!m_richEditBox->ContextFlyout->IsOpen)
     {
-        m_isFocused = false;
+        m_HasFocus = false;
     }
     UpdateCommonVisualState();
     UpdateDeleteButtonVisualState();
@@ -212,7 +212,7 @@ void EquationTextBox::UpdateCommonVisualState()
 {
     String ^ state = "Normal";
 
-    if (m_isFocused)
+    if (m_HasFocus)
     {
         state = "Focused";
     }
@@ -261,5 +261,5 @@ bool EquationTextBox::ShouldDeleteButtonBeVisible()
     {
         m_richEditBox->TextDocument->GetMath(&text);
     }
-    return (!text->IsEmpty() && m_isFocused);
+    return (!text->IsEmpty() && m_HasFocus);
 }

--- a/src/Calculator/Controls/EquationTextBox.h
+++ b/src/Calculator/Controls/EquationTextBox.h
@@ -22,6 +22,8 @@ namespace CalculatorApp
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::UIElement^, KeyGraphFeaturesContent);
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Controls::Flyout^, ColorChooserFlyout);
 
+            PROPERTY_R(bool, HasFocus);
+
             event Windows::UI::Xaml::RoutedEventHandler ^ RemoveButtonClicked;
             event Windows::UI::Xaml::RoutedEventHandler ^ EquationSubmitted;
 
@@ -45,7 +47,6 @@ namespace CalculatorApp
             void OnRichEditBoxLoaded(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
             void OnRichEditBoxGotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
             void OnRichEditBoxLostFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-            void OnRichEditBoxLosingFocus(Windows::UI::Xaml::UIElement ^ sender, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ e);
             void OnRichEditBoxTextChanged(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
 
             void OnDeleteButtonClicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
@@ -64,7 +65,6 @@ namespace CalculatorApp
             Windows::UI::Xaml::Controls::Button^ m_functionButton;
             Windows::UI::Xaml::Controls::Primitives::ToggleButton^ m_colorChooserButton;
 
-            bool m_isFocused;
             bool m_isPointerOver;
             bool m_isColorChooserFlyoutOpen;
         };

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -84,7 +84,11 @@ void EquationInputArea::InputTextBox_Submitted(Object ^ sender, RoutedEventArgs 
     auto tb = static_cast<EquationTextBox ^>(sender);
     auto eq = static_cast<EquationViewModel ^>(tb->DataContext);
     eq->Expression = tb->GetEquationText();
-    FocusManager::TryMoveFocus(::FocusNavigationDirection::Left);
+
+    if (tb->HasFocus)
+    {
+        FocusManager::TryMoveFocus(::FocusNavigationDirection::Left);
+    }
 }
 
 void EquationInputArea::EquationTextBox_RemoveButtonClicked(Object ^ sender, RoutedEventArgs ^ e)


### PR DESCRIPTION
## Part of #338

### Description of the changes:
- After submitting an equation with the enter key we should move focus away from the EquationTextBox . Previously this would happen anytime the equation was submitted, now it only occurs if it was submitted and the EquationTextBox has focus, allowing the user to tab away to submit and keep focus flowing to the next element as normal.

### How changes were validated:
- Manual tests
