### PR TITLE
Modify how we manage the visibility of the history button

### DIFF
--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -454,7 +454,6 @@
                         <Setter Target="M5.MaxWidth" Value="80"/>
                         <Setter Target="MemButton.(Grid.Column)" Value="5"/>
                         <Setter Target="MemoryButton.(Grid.Column)" Value="6"/>
-                        <Setter Target="HistoryButton.Visibility" Value="Collapsed"/>
                     </VisualState.Setters>
                     <Storyboard Completed="OnModeVisualStateCompleted"/>
                 </VisualState>
@@ -491,7 +490,6 @@
                         <Setter Target="ColumnMain.Width" Value="320*"/>
                         <Setter Target="ColumnHistory.Width" Value="240*"/>
                         <Setter Target="DockPanel.Visibility" Value="Visible"/>
-                        <Setter Target="HistoryButton.Visibility" Value="Collapsed"/>
                         <Setter Target="M6.Width" Value="0"/>
                     </VisualState.Setters>
                     <Storyboard Completed="OnLayoutVisualStateCompleted"/>
@@ -657,27 +655,26 @@
                                                     IsEnabled="{x:Bind Model.IsProgrammer, Mode=OneWay}"
                                                     x:Load="False"/>
 
-            <Grid x:Name="HistoryButtonParent" Visibility="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}">
-                <Button x:Name="HistoryButton"
-                        x:Uid="HistoryButton"
-                        Grid.Row="0"
-                        Style="{StaticResource HistoryButtonStyle}"
-                        AutomationProperties.AutomationId="HistoryButton"
-                        Command="{x:Bind HistoryButtonPressed, Mode=OneTime}"
-                        Content="&#xe81c;"
-                        ExitDisplayModeOnAccessKeyInvoked="False"
-                        TabIndex="2"
-                        IsEnabled="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}">
-                    <FlyoutBase.AttachedFlyout>
-                        <Flyout x:Name="HistoryFlyout"
-                                AutomationProperties.AutomationId="HistoryFlyout"
-                                Closed="HistoryFlyout_Closed"
-                                FlyoutPresenterStyle="{StaticResource HistoryFlyoutStyle}"
-                                Opened="HistoryFlyout_Opened"
-                                Placement="Full"/>
-                    </FlyoutBase.AttachedFlyout>
-                </Button>
-            </Grid>
+            <Button x:Name="HistoryButton"
+                    x:Uid="HistoryButton"
+                    Grid.Row="0"
+                    Style="{StaticResource HistoryButtonStyle}"
+                    AutomationProperties.AutomationId="HistoryButton"
+                    Command="{x:Bind HistoryButtonPressed, Mode=OneTime}"
+                    Content="&#xe81c;"
+                    ExitDisplayModeOnAccessKeyInvoked="False"
+                    TabIndex="2"
+                    Visibility="{x:Bind local:Calculator.HasHistory(Model.IsAlwaysOnTop, Model.IsProgrammer, DockPanel.Visibility), Mode=OneWay}"
+                    IsEnabled="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}">
+                <FlyoutBase.AttachedFlyout>
+                    <Flyout x:Name="HistoryFlyout"
+                            AutomationProperties.AutomationId="HistoryFlyout"
+                            Closed="HistoryFlyout_Closed"
+                            FlyoutPresenterStyle="{StaticResource HistoryFlyoutStyle}"
+                            Opened="HistoryFlyout_Opened"
+                            Placement="Full"/>
+                </FlyoutBase.AttachedFlyout>
+            </Button>
 
             <!-- Scientific angle buttons -->
             <local:CalculatorScientificAngleButtons x:Name="ScientificAngleButtons"

--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -664,7 +664,7 @@
                     Content="&#xe81c;"
                     ExitDisplayModeOnAccessKeyInvoked="False"
                     TabIndex="2"
-                    Visibility="{x:Bind local:Calculator.HasHistory(Model.IsAlwaysOnTop, Model.IsProgrammer, DockPanel.Visibility), Mode=OneWay}"
+                    Visibility="{x:Bind local:Calculator.ShouldDisplayHistoryButton(Model.IsAlwaysOnTop, Model.IsProgrammer, DockPanel.Visibility), Mode=OneWay}"
                     IsEnabled="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}">
                 <FlyoutBase.AttachedFlyout>
                     <Flyout x:Name="HistoryFlyout"

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -714,3 +714,7 @@ void Calculator::Calculator_SizeChanged(Object ^ /*sender*/, SizeChangedEventArg
     }
 }
 
+::Visibility Calculator::HasHistory(bool isAlwaysOnTop, bool isProgrammer, ::Visibility dockPanelVisibility)
+{
+    return !isAlwaysOnTop && !isProgrammer && dockPanelVisibility == ::Visibility::Collapsed ? ::Visibility::Visible : ::Visibility::Collapsed;
+}

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -714,7 +714,7 @@ void Calculator::Calculator_SizeChanged(Object ^ /*sender*/, SizeChangedEventArg
     }
 }
 
-::Visibility Calculator::HasHistory(bool isAlwaysOnTop, bool isProgrammer, ::Visibility dockPanelVisibility)
+::Visibility Calculator::ShouldDisplayHistoryButton(bool isAlwaysOnTop, bool isProgrammer, ::Visibility dockPanelVisibility)
 {
     return !isAlwaysOnTop && !isProgrammer && dockPanelVisibility == ::Visibility::Collapsed ? ::Visibility::Visible : ::Visibility::Collapsed;
 }

--- a/src/Calculator/Views/Calculator.xaml.h
+++ b/src/Calculator/Views/Calculator.xaml.h
@@ -71,7 +71,7 @@ public
         void SetDefaultFocus();
 
         // Methods used by native bindings
-        static Windows::UI::Xaml::Visibility HasHistory(bool isAlwaysOnTop, bool isProgrammer, Windows::UI::Xaml::Visibility dockPanelVisibility);
+        static Windows::UI::Xaml::Visibility ShouldDisplayHistoryButton(bool isAlwaysOnTop, bool isProgrammer, Windows::UI::Xaml::Visibility dockPanelVisibility);
     private:
         void OnLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 

--- a/src/Calculator/Views/Calculator.xaml.h
+++ b/src/Calculator/Views/Calculator.xaml.h
@@ -69,6 +69,9 @@ public
         void CloseMemoryFlyout();
 
         void SetDefaultFocus();
+
+        // Methods used by native bindings
+        static Windows::UI::Xaml::Visibility HasHistory(bool isAlwaysOnTop, bool isProgrammer, Windows::UI::Xaml::Visibility dockPanelVisibility);
     private:
         void OnLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 
@@ -143,5 +146,6 @@ public
         void OnHistoryAccessKeyInvoked(_In_ Windows::UI::Xaml::UIElement ^ sender, _In_ Windows::UI::Xaml::Input::AccessKeyInvokedEventArgs ^ args);
         void OnMemoryAccessKeyInvoked(_In_ Windows::UI::Xaml::UIElement ^ sender, _In_ Windows::UI::Xaml::Input::AccessKeyInvokedEventArgs ^ args);
         void OnVisualStateChanged(Platform::Object ^ sender, Windows::UI::Xaml::VisualStateChangedEventArgs ^ e);
-    };
+
+   };
 }


### PR DESCRIPTION
## Fixes #820 

FIx issue with Programmer mode

### Description of the changes:
- Use a binding function instead of visual states to manage the visibility of the History button

### How changes were validated:
- Manually

