### PR TITLE
Add error handling to graph and equations

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -175,8 +175,8 @@
                     <SolidColorBrush x:Key="AppControlTransparentButtonBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
                     <SolidColorBrush x:Key="EquationButtonHideLineBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
                     <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="Transparent"/>
-                    <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="#33EB5757"/>
-                    <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="#FFEB5757"/>
+                    <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                    <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}"/>
                     <SolidColorBrush x:Key="EquationButtonHideLineForegroundBrush" Color="{StaticResource SystemColorGrayTextColor}"/>
                     <!-- TODO: Figure out what colors we can use in high contrast -->
                     <SolidColorBrush x:Key="EquationBrush1" Color="{ThemeResource SystemColorGrayTextColor}"/>

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -1516,7 +1516,7 @@
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="FunctionButton" Storyboard.TargetProperty="Visibility">
                                                     <DiscreteObjectKeyFrame KeyTime="0">
                                                         <DiscreteObjectKeyFrame.Value>
-                                                            <Visibility>Visible</Visibility>
+                                                            <Visibility>Collapsed</Visibility>
                                                         </DiscreteObjectKeyFrame.Value>
                                                     </DiscreteObjectKeyFrame>
                                                 </ObjectAnimationUsingKeyFrames>

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -53,6 +53,8 @@
                     <SolidColorBrush x:Key="EquationBoxHoverButtonForegroundBrush" Color="{ThemeResource SystemBaseHighColor}"/>
                     <SolidColorBrush x:Key="EquationBoxBorderBrush" Color="{ThemeResource TextControlBackground}"/>
                     <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="White"/>
+                    <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="#33EB5757"/>
+                    <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="#FFEB5757"/>
                     <SolidColorBrush x:Key="EquationButtonHideLineBackgroundBrush"
                                      Opacity="0.4"
                                      Color="#FFFFFF"/>
@@ -119,6 +121,8 @@
                     <SolidColorBrush x:Key="EquationBoxHoverButtonForegroundBrush" Color="{ThemeResource SystemBaseHighColor}"/>
                     <SolidColorBrush x:Key="EquationBoxBorderBrush" Color="{ThemeResource TextControlBackground}"/>
                     <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="Black"/>
+                    <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="#33EB5757"/>
+                    <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="#FFEB5757"/>
                     <SolidColorBrush x:Key="EquationButtonHideLineBackgroundBrush"
                                      Opacity="0.4"
                                      Color="#000000"/>
@@ -171,6 +175,8 @@
                     <SolidColorBrush x:Key="AppControlTransparentButtonBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
                     <SolidColorBrush x:Key="EquationButtonHideLineBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
                     <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="Transparent"/>
+                    <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="#33EB5757"/>
+                    <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="#FFEB5757"/>
                     <SolidColorBrush x:Key="EquationButtonHideLineForegroundBrush" Color="{StaticResource SystemColorGrayTextColor}"/>
                     <!-- TODO: Figure out what colors we can use in high contrast -->
                     <SolidColorBrush x:Key="EquationBrush1" Color="{ThemeResource SystemColorGrayTextColor}"/>
@@ -1231,7 +1237,7 @@
                 </Setter>
             </Style>
 
-            <Style x:Key="MathRichEdit_EquationTextBoxStyle" TargetType="Controls:MathRichEditBox">
+            <Style x:Key="MathRichEditBoxStyle" TargetType="Controls:MathRichEditBox">
                 <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}"/>
                 <Setter Property="Background" Value="Transparent"/>
                 <Setter Property="ContentLinkForegroundColor" Value="{ThemeResource ContentLinkForegroundColor}"/>
@@ -1427,14 +1433,29 @@
 
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
+                                        
                                         <VisualState x:Name="Normal">
-
                                             <Storyboard>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="EquationBoxBorder" Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackground}"/>
-                                                </ObjectAnimationUsingKeyFrames>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="EquationBoxBorder" Storyboard.TargetProperty="BorderBrush">
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource EquationBoxBorderBrush}"/>
+                                                </ObjectAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="Error">
+                                            <Storyboard>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="EquationBoxBorder" Storyboard.TargetProperty="BorderBrush">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource EquationBoxErrorBorderBrush}"/>
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="EquationBoxBorder" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource EquationBoxErrorBackgroundBrush}"/>
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ErrorIcon" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0">
+                                                        <DiscreteObjectKeyFrame.Value>
+                                                            <Visibility>Visible</Visibility>
+                                                        </DiscreteObjectKeyFrame.Value>
+                                                    </DiscreteObjectKeyFrame>
                                                 </ObjectAnimationUsingKeyFrames>
                                             </Storyboard>
                                         </VisualState>
