### PR TITLE
Fix calculators in features/GraphingCalculator

### DIFF
--- a/src/CalcViewModel/Common/KeyboardShortcutManager.cpp
+++ b/src/CalcViewModel/Common/KeyboardShortcutManager.cpp
@@ -10,7 +10,6 @@
 using namespace Concurrency;
 using namespace Platform;
 using namespace std;
-using namespace std::chrono;
 using namespace Windows::ApplicationModel::Resources;
 using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;
@@ -432,8 +431,9 @@ void KeyboardShortcutManager::OnCharacterReceivedHandler(CoreWindow ^ sender, Ch
             wchar_t character = static_cast<wchar_t>(args->KeyCode);
             auto buttons = s_CharacterForButtons.find(viewId)->second.equal_range(character);
 
-            LightUpButtons(buttons);
             RunFirstEnabledButtonCommand(buttons);
+
+            LightUpButtons(buttons);
         }
     }
 }
@@ -601,8 +601,6 @@ void KeyboardShortcutManager::OnKeyDownHandler(CoreWindow ^ sender, KeyEventArgs
                         LightUpButtons(buttons);
                     }
                 }
-
-                RunFirstEnabledButtonCommand(buttons);
             }
         }
     }


### PR DESCRIPTION
The current branch `features/GraphingCalculator` has a major issue with the standard/scientific/programmer calculators, `1+1 =` displaying 3 for example.

The reason is a faulty merge with origin/master ~5 months ago that added an extra call to `RunFirstEnabledButtonCommand(buttons);` in `KeyboardShortcutManager.cpp`.

Because of that, the CalcManager receives 2 `EQU` commands when users type <kbd>Enter</kbd>. 

### Description of the changes:
- fix merge issues

### How changes were validated:
- manually

