### PR TITLE
Hide or Disable graphing calculator menu item when necessary

### DIFF
--- a/src/CalcViewModel/Common/NavCategory.cpp
+++ b/src/CalcViewModel/Common/NavCategory.cpp
@@ -84,23 +84,26 @@ bool IsGraphingModeEnabled()
     {
         return _isGraphingModeEnabledCached->Value;
     }
+
     DWORD allowGraphingCalculator{ 0 };
     DWORD bufferSize{ sizeof(allowGraphingCalculator) };
-    // Make sure to call RegOpenKey only on Windows 10 1903+
-    if (!RegGetValueW(
+    // Make sure to call RegGetValueW only on Windows 10 1903+
+    if (RegGetValueW(
             HKEY_LOCAL_MACHINE,
             L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Calculator",
             L"AllowGraphingCalculator",
-            RRF_RT_REG_DWORD,
+            RRF_RT_REG_DWORD | RRF_RT_REG_BINARY,
             nullptr,
             reinterpret_cast<LPBYTE>(&allowGraphingCalculator),
-            &bufferSize) != ERROR_SUCCESS)
+            &bufferSize)
+        == ERROR_SUCCESS)
+    {
+        _isGraphingModeEnabledCached = allowGraphingCalculator != 0;
+    }
+    else
     {
         _isGraphingModeEnabledCached = true;
-        return true;
     }
-
-    _isGraphingModeEnabledCached = allowGraphingCalculator != 0;
     return _isGraphingModeEnabledCached->Value;
 }
 

--- a/src/CalcViewModel/Common/NavCategory.h
+++ b/src/CalcViewModel/Common/NavCategory.h
@@ -67,7 +67,9 @@ namespace CalculatorApp
                 wchar_t const* glyph,
                 CategoryGroupType group,
                 MyVirtualKey vKey,
-                bool categorySupportsNegative)
+                wchar_t const* aKey,
+                bool categorySupportsNegative,
+                bool enabled)
                 : viewMode(mode)
                 , serializationId(id)
                 , friendlyName(name)
@@ -75,7 +77,9 @@ namespace CalculatorApp
                 , glyph(glyph)
                 , groupType(group)
                 , virtualKey(vKey)
+                , accessKey(aKey)
                 , supportsNegative(categorySupportsNegative)
+                , isEnabled(enabled)
             {
             }
 
@@ -86,7 +90,9 @@ namespace CalculatorApp
             const wchar_t* const glyph;
             const CategoryGroupType groupType;
             const MyVirtualKey virtualKey;
+            const wchar_t* const accessKey;
             const bool supportsNegative;
+            const bool isEnabled;
         };
 
     private
@@ -110,45 +116,17 @@ namespace CalculatorApp
         {
         public:
             OBSERVABLE_OBJECT();
+            PROPERTY_R(Platform::String ^, Name);
+            PROPERTY_R(Platform::String ^, AutomationName);
+            PROPERTY_R(Platform::String ^, Glyph);
+            PROPERTY_R(ViewMode, Mode);
+            PROPERTY_R(Platform::String ^, AccessKey);
+            PROPERTY_R(bool, SupportsNegative);
+            PROPERTY_R(bool, IsEnabled);
 
             property Platform::String
-                ^ Name { Platform::String ^ get() { return m_name; } }
+                ^ AutomationId { Platform::String ^ get() { return m_Mode.ToString(); } }
 
-                property Platform::String
-                ^ AutomationName { Platform::String ^ get() { return m_automationName; } }
-
-                property Platform::String
-                ^ Glyph { Platform::String ^ get() { return m_glyph; } }
-
-                property int Position
-            {
-                int get()
-                {
-                    return m_position;
-                }
-            }
-
-            property ViewMode Mode
-            {
-                ViewMode get()
-                {
-                    return m_viewMode;
-                }
-            }
-
-            property Platform::String
-                ^ AutomationId { Platform::String ^ get() { return m_viewMode.ToString(); } }
-
-                property Platform::String
-                ^ AccessKey { Platform::String ^ get() { return m_accessKey; } }
-
-                property bool SupportsNegative
-            {
-                bool get()
-                {
-                    return m_supportsNegative;
-                }
-            }
 
             // For saving/restoring last mode used.
             static int Serialize(ViewMode mode);
@@ -180,16 +158,17 @@ namespace CalculatorApp
                            Platform::String ^ accessKey,
                            Platform::String ^ mode,
                            ViewMode viewMode,
-                           bool supportsNegative)
-                : m_name(name)
-                , m_automationName(automationName)
-                , m_glyph(glyph)
-                , m_accessKey(accessKey)
-                , m_mode(mode)
-                , m_viewMode(viewMode)
-                , m_supportsNegative(supportsNegative)
+                           bool supportsNegative,
+                           bool isEnabled)
+                : m_Name(name)
+                , m_AutomationName(automationName)
+                , m_Glyph(glyph)
+                , m_AccessKey(accessKey)
+                , m_modeString(mode)
+                , m_Mode(viewMode)
+                , m_SupportsNegative(supportsNegative)
+                , m_IsEnabled(isEnabled)
             {
-                m_position = NavCategory::GetPosition(m_viewMode);
             }
 
             static std::vector<MyVirtualKey> GetCategoryAcceleratorKeys();