@@ -1442,9 +1463,6 @@
                                         <VisualState x:Name="PointerOver">
 
                                             <Storyboard>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="EquationBoxBorder" Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBackground}"/>
-                                                </ObjectAnimationUsingKeyFrames>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="EquationBoxBorder" Storyboard.TargetProperty="BorderBrush">
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor}"/>
                                                 </ObjectAnimationUsingKeyFrames>
@@ -1466,6 +1484,53 @@
                                                     <DiscreteObjectKeyFrame KeyTime="0">
                                                         <DiscreteObjectKeyFrame.Value>
                                                             <Visibility>Visible</Visibility>
+                                                        </DiscreteObjectKeyFrame.Value>
+                                                    </DiscreteObjectKeyFrame>
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ErrorIcon" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0">
+                                                        <DiscreteObjectKeyFrame.Value>
+                                                            <Visibility>Collapsed</Visibility>
+                                                        </DiscreteObjectKeyFrame.Value>
+                                                    </DiscreteObjectKeyFrame>
+                                                </ObjectAnimationUsingKeyFrames>
+                                            </Storyboard>
+                                        </VisualState>
+
+                                        <VisualState x:Name="PointerOverError">
+
+                                            <Storyboard>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="EquationBoxBorder" Storyboard.TargetProperty="BorderBrush">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor}"/>
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="EquationBoxBorder" Storyboard.TargetProperty="Background">
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource EquationBoxErrorBackgroundBrush}"/>
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ColorChooserButton" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0">
+                                                        <DiscreteObjectKeyFrame.Value>
+                                                            <Visibility>Visible</Visibility>
+                                                        </DiscreteObjectKeyFrame.Value>
+                                                    </DiscreteObjectKeyFrame>
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="FunctionButton" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0">
+                                                        <DiscreteObjectKeyFrame.Value>
+                                                            <Visibility>Visible</Visibility>
+                                                        </DiscreteObjectKeyFrame.Value>
+                                                    </DiscreteObjectKeyFrame>
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RemoveButton" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0">
+                                                        <DiscreteObjectKeyFrame.Value>
+                                                            <Visibility>Visible</Visibility>
+                                                        </DiscreteObjectKeyFrame.Value>
+                                                    </DiscreteObjectKeyFrame>
+                                                </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ErrorIcon" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0">
+                                                        <DiscreteObjectKeyFrame.Value>
+                                                            <Visibility>Collapsed</Visibility>
                                                         </DiscreteObjectKeyFrame.Value>
                                                     </DiscreteObjectKeyFrame>
                                                 </ObjectAnimationUsingKeyFrames>
@@ -1509,11 +1574,17 @@
                                                         </DiscreteObjectKeyFrame.Value>
                                                     </DiscreteObjectKeyFrame>
                                                 </ObjectAnimationUsingKeyFrames>
+                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ErrorIcon" Storyboard.TargetProperty="Visibility">
+                                                    <DiscreteObjectKeyFrame KeyTime="0">
+                                                        <DiscreteObjectKeyFrame.Value>
+                                                            <Visibility>Collapsed</Visibility>
+                                                        </DiscreteObjectKeyFrame.Value>
+                                                    </DiscreteObjectKeyFrame>
+                                                </ObjectAnimationUsingKeyFrames>
                                             </Storyboard>
                                         </VisualState>
                                         <VisualState x:Name="ButtonCollapsed"/>
                                     </VisualStateGroup>
-
                                 </VisualStateManager.VisualStateGroups>
 
                                 <ToggleButton x:Name="EquationButton"
@@ -1639,11 +1710,11 @@
                                             <ColumnDefinition Width="Auto"/>
                                             <ColumnDefinition Width="Auto"/>
                                         </Grid.ColumnDefinitions>
-                                        <Controls:MathRichEditBox x:Name="EquationTextBox"
+                                        <Controls:MathRichEditBox x:Name="MathRichEditBox"
                                                                   MinHeight="44"
                                                                   Padding="{TemplateBinding Padding}"
                                                                   VerticalAlignment="Stretch"
-                                                                  Style="{StaticResource MathRichEdit_EquationTextBoxStyle}"
+                                                                  Style="{StaticResource MathRichEditBoxStyle}"
                                                                   BorderThickness="0"
                                                                   FontFamily="{TemplateBinding FontFamily}"
                                                                   FontSize="{TemplateBinding FontSize}"
