### PR TITLE
Use only NumberBase to represent radix in CalcViewModel

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -79,7 +79,7 @@ StandardCalculatorViewModel::StandardCalculatorViewModel()
     , m_valueBitLength(BitLength::BitLengthQWord)
     , m_isBitFlipChecked(false)
     , m_isBinaryBitFlippingEnabled(false)
-    , m_CurrentRadixType(RADIX_TYPE::DEC_RADIX)
+    , m_CurrentRadixType(NumberBase::DecBase)
     , m_CurrentAngleType(NumbersAndOperatorsEnum::Degree)
     , m_Announcement(nullptr)
     , m_OpenParenthesisCount(0)
@@ -168,7 +168,7 @@ String ^ StandardCalculatorViewModel::CalculateNarratorDisplayValue(_In_ wstring
     }
 
     // In Programmer modes using non-base10, we want the strings to be read as literal digits.
-    if (IsProgrammer && CurrentRadixType != RADIX_TYPE::DEC_RADIX)
+    if (IsProgrammer && CurrentRadixType != NumberBase::DecBase)
     {
         localizedValue = GetNarratorStringReadRawNumbers(localizedValue);
     }
@@ -681,23 +681,18 @@ void StandardCalculatorViewModel::OnButtonPressed(Object ^ parameter)
     }
 }
 
-NumberBase StandardCalculatorViewModel::GetNumberBase()
+RADIX_TYPE StandardCalculatorViewModel::GetRadixTypeFromNumberBase(NumberBase base)
 {
-    if (CurrentRadixType == HEX_RADIX)
+    switch (base)
     {
-        return NumberBase::HexBase;
-    }
-    else if (CurrentRadixType == DEC_RADIX)
-    {
-        return NumberBase::DecBase;
-    }
-    else if (CurrentRadixType == OCT_RADIX)
-    {
-        return NumberBase::OctBase;
-    }
-    else
-    {
-        return NumberBase::BinBase;
+    case NumberBase::BinBase:
+        return RADIX_TYPE::BIN_RADIX;
+    case NumberBase::HexBase:
+        return RADIX_TYPE::HEX_RADIX;
+    case NumberBase::OctBase:
+        return RADIX_TYPE::OCT_RADIX;
+    default:
+        return RADIX_TYPE::DEC_RADIX;
     }
 }
 
