### PR TITLE
Changing CCalcEngine::s_engineStrings to use wstring_view for keys

### DIFF
--- a/src/CalcManager/CEngine/calc.cpp
+++ b/src/CalcManager/CEngine/calc.cpp
@@ -24,17 +24,16 @@ static constexpr wstring_view DEFAULT_NUMBER_STR = L"0";
 // Read strings for keys, errors, trig types, etc.
 // These will be copied from the resources to local memory.
 
-unordered_map<wstring, wstring> CCalcEngine::s_engineStrings;
+unordered_map<wstring_view, wstring> CCalcEngine::s_engineStrings;
 
 void CCalcEngine::LoadEngineStrings(CalculationManager::IResourceProvider& resourceProvider)
 {
     for (const auto& sid : g_sids)
     {
-        auto locKey = wstring{ sid };
-        auto locString = resourceProvider.GetCEngineString(locKey);
+        auto locString = resourceProvider.GetCEngineString(sid);
         if (!locString.empty())
         {
-            s_engineStrings[locKey] = locString;
+            s_engineStrings[sid] = locString;
         }
     }
 }

--- a/src/CalcManager/CalculatorResource.h
+++ b/src/CalcManager/CalculatorResource.h
@@ -1,7 +1,9 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
+
+#include <string_view>
 
 namespace CalculationManager
 {
@@ -19,6 +21,6 @@ namespace CalculationManager
         // ids "sDecimal", "sThousand" and "sGrouping". See
         // https://technet.microsoft.com/en-us/library/cc782655(v=ws.10).aspx
         // for what these values refer to.
-        virtual std::wstring GetCEngineString(const std::wstring& id) = 0;
+        virtual std::wstring GetCEngineString(std::wstring_view id) = 0;
     };
 }

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -98,7 +98,7 @@ public:
     {
         return s_engineStrings[std::to_wstring(ids)];
     }
-    static std::wstring_view GetString(std::wstring ids)
+    static std::wstring_view GetString(std::wstring_view ids)
     {
         return s_engineStrings[ids];
     }
@@ -161,7 +161,7 @@ private:
 
     std::array<CalcEngine::Rational, NUM_WIDTH_LENGTH> m_chopNumbers;      // word size enforcement
     std::array<std::wstring, NUM_WIDTH_LENGTH> m_maxDecimalValueStrings;   // maximum values represented by a given word width based off m_chopNumbers
-    static std::unordered_map<std::wstring, std::wstring> s_engineStrings; // the string table shared across all instances
+    static std::unordered_map<std::wstring_view, std::wstring> s_engineStrings; // the string table shared across all instances
     wchar_t m_decimalSeparator;
     wchar_t m_groupSeparator;
 

--- a/src/CalcViewModel/Common/EngineResourceProvider.cpp
+++ b/src/CalcViewModel/Common/EngineResourceProvider.cpp
@@ -17,7 +17,7 @@ namespace CalculatorApp
         m_resLoader = ResourceLoader::GetForViewIndependentUse("CEngineStrings");
     }
 
-    wstring EngineResourceProvider::GetCEngineString(const wstring& id)
+    wstring EngineResourceProvider::GetCEngineString(wstring_view id)
     {
         const auto& localizationSettings = LocalizationSettings::GetInstance();
 
@@ -43,7 +43,7 @@ namespace CalculatorApp
             return numberGroupingString;
         }
 
-        StringReference idRef(id.c_str());
+        StringReference idRef(id.data(), id.length());
         String ^ str = m_resLoader->GetString(idRef);
         return str->Begin();
     }

--- a/src/CalcViewModel/Common/EngineResourceProvider.h
+++ b/src/CalcViewModel/Common/EngineResourceProvider.h
@@ -11,7 +11,7 @@ namespace CalculatorApp
     {
     public:
         EngineResourceProvider();
-        virtual std::wstring GetCEngineString(const std::wstring& id) override;
+        virtual std::wstring GetCEngineString(std::wstring_view id) override;
 
     private:
         Windows::ApplicationModel::Resources::ResourceLoader ^ m_resLoader;


### PR DESCRIPTION
## Fixes #828.

### Description of the changes:
- Changed CalcEngine::s_engineStrings to unordered_map<wstring_view, wstring>
- Updated CCalcEngine::LoadEngineStrings to use wstring_view directly since it no longer needs to copy into a string
- Updated EngineResourceProvider::GetCEngineString to take a wstring_view as an argument