@@ -1667,6 +1738,15 @@
                                                 AutomationProperties.AccessibilityView="Raw"
                                                 Content="&#xE10A;"
                                                 IsTabStop="False"
+                                                Visibility="Collapsed"/>
+                                        <FontIcon x:Name="ErrorIcon"
+                                                Grid.Column="3"
+                                                MinWidth="34"
+                                                VerticalAlignment="Stretch"
+                                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                AutomationProperties.AccessibilityView="Raw"
+                                                Glyph="&#xE783;"
+                                                FontSize="16"
                                                 Visibility="Collapsed"/>
                                         <Button x:Name="RemoveButton"
                                                 Grid.Column="3"

--- a/src/Calculator/Controls/EquationTextBox.h
+++ b/src/Calculator/Controls/EquationTextBox.h
@@ -22,6 +22,7 @@ namespace CalculatorApp
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Media::SolidColorBrush^, EquationColor);
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Controls::Flyout^, ColorChooserFlyout);
             DEPENDENCY_PROPERTY(Platform::String ^, EquationButtonContentIndex);
+            DEPENDENCY_PROPERTY_WITH_CALLBACK(bool, HasError);
 
             PROPERTY_R(bool, HasFocus);
 
@@ -59,6 +60,8 @@ namespace CalculatorApp
 
             void OnColorFlyoutOpened(Platform::Object^ sender, Platform::Object^ e);
             void OnColorFlyoutClosed(Platform::Object^ sender, Platform::Object^ e);
+
+            void OnHasErrorPropertyChanged(bool oldValue, bool newValue);
 
             CalculatorApp::Controls::MathRichEditBox^ m_richEditBox;
             Windows::UI::Xaml::Controls::Primitives::ToggleButton^ m_equationButton;

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -54,6 +54,7 @@
                                               EquationButtonContentIndex="{x:Bind FunctionLabelIndex, Mode=OneWay}"
                                               EquationSubmitted="InputTextBox_Submitted"
                                               GotFocus="InputTextBox_GotFocus"
+                                              HasError="{x:Bind GraphEquation.HasGraphError, Mode=OneWay}"
                                               Loaded="EquationTextBoxLoaded"
                                               LostFocus="InputTextBox_LostFocus"
                                               RemoveButtonClicked="EquationTextBox_RemoveButtonClicked"

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -37,7 +37,6 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
     private:
         void GraphingCalculator_DataContextChanged(Windows::UI::Xaml::FrameworkElement ^ sender, Windows::UI::Xaml::DataContextChangedEventArgs ^ args);
 
