### PR TITLE
Updating RemoveUnwantedCharsFromString to be a template

### DIFF
--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -423,9 +423,9 @@ CopyPasteManager::GetMaxOperandLengthAndValue(ViewMode mode, CategoryGroupType m
 
 Platform::String ^ CopyPasteManager::SanitizeOperand(Platform::String ^ operand)
 {
-    wchar_t unWantedChars[] = { L'\'', L'_', L'`', L'(', L')', L'-', L'+' };
+    constexpr wchar_t unWantedChars[] = { L'\'', L'_', L'`', L'(', L')', L'-', L'+' };
 
-    return ref new String(Utils::RemoveUnwantedCharsFromString(operand->Data(), unWantedChars, static_cast<int>(size(unWantedChars))).c_str());
+    return ref new String(Utils::RemoveUnwantedCharsFromString(operand->Data(), unWantedChars).c_str());
 }
 
 IBox<unsigned long long int> ^ CopyPasteManager::TryOperandToULL(String ^ operand, NumberBase numberBase)
@@ -596,8 +596,8 @@ ULONG32 CopyPasteManager::ProgrammerOperandLength(Platform::String ^ operand, Nu
 // euro(€) - 8364
 Platform::String ^ CopyPasteManager::RemoveUnwantedCharsFromString(Platform::String ^ input)
 {
-    wchar_t unWantedChars[] = { L' ', L',', L'"', 165, 164, 8373, 36, 8353, 8361, 8362, 8358, 8377, 163, 8364, 8234, 8235, 8236, 8237 };
-    return ref new String(Utils::RemoveUnwantedCharsFromString(input->Data(), unWantedChars, 18).c_str());
+    constexpr wchar_t unWantedChars[] = { L' ', L',', L'"', 165, 164, 8373, 36, 8353, 8361, 8362, 8358, 8377, 163, 8364, 8234, 8235, 8236, 8237 };
+    return ref new String(Utils::RemoveUnwantedCharsFromString(input->Data(), unWantedChars).c_str());
 }
 
 bool CopyPasteManager::IsErrorMessage(Platform::String ^ message)

--- a/src/CalcViewModel/Common/Utils.cpp
+++ b/src/CalcViewModel/Common/Utils.cpp
@@ -47,8 +47,8 @@ String ^ Utils::GetStringValue(String ^ input)
 
 double Utils::GetDoubleFromWstring(wstring input)
 {
-    wchar_t unWantedChars[] = { L' ', L',', 8234, 8235, 8236, 8237 };
-    wstring ws = RemoveUnwantedCharsFromString(input, unWantedChars, 6);
+    constexpr wchar_t unWantedChars[] = { L' ', L',', 8234, 8235, 8236, 8237 };
+    wstring ws = RemoveUnwantedCharsFromString(input, unWantedChars);
     return stod(ws);
 }
 
@@ -78,16 +78,6 @@ void Utils::RunOnUIThreadNonblocking(std::function<void()>&& function, _In_ Core
 bool Utils::IsLastCharacterTarget(_In_ wstring const& input, _In_ wchar_t target)
 {
     return !input.empty() && input.back() == target;
-}
-
-// Return wstring after removing characters specified by unwantedChars array
-wstring Utils::RemoveUnwantedCharsFromString(wstring input, wchar_t* unwantedChars, unsigned int size)
-{
-    for (unsigned int i = 0; i < size; ++i)
-    {
-        input.erase(std::remove(input.begin(), input.end(), unwantedChars[i]), input.end());
-    }
-    return input;
 }
 
 void Utils::SerializeCommandsAndTokens(

--- a/src/CalcViewModel/Common/Utils.h
+++ b/src/CalcViewModel/Common/Utils.h
@@ -379,7 +379,18 @@ namespace Utils
     void IFTPlatformException(HRESULT hr);
     Platform::String ^ GetStringValue(Platform::String ^ input);
     bool IsLastCharacterTarget(std::wstring const& input, wchar_t target);
-    std::wstring RemoveUnwantedCharsFromString(std::wstring inputString, wchar_t* unwantedChars, unsigned int size);
+
+    // Return wstring after removing characters specified by unwantedChars array
+    template <size_t N>
+    std::wstring RemoveUnwantedCharsFromString(std::wstring inputString, const wchar_t (&unwantedChars)[N])
+    {
+        for (const wchar_t unwantedChar : unwantedChars)
+        {
+            inputString.erase(std::remove(inputString.begin(), inputString.end(), unwantedChar), inputString.end());
+        }
+        return inputString;
+    }
+
     double GetDoubleFromWstring(std::wstring input);
     int GetWindowId();
     void RunOnUIThreadNonblocking(std::function<void()>&& function, _In_ Windows::UI::Core::CoreDispatcher ^ currentDispatcher);


### PR DESCRIPTION
## Fixes #807.

### Description of the changes:
- Updating RemoveUnwantedCharsFromString to be a template accepting an array with a known size.
- Using a range-for to loop through unwanted characters thanks to the change above.
- Updated call sites so they no longer need to explicitly specify the number of characters in the array.

### How changes were validated:
- Manual testing

