### PR TITLE
Fixing typo in StandardCalculatorViewModel::UpdatecommandsInRecording…

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1709,9 +1709,8 @@ void StandardCalculatorViewModel::UpdateOperand(int pos, String ^ text)
     }
 }
 
-void StandardCalculatorViewModel::UpdatecommandsInRecordingMode()
+void StandardCalculatorViewModel::UpdateCommandsInRecordingMode()
 {
-    vector<unsigned char> savedCommands = m_standardCalculatorManager.GetSavedCommands();
     shared_ptr<vector<int>> commands = make_shared<vector<int>>();
     bool isDecimal = false;
     bool isNegative = false;
@@ -1719,12 +1718,9 @@ void StandardCalculatorViewModel::UpdatecommandsInRecordingMode()
     bool ePlusMode = false;
     bool eMinusMode = false;
 
-    int num = 0;
-    Command val;
-    for (unsigned int i = 0; i < savedCommands.size(); ++i)
+    for (const auto savedCommand : m_standardCalculatorManager.GetSavedCommands())
     {
-        val = safe_cast<Command>(savedCommands[i]);
-        num = static_cast<int>(val);
+        const Command val = safe_cast<Command>(savedCommand);
         if (val == Command::CommandSIGN)
         {
             isNegative = true;
@@ -1762,7 +1758,7 @@ void StandardCalculatorViewModel::UpdatecommandsInRecordingMode()
             commands->clear();
             continue;
         }
-        commands->push_back(num);
+        commands->push_back(static_cast<int>(val));
     }
 
     if (!commands->empty())

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1720,7 +1720,7 @@ void StandardCalculatorViewModel::UpdateCommandsInRecordingMode()
 
     for (const auto savedCommand : m_standardCalculatorManager.GetSavedCommands())
     {
-        const Command val = safe_cast<Command>(savedCommand);
+        const Command val = static_cast<Command>(savedCommand);
         if (val == Command::CommandSIGN)
         {
             isNegative = true;

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -43,7 +43,7 @@ namespace CalculatorApp
         public:
             StandardCalculatorViewModel();
             void UpdateOperand(int pos, Platform::String ^ text);
-            void UpdatecommandsInRecordingMode();
+            void UpdateCommandsInRecordingMode();
 
             OBSERVABLE_OBJECT_CALLBACK(OnPropertyChanged);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, DisplayValue);


### PR DESCRIPTION
## Fixes #809.

### Description of the changes:
- Capitalizing `Commands`
- Removing unnecessary copy of vector in StandardCalculatorViewModel::UpdateCommandsInRecordingMode
- Using range-for in StandardCalculatorViewModel::UpdateCommandsInRecordingMode