-        void GraphVariablesUpdated(Platform::Object ^ sender, Object ^ args);
         void OnVariableChanged(Platform::Object ^ sender, CalculatorApp::ViewModel::VariableChangedEventArgs args);
         void OnEquationsVectorChanged(
             Windows::Foundation::Collections::IObservableVector<CalculatorApp::ViewModel::EquationViewModel ^> ^ sender,

--- a/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
+++ b/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
@@ -26,119 +26,6 @@
                 <Setter.Value>
                     <ControlTemplate TargetType="controls:EquationTextBox">
                         <Grid>
-                            <Grid.Resources>
-                                <Style x:Key="KGF_EquationTextBoxStyle" TargetType="controls:MathRichEditBox">
-                                    <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}"/>
-                                    <Setter Property="Background" Value="Transparent"/>
-                                    <Setter Property="ContentLinkForegroundColor" Value="{ThemeResource ContentLinkForegroundColor}"/>
-                                    <Setter Property="ContentLinkBackgroundColor" Value="{ThemeResource ContentLinkBackgroundColor}"/>
-                                    <Setter Property="SelectionHighlightColor" Value="{ThemeResource TextControlSelectionHighlightColor}"/>
-                                    <Setter Property="BorderBrush" Value="{ThemeResource TextControlBorderBrush}"/>
-                                    <Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderThemeThickness}"/>
-                                    <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
-                                    <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
-                                    <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Auto"/>
-                                    <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto"/>
-                                    <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden"/>
-                                    <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden"/>
-                                    <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False"/>
-                                    <Setter Property="Padding" Value="{ThemeResource TextControlThemePadding}"/>
-                                    <Setter Property="UseSystemFocusVisuals" Value="{ThemeResource IsApplicationFocusVisualKindReveal}"/>
-                                    <Setter Property="ContextFlyout" Value="{StaticResource TextControlCommandBarContextFlyout}"/>
-                                    <Setter Property="Template">
-                                        <Setter.Value>
-                                            <ControlTemplate TargetType="controls:MathRichEditBox">
-                                                <Grid>
-                                                    <Grid.RowDefinitions>
-                                                        <RowDefinition Height="Auto"/>
-                                                        <RowDefinition Height="*"/>
-                                                        <RowDefinition Height="Auto"/>
-                                                    </Grid.RowDefinitions>
-
-                                                    <Grid.ColumnDefinitions>
-                                                        <ColumnDefinition Width="*"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                        <ColumnDefinition Width="Auto"/>
-                                                    </Grid.ColumnDefinitions>
-
-                                                    <VisualStateManager.VisualStateGroups>
-                                                        <VisualStateGroup x:Name="CommonStates">
-                                                            <VisualState x:Name="Disabled"/>
-                                                            <VisualState x:Name="Normal"/>
-                                                            <VisualState x:Name="PointerOver"/>
-                                                            <VisualState x:Name="Focused"/>
-                                                        </VisualStateGroup>
-                                                    </VisualStateManager.VisualStateGroups>
-
-                                                    <ContentPresenter x:Name="HeaderContentPresenter"
-                                                                      Grid.Row="0"
-                                                                      Grid.Column="0"
-                                                                      Grid.ColumnSpan="4"
-                                                                      Margin="{ThemeResource RichEditBoxTopHeaderMargin}"
-                                                                      Foreground="{ThemeResource TextControlHeaderForeground}"
-                                                                      FontWeight="Normal"
-                                                                      x:DeferLoadStrategy="Lazy"
-                                                                      Content="{TemplateBinding Header}"
-                                                                      ContentTemplate="{TemplateBinding HeaderTemplate}"
-                                                                      TextWrapping="Wrap"
-                                                                      Visibility="Collapsed"/>
-                                                    <Border x:Name="BorderElement"
-                                                            Grid.Row="1"
-                                                            Grid.RowSpan="1"
-                                                            Grid.Column="0"
-                                                            Grid.ColumnSpan="4"
-                                                            MinWidth="{ThemeResource TextControlThemeMinWidth}"
-                                                            MinHeight="{ThemeResource TextControlThemeMinHeight}"
-                                                            BorderBrush="{TemplateBinding BorderBrush}"
-                                                            BorderThickness="0"
-                                                            Control.IsTemplateFocusTarget="True"
-                                                            CornerRadius="{TemplateBinding CornerRadius}"/>
-                                                    <ScrollViewer x:Name="ContentElement"
-                                                                  Grid.Row="1"
-                                                                  Grid.Column="0"
-                                                                  Margin="{TemplateBinding BorderThickness}"
-                                                                  Padding="{TemplateBinding Padding}"
-                                                                  VerticalAlignment="Center"
-                                                                  AutomationProperties.AccessibilityView="Raw"
-                                                                  HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-                                                                  HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-                                                                  IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-                                                                  IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-                                                                  IsTabStop="False"
-                                                                  IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-                                                                  VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-                                                                  VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-                                                                  ZoomMode="Disabled"/>
-                                                    <TextBlock x:Name="PlaceholderTextContentPresenter"
-                                                               Grid.Row="1"
-                                                               Grid.Column="0"
-                                                               Grid.ColumnSpan="4"
-                                                               Margin="{TemplateBinding BorderThickness}"
-                                                               Padding="{TemplateBinding Padding}"
-                                                               VerticalAlignment="Center"
-                                                               Foreground="{ThemeResource TextControlPlaceholderForeground}"
-                                                               IsHitTestVisible="False"
-                                                               Text="{TemplateBinding PlaceholderText}"
-                                                               TextAlignment="{TemplateBinding TextAlignment}"
-                                                               TextWrapping="{TemplateBinding TextWrapping}"/>
-                                                    <ContentPresenter x:Name="DescriptionPresenter"
-                                                                      Grid.Row="2"
-                                                                      Grid.Column="0"
-                                                                      Grid.ColumnSpan="4"
-                                                                      Background="Transparent"
-                                                                      Foreground="{ThemeResource SystemControlDescriptionTextForegroundBrush}"
-                                                                      x:Load="False"
-                                                                      AutomationProperties.AccessibilityView="Raw"
-                                                                      Content="{TemplateBinding Description}"/>
-
-                                                </Grid>
-
-                                            </ControlTemplate>
-                                        </Setter.Value>
-                                    </Setter>
-                                </Style>
-                            </Grid.Resources>
 
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="Auto"/>
@@ -184,12 +71,12 @@
                                 </ToggleButton.Resources>
                             </ToggleButton>
 
