### PR TITLE
Build and test x86 in PR builds

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -23,7 +23,6 @@ jobs:
 - template: ./templates/build-app-public.yaml
   parameters:
     platform: x86
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
 - template: ./templates/build-app-public.yaml
   parameters:


### PR DESCRIPTION
Currently, our unit tests aren't running properly in x64 because of a VSTest issue (#721).

Until we can get this fixed, run x86 builds and tests for PR builds.