@@ -713,8 +708,8 @@ void StandardCalculatorViewModel::OnPasteCommand(Object ^ parameter)
 {
     auto that(this);
     ViewMode mode;
-    NumberBase numberBase = NumberBase::Unknown;
     BitLength bitLengthType = BitLength::BitLengthUnknown;
+    NumberBase numberBase = NumberBase::Unknown;
     if (IsScientific)
     {
         mode = ViewMode::Scientific;
@@ -722,8 +717,8 @@ void StandardCalculatorViewModel::OnPasteCommand(Object ^ parameter)
     else if (IsProgrammer)
     {
         mode = ViewMode::Programmer;
-        numberBase = GetNumberBase();
         bitLengthType = m_valueBitLength;
+        numberBase = CurrentRadixType;
     }
     else
     {
@@ -1248,7 +1243,7 @@ String ^ StandardCalculatorViewModel::GetLocalizedStringFormat(String ^ format, 
 void StandardCalculatorViewModel::ResetDisplay()
 {
     AreHEXButtonsEnabled = false;
-    CurrentRadixType = (int)RADIX_TYPE::DEC_RADIX;
+    CurrentRadixType = NumberBase::DecBase;
     m_standardCalculatorManager.SetRadix(DEC_RADIX);
 }
 
@@ -1257,16 +1252,16 @@ void StandardCalculatorViewModel::SetPrecision(int32_t precision)
     m_standardCalculatorManager.SetPrecision(precision);
 }
 
-void StandardCalculatorViewModel::SwitchProgrammerModeBase(RADIX_TYPE radixType)
+void StandardCalculatorViewModel::SwitchProgrammerModeBase(NumberBase numberBase)
 {
     if (IsInError)
     {
         m_standardCalculatorManager.SendCommand(Command::CommandCLEAR);
     }
 
-    AreHEXButtonsEnabled = (radixType == RADIX_TYPE::HEX_RADIX);
-    CurrentRadixType = (int)radixType;
-    m_standardCalculatorManager.SetRadix(radixType);
+    AreHEXButtonsEnabled = numberBase == NumberBase::HexBase;
+    CurrentRadixType = numberBase;
+    m_standardCalculatorManager.SetRadix(GetRadixTypeFromNumberBase(numberBase));
 }
 
 void StandardCalculatorViewModel::SetMemorizedNumbersString()

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -40,7 +40,6 @@ namespace CalculatorApp
             StandardCalculatorViewModel();
             void UpdateOperand(int pos, Platform::String ^ text);
             void UpdatecommandsInRecordingMode();
-            CalculatorApp::Common::NumberBase GetNumberBase();
 
             OBSERVABLE_OBJECT_CALLBACK(OnPropertyChanged);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, DisplayValue);
@@ -71,7 +70,7 @@ namespace CalculatorApp
             OBSERVABLE_PROPERTY_RW(Platform::String ^, CalculationResultAutomationName);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, CalculationExpressionAutomationName);
             OBSERVABLE_PROPERTY_RW(bool, IsShiftProgrammerChecked);
-            OBSERVABLE_PROPERTY_RW(int, CurrentRadixType);
+            OBSERVABLE_PROPERTY_RW(CalculatorApp::Common::NumberBase, CurrentRadixType);
             OBSERVABLE_PROPERTY_RW(bool, AreTokensUpdated);
             OBSERVABLE_PROPERTY_RW(bool, AreAlwaysOnTopResultsUpdated);
             OBSERVABLE_PROPERTY_RW(bool, AreHistoryShortcutsEnabled);
@@ -358,14 +357,11 @@ namespace CalculatorApp
             void Recalculate(bool fromHistory = false);
             bool IsOperator(CalculationManager::Command cmdenum);
             void FtoEButtonToggled();
-            void SwitchProgrammerModeBase(RADIX_TYPE calculatorBase);
+            void SwitchProgrammerModeBase(CalculatorApp::Common::NumberBase calculatorBase);
             void SetMemorizedNumbersString();
             void SwitchAngleType(NumbersAndOperatorsEnum num);
             void ResetDisplay();
-            RADIX_TYPE GetCurrentRadixType()
-            {
-                return (RADIX_TYPE)m_CurrentRadixType;
-            }
+          
             void SetPrecision(int32_t precision);
             void UpdateMaxIntDigits()
             {
@@ -389,6 +385,7 @@ namespace CalculatorApp
                 _Inout_ std::shared_ptr<std::vector<std::shared_ptr<IExpressionCommand>>> const& commands);
             void SetTokens(_Inout_ std::shared_ptr<std::vector<std::pair<std::wstring, int>>> const& tokens);
             NumbersAndOperatorsEnum ConvertIntegerToNumbersAndOperatorsEnum(unsigned int parameter);
+            static RADIX_TYPE GetRadixTypeFromNumberBase(CalculatorApp::Common::NumberBase base);
             NumbersAndOperatorsEnum m_CurrentAngleType;
             wchar_t m_decimalSeparator;
             CalculatorDisplay m_calculatorDisplay;

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -368,7 +368,7 @@ void Calculator::EnsureProgrammer()
     }
 
     OpsPanel->EnsureProgrammerRadixOps();
-    ProgrammerOperators->SetRadixButton(Model->GetCurrentRadixType());
+    ProgrammerOperators->SetRadixButton(Model->CurrentRadixType);
 }
 
 void Calculator::OnCalcPropertyChanged(_In_ Object ^ sender, _In_ PropertyChangedEventArgs ^ e)