-                            <controls:MathRichEditBox x:Name="EquationTextBox"
+                            <controls:MathRichEditBox x:Name="MathRichEditBox"
                                                       Grid.Column="1"
                                                       MinHeight="44"
                                                       Padding="{TemplateBinding Padding}"
                                                       VerticalAlignment="Stretch"
-                                                      Style="{StaticResource MathRichEdit_EquationTextBoxStyle}"
+                                                      Style="{StaticResource MathRichEditBoxStyle}"
                                                       Background="Transparent"
                                                       BorderThickness="0"
                                                       FontFamily="{TemplateBinding FontFamily}"

--- a/src/GraphControl/Control/Equation.cpp
+++ b/src/GraphControl/Control/Equation.cpp
@@ -26,7 +26,13 @@ namespace GraphControl
     DependencyProperty ^ Equation::s_isLineEnabledProperty;
     static constexpr auto s_propertyName_IsLineEnabled = L"IsLineEnabled";
 
-	DependencyProperty ^ Equation::s_xInterceptProperty;
+    DependencyProperty ^ Equation::s_hasGraphErrorProperty;
+    static constexpr auto s_propertyName_HasGraphError = L"HasGraphError";
+
+    DependencyProperty ^ Equation::s_isValidatedProperty;
+    static constexpr auto s_propertyName_IsValidated = L"IsValidated";
+
+    DependencyProperty ^ Equation::s_xInterceptProperty;
     static constexpr auto s_propertyName_XIntercept = L"XIntercept";
 
     DependencyProperty ^ Equation::s_yInterceptProperty;
@@ -79,6 +85,8 @@ namespace GraphControl
         String ^ Expression = StringReference(s_propertyName_Expression);
         String ^ LineColor = StringReference(s_propertyName_LineColor);
         String ^ IsLineEnabled = StringReference(s_propertyName_IsLineEnabled);
+        String ^ HasGraphError = StringReference(s_propertyName_HasGraphError);
+        String ^ IsValidated = StringReference(s_propertyName_IsValidated);
         String ^ XIntercept = StringReference(s_propertyName_XIntercept);
         String ^ YIntercept = StringReference(s_propertyName_YIntercept);
         String ^ Parity = StringReference(s_propertyName_Parity);
@@ -127,6 +135,24 @@ namespace GraphControl
                 bool ::typeid,
                 Equation::typeid,
                 ref new PropertyMetadata(nullptr, ref new PropertyChangedCallback(&Equation::OnCustomDependencyPropertyChanged)));
+        }
+
+        if (!s_hasGraphErrorProperty)
+        {
+            s_hasGraphErrorProperty = DependencyProperty::Register(
+                EquationProperties::HasGraphError,
+                bool ::typeid,
+                Equation::typeid,
+                ref new PropertyMetadata(false, ref new PropertyChangedCallback(&Equation::OnCustomDependencyPropertyChanged)));
+        }
+
+        if (!s_isValidatedProperty)
+        {
+            s_isValidatedProperty = DependencyProperty::Register(
+                EquationProperties::IsValidated,
+                bool ::typeid,
+                Equation::typeid,
+                ref new PropertyMetadata(false, ref new PropertyChangedCallback(&Equation::OnCustomDependencyPropertyChanged)));
         }
 
         if (!s_xInterceptProperty)
@@ -354,6 +380,14 @@ namespace GraphControl
             {
                 propertyName = EquationProperties::AnalysisError;
             }
+            else if (args->Property == s_hasGraphErrorProperty)
+            {
+                propertyName = EquationProperties::HasGraphError;
+            }
+            else if (args->Property == s_isValidatedProperty)
+            {
+                propertyName = EquationProperties::IsValidated;
+            }
 
             eq->PropertyChanged(eq, propertyName);
         }
@@ -397,5 +431,10 @@ namespace GraphControl
     wstring Equation::GetLineColor()
     {
         return L""s;
+    }
+
+    bool Equation::IsGraphableEquation()
+    {
+        return !Expression->IsEmpty() && IsLineEnabled && !HasGraphError;
     }
 }

--- a/src/GraphControl/Control/Equation.h
+++ b/src/GraphControl/Control/Equation.h
@@ -91,6 +91,44 @@ namespace GraphControl
 
 #pragma endregion
 
