### PR TITLE
Update navigation unit tests for graphing

### DIFF
--- a/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
+++ b/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
@@ -261,8 +261,8 @@ namespace CalculatorUnitTests
             ViewMode::Standard,
             ViewMode::Scientific,
             ViewMode::Programmer,
-            ViewMode::Date,
             ViewMode::Graphing,
+            ViewMode::Date,
             ViewMode::Currency,
             ViewMode::Volume,
             ViewMode::Length,
@@ -291,7 +291,7 @@ namespace CalculatorUnitTests
     void NavCategoryUnitTests::GetPosition()
     {
         // Position is the 1-based ordering of modes
-        vector<ViewMode> orderedModes = { ViewMode::Standard, ViewMode::Scientific, ViewMode::Programmer, ViewMode::Date,     ViewMode::Graphing,
+        vector<ViewMode> orderedModes = { ViewMode::Standard, ViewMode::Scientific, ViewMode::Programmer, ViewMode::Graphing, ViewMode::Date,
                                           ViewMode::Currency, ViewMode::Volume,   ViewMode::Length,     ViewMode::Weight,     ViewMode::Temperature,
                                           ViewMode::Energy,   ViewMode::Area,     ViewMode::Speed,      ViewMode::Time,       ViewMode::Power,
                                           ViewMode::Data,     ViewMode::Pressure, ViewMode::Angle };
@@ -320,8 +320,8 @@ namespace CalculatorUnitTests
         VERIFY_ARE_EQUAL(0, NavCategory::GetIndexInGroup(ViewMode::Standard, CategoryGroupType::Calculator));
         VERIFY_ARE_EQUAL(1, NavCategory::GetIndexInGroup(ViewMode::Scientific, CategoryGroupType::Calculator));
         VERIFY_ARE_EQUAL(2, NavCategory::GetIndexInGroup(ViewMode::Programmer, CategoryGroupType::Calculator));
-        VERIFY_ARE_EQUAL(3, NavCategory::GetIndexInGroup(ViewMode::Date, CategoryGroupType::Calculator));
-        VERIFY_ARE_EQUAL(4, NavCategory::GetIndexInGroup(ViewMode::Graphing, CategoryGroupType::Calculator));
+        VERIFY_ARE_EQUAL(3, NavCategory::GetIndexInGroup(ViewMode::Graphing, CategoryGroupType::Calculator));
+        VERIFY_ARE_EQUAL(4, NavCategory::GetIndexInGroup(ViewMode::Date, CategoryGroupType::Calculator));
 
         VERIFY_ARE_EQUAL(0, NavCategory::GetIndexInGroup(ViewMode::Currency, CategoryGroupType::Converter));
         VERIFY_ARE_EQUAL(1, NavCategory::GetIndexInGroup(ViewMode::Volume, CategoryGroupType::Converter));
@@ -381,8 +381,8 @@ namespace CalculatorUnitTests
         ValidateNavCategory(calculatorCategories, 0u, ViewMode::Standard, 1);
         ValidateNavCategory(calculatorCategories, 1u, ViewMode::Scientific, 2);
         ValidateNavCategory(calculatorCategories, 2u, ViewMode::Programmer, 3);
-        ValidateNavCategory(calculatorCategories, 3u, ViewMode::Date, 4);
-        ValidateNavCategory(calculatorCategories, 4u, ViewMode::Graphing, 5);
+        ValidateNavCategory(calculatorCategories, 3u, ViewMode::Graphing, 4);
+        ValidateNavCategory(calculatorCategories, 4u, ViewMode::Date, 5);
 
         NavCategoryGroup ^ converterGroup = menuOptions->GetAt(1);
         VERIFY_ARE_EQUAL(CategoryGroupType::Converter, converterGroup->GroupType);


### PR DESCRIPTION
At some point, the design of the navigation menu changed such that graphing calculator now appears above date calculator. The unit tests need to be updated to account for this change.

With this update, unit tests should pass in the CI builds for the graphing calculator feature branch.