@@ -197,14 +176,7 @@ namespace CalculatorApp
         private:
             static bool IsModeInCategoryGroup(ViewMode mode, CategoryGroupType groupType);
 
-            ViewMode m_viewMode;
-            Platform::String ^ m_name;
-            Platform::String ^ m_automationName;
-            Platform::String ^ m_glyph;
-            Platform::String ^ m_accessKey;
-            Platform::String ^ m_mode;
-            int m_position;
-            bool m_supportsNegative;
+            Platform::String ^ m_modeString;
         };
 
         [Windows::UI::Xaml::Data::Bindable] public ref class NavCategoryGroup sealed : public Windows::UI::Xaml::Data::INotifyPropertyChanged
@@ -218,15 +190,11 @@ namespace CalculatorApp
 
             static Windows::Foundation::Collections::IObservableVector<NavCategoryGroup ^> ^ CreateMenuOptions();
 
-            static Platform::String ^ GetHeaderResourceKey(CategoryGroupType type);
-
             internal : static NavCategoryGroup ^ CreateCalculatorCategory();
             static NavCategoryGroup ^ CreateConverterCategory();
 
         private:
             NavCategoryGroup(const NavCategoryGroupInitializer& groupInitializer);
-
-            static std::vector<NavCategoryInitializer> GetInitializerCategoryGroup(CategoryGroupType groupType);
         };
     }
 }

--- a/src/CalcViewModel/pch.h
+++ b/src/CalcViewModel/pch.h
@@ -40,6 +40,7 @@
 #include "winrt/Windows.Globalization.DateTimeFormatting.h"
 #include "winrt/Windows.System.UserProfile.h"
 #include "winrt/Windows.UI.Xaml.h"
+#include "winrt/Windows.Foundation.Metadata.h"
 
 // The following namespaces exist as a convenience to resolve
 // ambiguity for Windows types in the Windows::UI::Xaml::Automation::Peers

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3163,10 +3163,6 @@
     <value>AB</value>
     <comment>AccessKey for the About button. {StringCategory="Accelerator"}</comment>
   </data>
-  <data name="DateCalculationModeAccessKey" xml:space="preserve">
-    <value>4</value>
-    <comment>AccessKey for the Date Calculation mode navbar item. {StringCategory="Accelerator"}</comment>
-  </data>
   <data name="HistoryButton.AccessKey" xml:space="preserve">
     <value>I</value>
     <comment>Access key for the History button. {StringCategory="Accelerator"}</comment>
@@ -3178,18 +3174,6 @@
   <data name="NavView.AccessKey" xml:space="preserve">
     <value>H</value>
     <comment>Access key for the Hamburger button. {StringCategory="Accelerator"}</comment>
-  </data>
-  <data name="ProgrammerModeAccessKey" xml:space="preserve">
-    <value>3</value>
-    <comment>AccessKey for the Programmer mode navbar item. {StringCategory="Accelerator"}</comment>
-  </data>
-  <data name="ScientificModeAccessKey" xml:space="preserve">
-    <value>2</value>
-    <comment>AccessKey for the Scientific mode navbar item. {StringCategory="Accelerator"}</comment>
-  </data>
-  <data name="StandardModeAccessKey" xml:space="preserve">
-    <value>1</value>
-    <comment>AccessKey for the Standard mode navbar item. {StringCategory="Accelerator"}</comment>
   </data>
   <data name="CategoryName_AngleAccessKey" xml:space="preserve">
     <value>AN</value>

--- a/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
+++ b/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
@@ -38,28 +38,29 @@
                             </Grid.RowDefinitions>
 
                             <Button x:Name="KGFEquationButton"