+#pragma region bool HasGraphError DependencyProperty
+        static property Windows::UI::Xaml::DependencyProperty ^ HasGraphErrorProperty { Windows::UI::Xaml::DependencyProperty ^ get() { return s_hasGraphErrorProperty; } }
+
+        property bool HasGraphError
+        {
+            bool get()
+            {
+                return static_cast<bool>(GetValue(s_hasGraphErrorProperty));
+            }
+
+        internal:
+            void set(bool value)
+            {
+                SetValue(s_hasGraphErrorProperty, value);
+            }
+        }
+
+#pragma endregion
+
+#pragma region bool IsValidated DependencyProperty
+        static property Windows::UI::Xaml::DependencyProperty ^ IsValidatedProperty { Windows::UI::Xaml::DependencyProperty ^ get() { return s_isValidatedProperty; } }
+
+            property bool IsValidated
+        {
+            bool get()
+            {
+                return static_cast<bool>(GetValue(s_isValidatedProperty));
+            }
+
+        internal:
+            void set(bool value)
+            {
+                SetValue(s_isValidatedProperty, value);
+            }
+        }
+
+#pragma endregion
+
 #pragma region Key Graph Features
 
 
@@ -108,7 +146,7 @@ namespace GraphControl
             {
                 return static_cast<Platform::String^>(GetValue(s_xInterceptProperty));
             }
-            void set(Platform::String^ value)
+            internal: void set(Platform::String^ value)
             {
                 SetValue(s_xInterceptProperty, value);
             }
@@ -129,7 +167,7 @@ namespace GraphControl
             {
                 return static_cast<Platform::String^>(GetValue(s_yInterceptProperty));
             }
-            void set(Platform::String^ value)
+            internal: void set(Platform::String^ value)
             {
                 SetValue(s_yInterceptProperty, value);
             }
@@ -150,7 +188,7 @@ namespace GraphControl
             {
                 return static_cast<int>(GetValue(s_parityProperty));
             }
-            void set(int value)
+        internal: void set(int value)
             {
                 SetValue(s_parityProperty, value);
             }
@@ -171,7 +209,7 @@ namespace GraphControl
             {
                 return static_cast<int>(GetValue(s_periodicityDirectionProperty));
             }
-            void set(int value)
+        internal: void set(int value)
             {
                 SetValue(s_periodicityDirectionProperty, value);
             }
@@ -192,7 +230,7 @@ namespace GraphControl
             {
                 return static_cast<Platform::String ^>(GetValue(s_periodicityExpressionProperty));
             }
-            void set(Platform::String ^ value)
+            internal: void set(Platform::String ^ value)
             {
                 SetValue(s_periodicityExpressionProperty, value);
             }
@@ -213,7 +251,7 @@ namespace GraphControl
             {
                 return static_cast<Windows::Foundation::Collections::IVector<Platform::String^> ^>(GetValue(s_minimaProperty));
             }
-            void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
+            internal: void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
             {
                 SetValue(s_minimaProperty, value);
             }
@@ -234,7 +272,7 @@ namespace GraphControl
             {
                 return static_cast<Windows::Foundation::Collections::IVector<Platform::String^> ^>(GetValue(s_maximaProperty));
             }
-            void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
+            internal: void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
             {
                 SetValue(s_maximaProperty, value);
             }
@@ -255,7 +293,7 @@ namespace GraphControl
             {
                 return static_cast<Platform::String^>(GetValue(s_domainProperty));
             }
-            void set(Platform::String^ value)
+            internal: void set(Platform::String^ value)
             {
                 SetValue(s_domainProperty, value);
             }
@@ -276,7 +314,7 @@ namespace GraphControl
             {
                 return static_cast<Platform::String^>(GetValue(s_rangeProperty));
             }
-            void set(Platform::String^ value)
+            internal: void set(Platform::String^ value)
             {
                 SetValue(s_rangeProperty, value);
             }
@@ -297,7 +335,7 @@ namespace GraphControl
             {
                 return static_cast<Windows::Foundation::Collections::IVector<Platform::String^> ^>(GetValue(s_inflectionPointsProperty));
             }
-            void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
+            internal: void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
             {
                 SetValue(s_inflectionPointsProperty, value);
             }
@@ -318,7 +356,7 @@ namespace GraphControl
             {
                 return static_cast<Windows::Foundation::Collections::IObservableMap<Platform::String^, Platform::String ^> ^>(GetValue(s_monotonicityProperty));
             }
-            void set(Windows::Foundation::Collections::IObservableMap<Platform::String^, Platform::String ^> ^ value)
+            internal: void set(Windows::Foundation::Collections::IObservableMap<Platform::String^, Platform::String ^> ^ value)
             {
                 SetValue(s_monotonicityProperty, value);
             }
