### PR TITLE
Remove adjustment from local time

### DIFF
--- a/src/CalcViewModel/DateCalculatorViewModel.cpp
+++ b/src/CalcViewModel/DateCalculatorViewModel.cpp
@@ -60,7 +60,7 @@ DateCalculatorViewModel::DateCalculatorViewModel()
     auto today = calendar->GetDateTime();
 
     // FromDate and ToDate should be clipped (adjusted to a consistent hour in UTC)
-    m_fromDate = m_toDate = ClipTime(today, true);
+    m_fromDate = m_toDate = ClipTime(today);
 
     // StartDate should not be clipped
     m_startDate = today;
@@ -83,7 +83,7 @@ DateCalculatorViewModel::DateCalculatorViewModel()
 
     DayOfWeek trueDayOfWeek = calendar->DayOfWeek;
 
-    DateTime clippedTime = ClipTime(today, false);
+    DateTime clippedTime = ClipTime(today);
     calendar->SetDateTime(clippedTime);
     if (calendar->DayOfWeek != trueDayOfWeek)
     {
@@ -113,8 +113,8 @@ void DateCalculatorViewModel::OnInputsChanged()
 {
     if (m_IsDateDiffMode)
     {
-        DateTime clippedFromDate = ClipTime(FromDate, true);
-        DateTime clippedToDate = ClipTime(ToDate, true);
+        DateTime clippedFromDate = ClipTime(FromDate);
+        DateTime clippedToDate = ClipTime(ToDate);
 
         // Calculate difference between two dates
         auto dateDiff = m_dateCalcEngine->TryGetDateDifference(clippedFromDate, clippedToDate, m_daysOutputFormat);
@@ -386,30 +386,11 @@ String ^ DateCalculatorViewModel::GetLocalizedNumberString(int value) const
 /// Adjusts the given DateTime to 12AM of the same day
 /// </summary>
 /// <param name="dateTime">DateTime to clip</param>
-/// <param name="adjustUsingLocalTime">Adjust the datetime using local time (by default adjust using UTC time)</param>
-DateTime DateCalculatorViewModel::ClipTime(DateTime dateTime, bool adjustUsingLocalTime)
+DateTime DateCalculatorViewModel::ClipTime(DateTime dateTime)
 {
-    DateTime referenceDateTime;
-    if (adjustUsingLocalTime)
-    {
-        FILETIME fileTime;
-        fileTime.dwLowDateTime = (DWORD)(dateTime.UniversalTime & 0xffffffff);
-        fileTime.dwHighDateTime = (DWORD)(dateTime.UniversalTime >> 32);
-
-        FILETIME localFileTime;
-        FileTimeToLocalFileTime(&fileTime, &localFileTime);
-
-        referenceDateTime.UniversalTime = (DWORD)localFileTime.dwHighDateTime;
-        referenceDateTime.UniversalTime <<= 32;
-        referenceDateTime.UniversalTime |= (DWORD)localFileTime.dwLowDateTime;
-    }
-    else
-    {
-        referenceDateTime = dateTime;
-    }
     auto calendar = ref new Calendar();
     calendar->ChangeTimeZone("UTC");
-    calendar->SetDateTime(referenceDateTime);
+    calendar->SetDateTime(dateTime);
     calendar->Period = calendar->FirstPeriodInThisDay;
     calendar->Hour = calendar->FirstHourInThisPeriod;
     calendar->Minute = 0;

--- a/src/CalcViewModel/DateCalculatorViewModel.h
+++ b/src/CalcViewModel/DateCalculatorViewModel.h
@@ -110,7 +110,7 @@ namespace CalculatorApp
             Platform::String ^ GetDateDiffString() const;
             Platform::String ^ GetDateDiffStringInDays() const;
             Platform::String ^ GetLocalizedNumberString(int value) const;
-            static Windows::Foundation::DateTime ClipTime(Windows::Foundation::DateTime dateTime);
+            static Windows::Foundation::DateTime ClipTime(Windows::Foundation::DateTime dateTime, bool adjustUsingLocalTime = false);
 
             property bool IsOutOfBound
             {

--- a/src/CalcViewModel/DateCalculatorViewModel.h
+++ b/src/CalcViewModel/DateCalculatorViewModel.h
@@ -110,7 +110,7 @@ namespace CalculatorApp
             Platform::String ^ GetDateDiffString() const;
             Platform::String ^ GetDateDiffStringInDays() const;
             Platform::String ^ GetLocalizedNumberString(int value) const;
-            static Windows::Foundation::DateTime ClipTime(Windows::Foundation::DateTime dateTime, bool adjustToLocalTime);
+            static Windows::Foundation::DateTime ClipTime(Windows::Foundation::DateTime dateTime);
 
             property bool IsOutOfBound
             {


### PR DESCRIPTION
## Fixes #792.


### Description of the changes:
It looks like the CalendarDatePicker control now provides a UTC Date as the value, making it so the conditions in #557 do not apply anymore. The conversion from local time actually pushes the date forward a day. Changes due to #557 are reverted here.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Tested Manually
