### PR TITLE
Hide the Edit Variables button when no variables are available

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -15,6 +15,9 @@
 
     <UserControl.Resources>
         <ResourceDictionary>
+
+            <converters:ItemSizeToVisibilityConverter x:Key="ItemSizeToVisibilityConverter"/>
+
             <Style x:Key="GraphButtonStyle" TargetType="Button">
                 <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
                 <Setter Property="Background" Value="{ThemeResource AppControlTransparentButtonBackgroundBrush}"/>
@@ -370,9 +373,9 @@
                           VerticalAlignment="Stretch"
                           Style="{ThemeResource ThemedSwitchModeToggleButtonStyle}"
                           AutomationProperties.AutomationId="SwitchModeToggleButton"
-                          AutomationProperties.Name="{x:Bind GetInfoForSwitchModeToggleButton(SwitchModeToggleButton.IsChecked.Value), Mode=OneWay}"
+                          AutomationProperties.Name="{x:Bind local:GraphingCalculator.GetInfoForSwitchModeToggleButton(SwitchModeToggleButton.IsChecked.Value), Mode=OneWay}"
                           Checked="SwitchModeToggleButton_Checked"
-                          ToolTipService.ToolTip="{x:Bind GetInfoForSwitchModeToggleButton(SwitchModeToggleButton.IsChecked.Value), Mode=OneWay}"
+                          ToolTipService.ToolTip="{x:Bind local:GraphingCalculator.GetInfoForSwitchModeToggleButton(SwitchModeToggleButton.IsChecked.Value), Mode=OneWay}"
                           Unchecked="SwitchModeToggleButton_Checked"
                           Visibility="Collapsed">
                 <!-- TODO: update this icon -->
@@ -399,14 +402,14 @@
                             HorizontalAlignment="Right"
                             VerticalAlignment="Top"
                             Orientation="Horizontal">
-
                     <!-- Temporary button until the final UI is created -->
                     <Button x:Name="VariableEditing"
                             MinWidth="44"
                             MinHeight="44"
                             Margin="0,0,4,0"
                             Style="{StaticResource GraphButtonStyle}"
-                            RequestedTheme="Light">
+                            RequestedTheme="Light"
+                            Visibility="{x:Bind local:GraphingCalculator.ManageEditVariablesButtonVisibility(ViewModel.Variables.Size), Mode=OneWay}">
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE70F;"/>
                         <Button.Flyout>
                             <Flyout Placement="BottomEdgeAlignedLeft">
@@ -685,7 +688,7 @@
               Grid.Row="1"
               Grid.RowSpan="2"
               Grid.Column="1"
-              Visibility="{x:Bind ShouldDisplayPanel(IsSmallState, SwitchModeToggleButton.IsChecked.Value, x:False), Mode=OneWay}">
+              Visibility="{x:Bind local:GraphingCalculator.ShouldDisplayPanel(IsSmallState, SwitchModeToggleButton.IsChecked.Value, x:False), Mode=OneWay}">
             <Grid.RowDefinitions>
                 <RowDefinition Height="5*"/>
                 <RowDefinition Height="3*"/>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -436,3 +436,7 @@ void GraphingCalculator::TraceValuePopup_SizeChanged(Platform::Object ^ sender, 
 {
     PositionGraphPopup();
 }
+::Visibility GraphingCalculator::ManageEditVariablesButtonVisibility(unsigned int numberOfVariables)
+{
+    return numberOfVariables == 0 ? ::Visibility::Collapsed : ::Visibility::Visible;
+}

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -32,8 +32,9 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
             void set(CalculatorApp::ViewModel::GraphingCalculatorViewModel^ vm);
         }
 
-        Windows::UI::Xaml::Visibility ShouldDisplayPanel(bool isSmallState, bool isEquationModeActivated, bool isGraphPanel);
-        Platform::String ^ GetInfoForSwitchModeToggleButton(bool isChecked);
+        static Windows::UI::Xaml::Visibility ShouldDisplayPanel(bool isSmallState, bool isEquationModeActivated, bool isGraphPanel);
+        static Platform::String ^ GetInfoForSwitchModeToggleButton(bool isChecked);
+        static Windows::UI::Xaml::Visibility ManageEditVariablesButtonVisibility(unsigned int numberOfVariables);
     private:
         void GraphingCalculator_DataContextChanged(Windows::UI::Xaml::FrameworkElement ^ sender, Windows::UI::Xaml::DataContextChangedEventArgs ^ args);
 
@@ -59,7 +60,6 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
 
         void OnShowTracePopupChanged(bool newValue);
         void OnTracePointChanged(Windows::Foundation::Point newPoint);
-
     private:
         Windows::Foundation::EventRegistrationToken m_dataRequestedToken;
         Windows::Foundation::EventRegistrationToken m_vectorChangedToken;


### PR DESCRIPTION
### Description of the changes:
- Hide the `Edit Variables` button when no variables are set.

### How changes were validated:
- manually