-                                          x:Uid="equationAnalysisBack"
-                                          MinWidth="44"
-                                          MinHeight="44"
-                                          VerticalAlignment="Stretch"
-                                          Background="{TemplateBinding EquationColor}"
-                                          Foreground="{StaticResource SystemChromeWhiteColor}"
-                                          BorderThickness="0">
+                                    x:Uid="equationAnalysisBack"
+                                    MinWidth="44"
+                                    MinHeight="44"
+                                    VerticalAlignment="Stretch"
+                                    Background="{TemplateBinding EquationColor}"
+                                    Foreground="{StaticResource SystemChromeWhiteColor}"
+                                    BorderThickness="0">
                                 <Button.Content>
                                     <StackPanel x:Name="FunctionNumberLabel"
-                                                    HorizontalAlignment="Center"
-                                                    VerticalAlignment="Center"
-                                                    Background="Transparent"
-                                                    Orientation="Horizontal"
-                                                    Margin="5,0">
-                                        <FontIcon VerticalAlignment="Center"
+                                                Margin="5,0"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Background="Transparent"
+                                                Orientation="Horizontal">
+                                        <FontIcon Margin="0,0,6,0"
+                                                  VerticalAlignment="Center"
                                                   FontFamily="{ThemeResource SymbolThemeFontFamily}"
                                                   FontSize="16"
-                                                  Glyph="&#xE72B;" Margin="0,0,6,0"/>
+                                                  Glyph="&#xE72B;"/>
                                         <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xF893;"/>
                                         <TextBlock Margin="-5,19,0,0"
-                                                       FontSize="11"
-                                                       Text="{TemplateBinding EquationButtonContentIndex}"/>
+                                                   FontSize="11"
+                                                   Text="{TemplateBinding EquationButtonContentIndex}"/>
                                     </StackPanel>
 
                                 </Button.Content>
@@ -201,9 +202,9 @@
                             <ContentPresenter x:Name="DescriptionPresenter"
                                               Grid.Row="2"
                                               Foreground="{ThemeResource SystemControlDescriptionTextForegroundBrush}"
-                                              x:Load="False"
                                               AutomationProperties.AccessibilityView="Raw"