@@ -339,7 +377,7 @@ namespace GraphControl
             {
                 return static_cast<Windows::Foundation::Collections::IVector<Platform::String^> ^>(GetValue(s_verticalAsymptotesProperty));
             }
-            void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
+            internal: void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
             {
                 SetValue(s_verticalAsymptotesProperty, value);
             }
@@ -360,7 +398,7 @@ namespace GraphControl
             {
                 return static_cast<Windows::Foundation::Collections::IVector<Platform::String^> ^>(GetValue(s_horizontalAsymptotesProperty));
             }
-            void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
+            internal: void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
             {
                 SetValue(s_horizontalAsymptotesProperty, value);
             }
@@ -381,7 +419,7 @@ namespace GraphControl
             {
                 return static_cast<Windows::Foundation::Collections::IVector<Platform::String^> ^>(GetValue(s_obliqueAsymptotesProperty));
             }
-            void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
+            internal: void set(Windows::Foundation::Collections::IVector<Platform::String^> ^ value)
             {
                 SetValue(s_obliqueAsymptotesProperty, value);
             }
@@ -402,7 +440,7 @@ namespace GraphControl
             {
                 return static_cast<int>(GetValue(s_tooComplexFeaturesProperty));
             }
-            void set(int value)
+        internal: void set(int value)
             {
                 SetValue(s_tooComplexFeaturesProperty, value);
             }
@@ -423,7 +461,7 @@ namespace GraphControl
             {
                 return static_cast<int>(GetValue(s_analysisErrorProperty));
             }
-            void set(int value)
+            internal: void set(int value)
             {
                 SetValue(s_analysisErrorProperty, value);
             }
@@ -434,6 +472,7 @@ namespace GraphControl
         internal : event PropertyChangedEventHandler ^ PropertyChanged;
 
         std::wstring GetRequest();
+        bool IsGraphableEquation();
 
     private:
         static void OnCustomDependencyPropertyChanged(Windows::UI::Xaml::DependencyObject ^ obj, Windows::UI::Xaml::DependencyPropertyChangedEventArgs ^ args);
@@ -446,6 +485,8 @@ namespace GraphControl
         static Windows::UI::Xaml::DependencyProperty ^ s_expressionProperty;
         static Windows::UI::Xaml::DependencyProperty ^ s_lineColorProperty;
         static Windows::UI::Xaml::DependencyProperty ^ s_isLineEnabledProperty;
+        static Windows::UI::Xaml::DependencyProperty ^ s_hasGraphErrorProperty;
+        static Windows::UI::Xaml::DependencyProperty ^ s_isValidatedProperty;
         static Windows::UI::Xaml::DependencyProperty ^ s_xInterceptProperty;
         static Windows::UI::Xaml::DependencyProperty ^ s_yInterceptProperty;
         static Windows::UI::Xaml::DependencyProperty ^ s_parityProperty;

