### PR TITLE
Build GraphingCalculator against SDK 18362

### DIFF
--- a/src/CalcManager/CalcManager.vcxproj
+++ b/src/CalcManager/CalcManager.vcxproj
@@ -45,7 +45,7 @@
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.19019.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/CalcViewModel/CalcViewModel.vcxproj
+++ b/src/CalcViewModel/CalcViewModel.vcxproj
@@ -42,7 +42,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.19019.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/src/Calculator/Calculator.vcxproj
+++ b/src/Calculator/Calculator.vcxproj
@@ -8,7 +8,7 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.19019.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <!-- We want to manually control the MinVersion/MaxVersionTested in the manifest so turn of the replacement. -->
     <AppxOSMinVersionReplaceManifestVersion>false</AppxOSMinVersionReplaceManifestVersion>

--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -16,6 +16,19 @@ using namespace Windows::Foundation::Collections;
 
 DEPENDENCY_PROPERTY_INITIALIZATION(MathRichEditBox, MathText);
 
+// TODO remove when Windows 10 version 2004 SDK is adopted
+namespace Windows_2004_Prerelease
+{
+    constexpr auto RichEditMathMode_MathOnly = 1;
+
+    [uuid("619c20f2-cb3b-4521-981f-2865b1b93f04")] __interface ITextDocument4 : IInspectable
+    {
+        HRESULT SetMath(HSTRING value);
+        HRESULT GetMath(HSTRING * value);
+        HRESULT SetMathMode(int32_t mathMode);
+    };
+}
+
 MathRichEditBox::MathRichEditBox()
 {
     static LimitedAccessFeatureStatus m_lafResultStatus;
@@ -24,17 +37,19 @@ MathRichEditBox::MathRichEditBox()
     if (packageName == L"Microsoft.WindowsCalculator.Dev")
     {
         m_lafResultStatus = LimitedAccessFeatures::TryUnlockFeature(
-            "com.microsoft.windows.richeditmath",
-            "BeDD/jxKhz/yfVNA11t4uA==", // Microsoft.WindowsCalculator.Dev
-            "8wekyb3d8bbwe has registered their use of com.microsoft.windows.richeditmath with Microsoft and agrees to the terms of use.")->Status;
+                                "com.microsoft.windows.richeditmath",
+                                "BeDD/jxKhz/yfVNA11t4uA==", // Microsoft.WindowsCalculator.Dev
+                                "8wekyb3d8bbwe has registered their use of com.microsoft.windows.richeditmath with Microsoft and agrees to the terms of use.")
+                                ->Status;
     }
 
     else if (packageName == L"Microsoft.WindowsCalculator")
     {
         m_lafResultStatus = LimitedAccessFeatures::TryUnlockFeature(
-            "com.microsoft.windows.richeditmath",
-            "pfanNuxnzo+mAkBQ3N/rGQ==", // Microsoft.WindowsCalculator
-            "8wekyb3d8bbwe has registered their use of com.microsoft.windows.richeditmath with Microsoft and agrees to the terms of use.")->Status;
+                                "com.microsoft.windows.richeditmath",
+                                "pfanNuxnzo+mAkBQ3N/rGQ==", // Microsoft.WindowsCalculator
+                                "8wekyb3d8bbwe has registered their use of com.microsoft.windows.richeditmath with Microsoft and agrees to the terms of use.")
+                                ->Status;
     }
 
     else if (packageName == L"Microsoft.WindowsCalculator.Graphing")
@@ -42,17 +57,29 @@ MathRichEditBox::MathRichEditBox()
         m_lafResultStatus = LimitedAccessFeatures::TryUnlockFeature(
                                 "com.microsoft.windows.richeditmath",
                                 "H6wflFFz3gkOsAHtG/D9Tg==", // Microsoft.WindowsCalculator.Graphing
-                                "8wekyb3d8bbwe has registered their use of com.microsoft.windows.richeditmath with Microsoft and agrees to the terms of use.")->Status;
+                                "8wekyb3d8bbwe has registered their use of com.microsoft.windows.richeditmath with Microsoft and agrees to the terms of use.")
+                                ->Status;
     }
 
-    TextDocument->SetMathMode(Windows::UI::Text::RichEditMathMode::MathOnly);
+    // TODO when Windows 10 version 2004 SDK is adopted, replace with:
+    // TextDocument->SetMathMode(Windows::UI::Text::RichEditMathMode::MathOnly);
+    Microsoft::WRL::ComPtr<Windows_2004_Prerelease::ITextDocument4> textDocument4;
+    reinterpret_cast<IInspectable*>(this->TextDocument)->QueryInterface(IID_PPV_ARGS(&textDocument4));
+    textDocument4->SetMathMode(Windows_2004_Prerelease::RichEditMathMode_MathOnly);
 }
 
 String ^ MathRichEditBox::GetMathTextProperty()
 {
-    String ^ text;
-    this->TextDocument->GetMath(&text);
-    return text;
+    // TODO when Windows 10 version 2004 SDK is adopted, replace with:
+    // String ^ text;
+    // this->TextDocument->GetMath(&text);
+    // return text;
+
+    Microsoft::WRL::ComPtr<Windows_2004_Prerelease::ITextDocument4> textDocument4;
+    reinterpret_cast<IInspectable*>(this->TextDocument)->QueryInterface(IID_PPV_ARGS(&textDocument4));
+    HSTRING math;
+    textDocument4->GetMath(&math);
+    return reinterpret_cast<String ^>(math);
 }
 
 void MathRichEditBox::SetMathTextProperty(String ^ newValue)