-                                              Content="{TemplateBinding Description}"/>
+                                              Content="{TemplateBinding Description}"
+                                              x:Load="False"/>
 
                         </Grid>
 

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -499,6 +499,7 @@ MUXC::NavigationViewItem ^ MainPage::CreateNavViewItemFromCategory(NavCategory ^
 
     item->Content = category->Name;
     item->AccessKey = category->AccessKey;
+    item->IsEnabled = category->IsEnabled;
     item->Style = static_cast<Windows::UI::Xaml::Style ^>(Resources->Lookup(L"NavViewItemStyle"));
 
     AutomationProperties::SetName(item, category->AutomationName);

--- a/src/CalculatorUnitTests/CurrencyConverterUnitTests.cpp
+++ b/src/CalculatorUnitTests/CurrencyConverterUnitTests.cpp
@@ -103,8 +103,6 @@ namespace CalculatorUnitTests
 {
     constexpr auto sc_Language_EN = L"en-US";
 
-    const UCM::Category CURRENCY_CATEGORY = { NavCategory::Serialize(ViewMode::Currency), L"Currency", false /*supportsNegative*/ };
-
     unique_ptr<CurrencyDataLoader> MakeLoaderWithResults(String ^ staticResponse, String ^ allRatiosResponse)
     {
         auto client = make_unique<MockCurrencyHttpClientWithResult>(staticResponse, allRatiosResponse);
@@ -382,8 +380,12 @@ TEST_METHOD(Load_Success_LoadedFromWeb)
 }
 ;
 
-TEST_CLASS(CurrencyConverterUnitTests){ const UCM::Unit GetUnit(const vector<UCM::Unit>& unitList, const wstring& target){
-    return *find_if(begin(unitList), end(unitList), [&target](const UCM::Unit& u) { return u.abbreviation == target; });
+TEST_CLASS(CurrencyConverterUnitTests){
+
+    const UCM::Category CURRENCY_CATEGORY = { NavCategory::Serialize(ViewMode::Currency), L"Currency", false /*supportsNegative*/ };
+
+    const UCM::Unit GetUnit(const vector<UCM::Unit>& unitList, const wstring& target){
+        return *find_if(begin(unitList), end(unitList), [&target](const UCM::Unit& u) { return u.abbreviation == target; });
 }
 
 TEST_METHOD(Loaded_LoadOrderedUnits)

--- a/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
+++ b/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
@@ -260,8 +260,8 @@ namespace CalculatorUnitTests
         ViewMode orderedModes[] = {
             ViewMode::Standard,
             ViewMode::Scientific,
-            ViewMode::Programmer,
             ViewMode::Graphing,
+            ViewMode::Programmer,
             ViewMode::Date,
             ViewMode::Currency,
             ViewMode::Volume,
@@ -291,7 +291,7 @@ namespace CalculatorUnitTests
     void NavCategoryUnitTests::GetPosition()
     {
         // Position is the 1-based ordering of modes
-        vector<ViewMode> orderedModes = { ViewMode::Standard, ViewMode::Scientific, ViewMode::Programmer, ViewMode::Graphing, ViewMode::Date,
+        vector<ViewMode> orderedModes = { ViewMode::Standard, ViewMode::Scientific, ViewMode::Graphing, ViewMode::Programmer, ViewMode::Date,
                                           ViewMode::Currency, ViewMode::Volume,   ViewMode::Length,     ViewMode::Weight,     ViewMode::Temperature,
                                           ViewMode::Energy,   ViewMode::Area,     ViewMode::Speed,      ViewMode::Time,       ViewMode::Power,
                                           ViewMode::Data,     ViewMode::Pressure, ViewMode::Angle };
@@ -319,8 +319,8 @@ namespace CalculatorUnitTests
     {
         VERIFY_ARE_EQUAL(0, NavCategory::GetIndexInGroup(ViewMode::Standard, CategoryGroupType::Calculator));
         VERIFY_ARE_EQUAL(1, NavCategory::GetIndexInGroup(ViewMode::Scientific, CategoryGroupType::Calculator));
-        VERIFY_ARE_EQUAL(2, NavCategory::GetIndexInGroup(ViewMode::Programmer, CategoryGroupType::Calculator));
-        VERIFY_ARE_EQUAL(3, NavCategory::GetIndexInGroup(ViewMode::Graphing, CategoryGroupType::Calculator));
+        VERIFY_ARE_EQUAL(2, NavCategory::GetIndexInGroup(ViewMode::Graphing, CategoryGroupType::Calculator));
+        VERIFY_ARE_EQUAL(3, NavCategory::GetIndexInGroup(ViewMode::Programmer, CategoryGroupType::Calculator));
         VERIFY_ARE_EQUAL(4, NavCategory::GetIndexInGroup(ViewMode::Date, CategoryGroupType::Calculator));
 
         VERIFY_ARE_EQUAL(0, NavCategory::GetIndexInGroup(ViewMode::Currency, CategoryGroupType::Converter));
@@ -345,9 +345,17 @@ namespace CalculatorUnitTests
     {
         VERIFY_ARE_EQUAL(ViewMode::Standard, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number1));
         VERIFY_ARE_EQUAL(ViewMode::Scientific, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number2));
-        VERIFY_ARE_EQUAL(ViewMode::Programmer, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number3));
-        VERIFY_ARE_EQUAL(ViewMode::Date, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number4));
-        VERIFY_ARE_EQUAL(ViewMode::Graphing, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number5));
+        if (Windows::Foundation::Metadata::ApiInformation::IsMethodPresent("Windows.UI.Text.RichEditTextDocument", "GetMath"))
+        {
+            VERIFY_ARE_EQUAL(ViewMode::Graphing, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number3));
+            VERIFY_ARE_EQUAL(ViewMode::Programmer, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number4));
+            VERIFY_ARE_EQUAL(ViewMode::Date, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number5));
+        }
+        else
+        {
+            VERIFY_ARE_EQUAL(ViewMode::Programmer, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number3));
+            VERIFY_ARE_EQUAL(ViewMode::Date, NavCategory::GetViewModeForVirtualKey(MyVirtualKey::Number4));
+        }
     }
 
     TEST_CLASS(NavCategoryGroupUnitTests)

--- a/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
+++ b/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
@@ -356,14 +356,13 @@ namespace CalculatorUnitTests
         TEST_METHOD(CreateNavCategoryGroup);
 
     private:
-        void ValidateNavCategory(IObservableVector<NavCategory ^> ^ categories, unsigned int index, ViewMode expectedMode, int expectedPosition)
+        void ValidateNavCategory(IObservableVector<NavCategory ^> ^ categories, unsigned int index, ViewMode expectedMode)
         {
             VERIFY_IS_LESS_THAN(0u, categories->Size);
             VERIFY_IS_GREATER_THAN(categories->Size, index);
 
             NavCategory ^ category = categories->GetAt(index);
             VERIFY_ARE_EQUAL(expectedMode, category->Mode);
-            VERIFY_ARE_EQUAL(expectedPosition, category->Position);
         }
     };
 
@@ -378,29 +377,37 @@ namespace CalculatorUnitTests
 
         IObservableVector<NavCategory^>^ calculatorCategories = calculatorGroup->Categories;
         VERIFY_ARE_EQUAL(5, calculatorCategories->Size);
