### PR TITLE
Fix prefix 0s after deleting decimal point

### DIFF
--- a/src/CalcManager/CEngine/CalcInput.cpp
+++ b/src/CalcManager/CEngine/CalcInput.cpp
@@ -231,6 +231,10 @@ void CalcInput::Backspace()
         if (!m_base.IsEmpty())
         {
             m_base.value.pop_back();
+            if (m_base.value == L"0")
+            {
+                m_base.value.pop_back();
+            }
         }
 
         if (m_base.value.size() <= m_decPtIndex)

--- a/src/CalculatorUITests/StandardModeFunctionalTests.cs
+++ b/src/CalculatorUITests/StandardModeFunctionalTests.cs
@@ -184,6 +184,17 @@ namespace CalculatorUITests
             Assert.AreEqual("-1,234", page.GetCalculatorResultText());
         }
 
+        // Issue #817: Prefixed multiple zeros
+        [TestMethod]
+        public void Operator_Delete_Prefix_Zeros()
+        {
+            page.StandardOperators.NumberPad.Input(0.1); // To enter decimal point
+            page.StandardOperators.BackSpaceButton.Click();
+            page.StandardOperators.BackSpaceButton.Click();
+            page.StandardOperators.NumberPad.Input(0);
+            Assert.AreEqual("0", page.GetCalculatorResultText();
+        }
+
         [TestMethod]
         public void Operator_ClearAll()
         {

--- a/src/CalculatorUITests/StandardModeFunctionalTests.cs
+++ b/src/CalculatorUITests/StandardModeFunctionalTests.cs
@@ -192,7 +192,7 @@ namespace CalculatorUITests
             page.StandardOperators.BackSpaceButton.Click();
             page.StandardOperators.BackSpaceButton.Click();
             page.StandardOperators.NumberPad.Input(0);
-            Assert.AreEqual("0", page.GetCalculatorResultText();
+            Assert.AreEqual("0", page.GetCalculatorResultText());
         }
 
         [TestMethod]

--- a/src/CalculatorUnitTests/CalcInputTest.cpp
+++ b/src/CalculatorUnitTests/CalcInputTest.cpp
@@ -252,6 +252,16 @@ namespace CalculatorEngineTests
             m_calcInput.Backspace();
             VERIFY_ARE_EQUAL(L"1.2", m_calcInput.ToString(10), L"Verify input after backspace.");
         }
+        // Issue #817: Prefixed multiple zeros
+        TEST_METHOD(BackspaceZeroDecimalWithoutPrefixZeros)
+        {
+            m_calcInput.TryAddDigit(0, 10, false, L"999", 64, 32);
+            m_calcInput.TryAddDecimalPt();
+            VERIFY_ARE_EQUAL(L"0.", m_calcInput.ToString(10), L"Verify input before backspace.")
+            m_calcInput.Backspace();
+            m_calcInput.TryAddDigit(0, 10, false, L"999", 64, 32);
+            VERIFY_ARE_EQUAL(L"0", m_calcInput.ToString(10), L"Verify input after backspace.")
+        }
 
         TEST_METHOD(SetDecimalSymbol)
         {


### PR DESCRIPTION
## Fixes #817 .


### Description of the changes:
- Added a verification if the remaining data is 0 only, and then pop this 0 out.
- 2 Tests corresponding

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Added an `UITest` and an `UnitTest`

Additional note: My respond may delay because I can't use git(hub) on weekdays.