### PR TITLE
Change GraphingCalculator package identity back to WindowsCalculator.Dev

### DIFF
--- a/src/Calculator/Package.appxmanifest
+++ b/src/Calculator/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap uap5 mp">
-    <Identity Name="Microsoft.WindowsCalculator.Graphing" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.1.0" />
+    <Identity Name="Microsoft.WindowsCalculator.Dev" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="0.0.1.0" />
     <mp:PhoneIdentity PhoneProductId="b58171c6-c70c-4266-a2e8-8f9c994f4456" PhonePublisherId="95d94207-0c7c-47ed-82db-d75c81153c35" />
     <Properties>
         <DisplayName>ms-resource:DevAppStoreName</DisplayName>


### PR DESCRIPTION
In the feature/GraphingCalculator branch, the app's package identity was set to Microsoft.WindowsCalculator.Graphing. Set it back to Microsoft.WindowsCalculator.Dev (same as the master branch), since we do not intend to keep this change when development is completed.

This change is required to get UI tests running on the feature/GraphingCalculator branch.