### PR TITLE
Enable PR and CI builds for feature branches

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -7,9 +7,11 @@
 trigger:
 - master
 - servicing/*
+- feature/*
 pr:
 - master
 - servicing/*
+- feature/*
 
 name: 0.$(Date:yyMM).$(DayOfMonth)$(Rev:rr).0
 


### PR DESCRIPTION
Enable PR and CI builds for feature branches, like the graphing calculator feature branch.