### PR TITLE
Changing CalculatorManager::GetSavedCommands to return a const ref

### DIFF
--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -119,7 +119,7 @@ namespace CalculationManager
 
         bool IsEngineRecording();
         bool IsInputEmpty();
-        std::vector<unsigned char> GetSavedCommands()
+        const std::vector<unsigned char> GetSavedCommands() const
         {
             return m_savedCommands;
         }

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -119,7 +119,7 @@ namespace CalculationManager
 
         bool IsEngineRecording();
         bool IsInputEmpty();
-        const std::vector<unsigned char> GetSavedCommands() const
+        const std::vector<unsigned char>& GetSavedCommands() const
         {
             return m_savedCommands;
         }


### PR DESCRIPTION
## Fixes #811.

### Description of the changes:
- Changing GetSavedCommands to be a const function returning a const reference to the underlying vector