--- a/src/Calculator/Views/CalculatorProgrammerOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerOperators.xaml.cpp
@@ -41,7 +41,7 @@ void CalculatorProgrammerOperators::HexButtonChecked(_In_ Object ^ sender, _In_ 
     TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::HexButton, ViewMode::Programmer);
     if (Model)
     {
-        Model->SwitchProgrammerModeBase(RADIX_TYPE::HEX_RADIX);
+        Model->SwitchProgrammerModeBase(NumberBase::HexBase);
     }
 }
 
@@ -50,7 +50,7 @@ void CalculatorProgrammerOperators::DecButtonChecked(_In_ Object ^ sender, _In_ 
     TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::DecButton, ViewMode::Programmer);
     if (Model)
     {
-        Model->SwitchProgrammerModeBase(RADIX_TYPE::DEC_RADIX);
+        Model->SwitchProgrammerModeBase(NumberBase::DecBase);
     }
 }
 
@@ -59,7 +59,7 @@ void CalculatorProgrammerOperators::OctButtonChecked(_In_ Object ^ sender, _In_ 
     TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::OctButton, ViewMode::Programmer);
     if (Model)
     {
-        Model->SwitchProgrammerModeBase(RADIX_TYPE::OCT_RADIX);
+        Model->SwitchProgrammerModeBase(NumberBase::OctBase);
     }
 }
 
@@ -68,30 +68,30 @@ void CalculatorProgrammerOperators::BinButtonChecked(_In_ Object ^ sender, _In_ 
     TraceLogger::GetInstance()->UpdateButtonUsage(NumbersAndOperatorsEnum::BinButton, ViewMode::Programmer);
     if (Model)
     {
-        Model->SwitchProgrammerModeBase(RADIX_TYPE::BIN_RADIX);
+        Model->SwitchProgrammerModeBase(NumberBase::BinBase);
     }
 }
 