-        ValidateNavCategory(calculatorCategories, 0u, ViewMode::Standard, 1);
-        ValidateNavCategory(calculatorCategories, 1u, ViewMode::Scientific, 2);
-        ValidateNavCategory(calculatorCategories, 2u, ViewMode::Programmer, 3);
-        ValidateNavCategory(calculatorCategories, 3u, ViewMode::Graphing, 4);
-        ValidateNavCategory(calculatorCategories, 4u, ViewMode::Date, 5);
+		ValidateNavCategory(calculatorCategories, 0u, ViewMode::Standard);
+		ValidateNavCategory(calculatorCategories, 1u, ViewMode::Scientific);
+		if (Windows::Foundation::Metadata::ApiInformation::IsMethodPresent("Windows.UI.Text.RichEditTextDocument", "GetMath"))
+		{
+			ValidateNavCategory(calculatorCategories, 2u, ViewMode::Graphing);
+			ValidateNavCategory(calculatorCategories, 3u, ViewMode::Programmer);
+			ValidateNavCategory(calculatorCategories, 4u, ViewMode::Date);
+		}
+		else 
+		{
+			ValidateNavCategory(calculatorCategories, 2u, ViewMode::Programmer);
+			ValidateNavCategory(calculatorCategories, 3u, ViewMode::Date);
+		}
 
         NavCategoryGroup ^ converterGroup = menuOptions->GetAt(1);
         VERIFY_ARE_EQUAL(CategoryGroupType::Converter, converterGroup->GroupType);
 
         IObservableVector<NavCategory ^> ^ converterCategories = converterGroup->Categories;
         VERIFY_ARE_EQUAL(13, converterCategories->Size);
-        ValidateNavCategory(converterCategories, 0u, ViewMode::Currency, 6);
-        ValidateNavCategory(converterCategories, 1u, ViewMode::Volume, 7);
-        ValidateNavCategory(converterCategories, 2u, ViewMode::Length, 8);
-        ValidateNavCategory(converterCategories, 3u, ViewMode::Weight, 9);
-        ValidateNavCategory(converterCategories, 4u, ViewMode::Temperature, 10);
-        ValidateNavCategory(converterCategories, 5u, ViewMode::Energy, 11);
-        ValidateNavCategory(converterCategories, 6u, ViewMode::Area, 12);
-        ValidateNavCategory(converterCategories, 7u, ViewMode::Speed, 13);
-        ValidateNavCategory(converterCategories, 8u, ViewMode::Time, 14);
-        ValidateNavCategory(converterCategories, 9u, ViewMode::Power, 15);
-        ValidateNavCategory(converterCategories, 10u, ViewMode::Data, 16);
-        ValidateNavCategory(converterCategories, 11u, ViewMode::Pressure, 17);
-        ValidateNavCategory(converterCategories, 12u, ViewMode::Angle, 18);
+        ValidateNavCategory(converterCategories, 0u, ViewMode::Currency);
+        ValidateNavCategory(converterCategories, 1u, ViewMode::Volume);
+        ValidateNavCategory(converterCategories, 2u, ViewMode::Length);
+        ValidateNavCategory(converterCategories, 3u, ViewMode::Weight);
+        ValidateNavCategory(converterCategories, 4u, ViewMode::Temperature);
+        ValidateNavCategory(converterCategories, 5u, ViewMode::Energy);
+        ValidateNavCategory(converterCategories, 6u, ViewMode::Area);
+        ValidateNavCategory(converterCategories, 7u, ViewMode::Speed);
+        ValidateNavCategory(converterCategories, 8u, ViewMode::Time);
+        ValidateNavCategory(converterCategories, 9u, ViewMode::Power);
+        ValidateNavCategory(converterCategories, 10u, ViewMode::Data);
+        ValidateNavCategory(converterCategories, 11u, ViewMode::Pressure);
+        ValidateNavCategory(converterCategories, 12u, ViewMode::Angle);
     }
 }


### PR DESCRIPTION
Hide the graphing calculator menu item when the OS doesn't support the feature or disable it when a group policy is set.

## Description of the changes:
- Hide the Graphing Calculator menu when running Windows versions prior to Vibranium
- Disable the Graphing Calculator menu when a group policy is set 
- Switch to the default view (Standard mode) when Graphing Calculator was the last used feature but the feature was disable later by the group policy
- modify accelerator keys of Programmer mode and Date Calculation if the Graphing Calculator menu item is visible or not (`3 and 4` or `4 and 5`)

Also:
- simplify `NavCategory` class
- remove NavCategory::Position (never used)

### How changes were validated:
- manually