--- a/src/GraphControl/Control/EquationCollection.h
+++ b/src/GraphControl/Control/EquationCollection.h
@@ -7,7 +7,7 @@
 
 namespace GraphControl
 {
-    delegate void EquationChangedEventHandler();
+    delegate void EquationChangedEventHandler(Equation ^ sender);
     delegate void VisibilityChangedEventHandler(Equation ^ sender);
 
 public
@@ -151,19 +151,19 @@ public
         event EquationChangedEventHandler ^ EquationLineEnabledChanged;
 
     private:
-        void OnEquationPropertyChanged(GraphControl::Equation ^, Platform::String ^ propertyName)
+        void OnEquationPropertyChanged(GraphControl::Equation ^ sender, Platform::String ^ propertyName)
         {
             if (propertyName == EquationProperties::LineColor)
             {
-                EquationStyleChanged();
+                EquationStyleChanged(sender);
             }
             else if (propertyName == EquationProperties::Expression)
             {
-                EquationChanged();
+                EquationChanged(sender);
             }
             else if (propertyName == EquationProperties::IsLineEnabled)
             {
-                EquationLineEnabledChanged();
+                EquationLineEnabledChanged(sender);
             }
         }
 

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -174,7 +174,8 @@ public
         void OnEquationChanged(GraphControl::Equation ^ equation);
         void OnEquationStyleChanged(GraphControl::Equation ^ equation);
         void OnEquationLineEnabledChanged(GraphControl::Equation ^ equation);
-        void UpdateGraph();
+        bool TryUpdateGraph();
+        void TryPlotGraph(bool shouldRetry);
         void UpdateGraphOptions(Graphing::IGraphingOptions& options, const std::vector<Equation ^>& validEqs);
         std::vector<Equation ^> GetGraphableEquations();
         void SetGraphArgs();
@@ -194,8 +195,8 @@ public
         void HandleTracingMovementTick(Object ^ sender, Object ^ e);
         void HandleKey(bool keyDown, Windows::System::VirtualKey key);
 
-        void SetEquationsAsValid(std::vector<Equation ^>);
-        void SetEquationsErrors(std::vector<Equation ^>);
+        void SetEquationsAsValid();
+        void SetEquationErrors();
 
         Windows::Foundation::Collections::IObservableVector<Platform::String ^> ^ ConvertWStringVector(std::vector<std::wstring> inVector);
         Windows::Foundation::Collections::IObservableMap<Platform::String ^, Platform::String ^> ^ ConvertWStringIntMap(std::map<std::wstring, int> inMap);

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -171,12 +171,12 @@ public
         void OnDependencyPropertyChanged(Windows::UI::Xaml::DependencyObject ^ obj, Windows::UI::Xaml::DependencyProperty ^ p);
 
         void OnEquationsChanged(Windows::UI::Xaml::DependencyPropertyChangedEventArgs ^ args);
-        void OnEquationChanged();
-        void OnEquationStyleChanged();
-        void OnEquationLineEnabledChanged();
+        void OnEquationChanged(GraphControl::Equation ^ equation);
+        void OnEquationStyleChanged(GraphControl::Equation ^ equation);
+        void OnEquationLineEnabledChanged(GraphControl::Equation ^ equation);
         void UpdateGraph();
         void UpdateGraphOptions(Graphing::IGraphingOptions& options, const std::vector<Equation ^>& validEqs);
-        std::vector<Equation ^> GetValidEquations();
+        std::vector<Equation ^> GetGraphableEquations();
         void SetGraphArgs();
         std::shared_ptr<Graphing::IGraph> GetGraph(GraphControl::Equation ^ equation);
         void UpdateVariables();
@@ -193,6 +193,9 @@ public
         void UpdateTracingChanged();
         void HandleTracingMovementTick(Object ^ sender, Object ^ e);
         void HandleKey(bool keyDown, Windows::System::VirtualKey key);
+
+        void SetEquationsAsValid(std::vector<Equation ^>);
+        void SetEquationsErrors(std::vector<Equation ^>);
 
         Windows::Foundation::Collections::IObservableVector<Platform::String ^> ^ ConvertWStringVector(std::vector<std::wstring> inVector);
         Windows::Foundation::Collections::IObservableMap<Platform::String ^, Platform::String ^> ^ ConvertWStringIntMap(std::map<std::wstring, int> inMap);

--- a/src/GraphControl/DirectX/RenderMain.cpp
+++ b/src/GraphControl/DirectX/RenderMain.cpp
@@ -68,8 +68,6 @@ namespace GraphControl::DX
                 renderer->SetGraphSize(static_cast<unsigned int>(m_swapChainPanel->ActualWidth), static_cast<unsigned int>(m_swapChainPanel->ActualHeight));
             }
         }
-
-        RunRenderPass();
     }
 
     void RenderMain::BackgroundColor::set(Windows::UI::Color backgroundColor)
@@ -125,12 +123,16 @@ namespace GraphControl::DX
         RunRenderPass();
     }
 
-    void RenderMain::RunRenderPass()
+    bool RenderMain::RunRenderPass()
     {
-        if (Render())
+        bool succesful = Render();
+
+        if (succesful)
         {
             m_deviceResources.Present();
         }
+
+        return succesful;
     }
 
     // Renders the current frame according to the current application state.

--- a/src/GraphControl/DirectX/RenderMain.h
+++ b/src/GraphControl/DirectX/RenderMain.h
@@ -46,7 +46,7 @@ namespace GraphControl::DX
 
         void CreateWindowSizeDependentResources();
 
-        void RunRenderPass();
+        bool RunRenderPass();
 
         // Indicates if we are in active tracing mode (the tracing box is being used and controlled through keyboard input)
         property bool ActiveTracing


### PR DESCRIPTION
## Part of #338

### Description of the changes:
- Updates graph control to flag equations if they fail to graph
- Updates graph control to flag equations if they successfully graph
- Graph control will not try to graph any equations that have previously failed, unless their expression has changed
- When graphing an equation that was previously successful, if the graphing fails, we will flag that equation and try graphing again without it
- Added UI to indicate that an equation has failed to graph
- Some other code tweaks

### How changes were validated:
- Manual tests