@@ -60,7 +87,11 @@ void MathRichEditBox::SetMathTextProperty(String ^ newValue)
     bool readOnlyState = this->IsReadOnly;
     this->IsReadOnly = false;
 
-    TextDocument->SetMath(newValue);
+    // TODO when Windows 10 version 2004 SDK is adopted, replace with:
+    // TextDocument->SetMath(newValue);
+    Microsoft::WRL::ComPtr<Windows_2004_Prerelease::ITextDocument4> textDocument4;
+    reinterpret_cast<IInspectable*>(this->TextDocument)->QueryInterface(IID_PPV_ARGS(&textDocument4));
+    textDocument4->SetMath(reinterpret_cast<HSTRING>(newValue));
 
     this->IsReadOnly = readOnlyState;
 }

--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -65,7 +65,11 @@ MathRichEditBox::MathRichEditBox()
     // TextDocument->SetMathMode(Windows::UI::Text::RichEditMathMode::MathOnly);
     Microsoft::WRL::ComPtr<Windows_2004_Prerelease::ITextDocument4> textDocument4;
     reinterpret_cast<IInspectable*>(this->TextDocument)->QueryInterface(IID_PPV_ARGS(&textDocument4));
-    textDocument4->SetMathMode(Windows_2004_Prerelease::RichEditMathMode_MathOnly);
+    auto hr = textDocument4->SetMathMode(Windows_2004_Prerelease::RichEditMathMode_MathOnly);
+    if (FAILED(hr))
+    {
+        throw Exception::CreateException(hr);
+    }
 }
 
 String ^ MathRichEditBox::GetMathTextProperty()
@@ -78,7 +82,11 @@ String ^ MathRichEditBox::GetMathTextProperty()
     Microsoft::WRL::ComPtr<Windows_2004_Prerelease::ITextDocument4> textDocument4;
     reinterpret_cast<IInspectable*>(this->TextDocument)->QueryInterface(IID_PPV_ARGS(&textDocument4));
     HSTRING math;
-    textDocument4->GetMath(&math);
+    auto hr = textDocument4->GetMath(&math);
+    if (FAILED(hr))
+    {
+        throw Exception::CreateException(hr);
+    }
     return reinterpret_cast<String ^>(math);
 }
 
@@ -91,7 +99,11 @@ void MathRichEditBox::SetMathTextProperty(String ^ newValue)
     // TextDocument->SetMath(newValue);
     Microsoft::WRL::ComPtr<Windows_2004_Prerelease::ITextDocument4> textDocument4;
     reinterpret_cast<IInspectable*>(this->TextDocument)->QueryInterface(IID_PPV_ARGS(&textDocument4));
-    textDocument4->SetMath(reinterpret_cast<HSTRING>(newValue));
+    auto hr = textDocument4->SetMath(reinterpret_cast<HSTRING>(newValue));
+    if (FAILED(hr))
+    {
+        throw Exception::CreateException(hr);
+    }
 
     this->IsReadOnly = readOnlyState;
 }

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -7,7 +7,7 @@
     <MinimumVisualStudioVersion>15.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.19019.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition=" '$(WindowsTargetPlatformVersion)' == '' ">10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
     <UnitTestPlatformVersion Condition="'$(UnitTestPlatformVersion)' == ''">15.0</UnitTestPlatformVersion>

--- a/src/GraphControl/GraphControl.vcxproj
+++ b/src/GraphControl/GraphControl.vcxproj
@@ -42,7 +42,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.19019.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion Condition="'$(WindowsTargetPlatformVersion)' == ''">10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>

--- a/src/MockGraphingImpl/MockGraphingImpl.vcxproj
+++ b/src/MockGraphingImpl/MockGraphingImpl.vcxproj
@@ -42,7 +42,7 @@
     <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <AppContainerApplication>true</AppContainerApplication>
     <ApplicationType>Windows Store</ApplicationType>
-    <WindowsTargetPlatformVersion>10.0.19019.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
     <WindowsTargetPlatformMinVersion>10.0.17134.0</WindowsTargetPlatformMinVersion>
     <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
   </PropertyGroup>


### PR DESCRIPTION
Allow the feature/GraphingCalculator branch to build without having a pre-release SDK installed on the build machines.
- Retarget projects back to 18362
- For the few APIs we need to use which are newer than 18362, use COM interop to call the methods directly

This change can be reverted once the Windows 10 version 2004 SDK is released and installed on the Azure Pipelines hosted build agents.