-void CalculatorProgrammerOperators::SetRadixButton(RADIX_TYPE radixType)
+void CalculatorProgrammerOperators::SetRadixButton(NumberBase numberBase)
 {
-    switch (radixType)
+    switch (numberBase)
     {
-    case RADIX_TYPE::DEC_RADIX:
+    case NumberBase::DecBase:
     {
         DecimalButton->IsChecked = true;
         break;
     }
-    case RADIX_TYPE::HEX_RADIX:
+    case NumberBase::HexBase:
     {
         HexButton->IsChecked = true;
         break;
     }
-    case RADIX_TYPE::OCT_RADIX:
+    case NumberBase::OctBase:
     {
         OctButton->IsChecked = true;
         break;
     }
-    case RADIX_TYPE::BIN_RADIX:
+    case NumberBase::BinBase:
     {
         BinaryButton->IsChecked = true;
         break;

--- a/src/Calculator/Views/CalculatorProgrammerOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorProgrammerOperators.xaml.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -6,6 +6,7 @@
 #include "Views/CalculatorProgrammerOperators.g.h"
 #include "Controls/RadixButton.h"
 #include "CalcViewModel/StandardCalculatorViewModel.h"
+#include "CalcViewModel/Common/NumberBase.h"
 
 namespace CalculatorApp
 {
@@ -24,7 +25,7 @@ namespace CalculatorApp
 
         DEPENDENCY_PROPERTY(_In_ Windows::UI::Xaml::Style ^, SymbolButtonStyle);
 
-        internal : void SetRadixButton(RADIX_TYPE radixType);
+        internal : void SetRadixButton(CalculatorApp::Common::NumberBase radixType);
 
     private:
         void DecButtonChecked(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);

--- a/src/Calculator/Views/NumberPad.xaml.cpp
+++ b/src/Calculator/Views/NumberPad.xaml.cpp
@@ -52,7 +52,7 @@ NumberPad::NumberPad()
     this->Num9Button->Content = localizationSettings.GetDigitSymbolFromEnUsDigit('9');
 }
 
-void NumberPad::OnCurrentRadixTypePropertyChanged(int /* oldValue */, int newValue)
+void NumberPad::OnCurrentRadixTypePropertyChanged(NumberBase /* oldValue */, NumberBase newValue)
 {
     Num0Button->IsEnabled = true;
     Num1Button->IsEnabled = true;
@@ -65,9 +65,7 @@ void NumberPad::OnCurrentRadixTypePropertyChanged(int /* oldValue */, int newVal
     Num8Button->IsEnabled = true;
     Num9Button->IsEnabled = true;
 
-    auto radixType = safe_cast<RADIX_TYPE>(newValue);
-
-    if (radixType == RADIX_TYPE::BIN_RADIX)
+    if (newValue == NumberBase::BinBase)
     {
         Num2Button->IsEnabled = false;
         Num3Button->IsEnabled = false;
@@ -78,7 +76,7 @@ void NumberPad::OnCurrentRadixTypePropertyChanged(int /* oldValue */, int newVal
         Num8Button->IsEnabled = false;
         Num9Button->IsEnabled = false;
     }
-    else if (radixType == RADIX_TYPE::OCT_RADIX)
+    else if (newValue == NumberBase::OctBase)
     {
         Num8Button->IsEnabled = false;
         Num9Button->IsEnabled = false;

--- a/src/Calculator/Views/NumberPad.xaml.h
+++ b/src/Calculator/Views/NumberPad.xaml.h
@@ -10,6 +10,7 @@
 
 #include "Views/NumberPad.g.h"
 #include "CalcViewModel/Common/KeyboardShortcutManager.h"
+#include "CalcViewModel/Common/NumberBase.h"
 #include "CalcManager/Header Files/RadixType.h"
 
 namespace CalculatorApp
@@ -21,7 +22,7 @@ namespace CalculatorApp
         DEPENDENCY_PROPERTY_OWNER(NumberPad);
 
         DEPENDENCY_PROPERTY(Windows::UI::Xaml::Style ^, ButtonStyle);
-        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(int, CurrentRadixType, safe_cast<int>(::RADIX_TYPE::DEC_RADIX));
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(CalculatorApp::Common::NumberBase, CurrentRadixType, CalculatorApp::Common::NumberBase::DecBase);
 
         property bool IsErrorVisualState
         {
@@ -30,7 +31,7 @@ namespace CalculatorApp
         }
 
     private:
-        void OnCurrentRadixTypePropertyChanged(int oldValue, int newValue);
+        void OnCurrentRadixTypePropertyChanged(CalculatorApp::Common::NumberBase oldValue, CalculatorApp::Common::NumberBase newValue);
 
 
         bool m_isErrorVisualState;

--- a/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
@@ -891,13 +891,13 @@ namespace CalculatorUnitTests
             };
             ValidateViewModelByCommands(m_viewModel, items, true);
             m_viewModel->OnMemoryButtonPressed();
-            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::OCT_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(NumberBase::OctBase);
             MemoryItemViewModel ^ memorySlotOct = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
             VERIFY_ARE_EQUAL(Platform::StringReference(L"377"), Utils::GetStringValue(memorySlotOct->Value));
-            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::DEC_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(NumberBase::DecBase);
             MemoryItemViewModel ^ memorySlotDec = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
             VERIFY_ARE_EQUAL(Platform::StringReference(L"255"), Utils::GetStringValue(memorySlotDec->Value));
-            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::BIN_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(NumberBase::BinBase);
             MemoryItemViewModel ^ memorySlotBin = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
             VERIFY_ARE_EQUAL(Platform::StringReference(L"1111 1111"), Utils::GetStringValue(memorySlotBin->Value));
         }


### PR DESCRIPTION
## Fixes #796 

### Description of the changes:
- simply replace RADIX_TYPE and int types used to represent radix by NumberBase 

### How changes were validated:
- manually

