### PR TITLE
Add context menu to rich edit to allow for keyboard support

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -1890,7 +1890,7 @@
 
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
-                                        
+
                                         <VisualState x:Name="Normal">
                                             <Storyboard>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="EquationBoxBorder" Storyboard.TargetProperty="BorderBrush">
@@ -2179,7 +2179,27 @@
                                                                   AcceptsReturn="false"
                                                                   InputScope="Text"
                                                                   MaxLength="2048"
-                                                                  TextWrapping="NoWrap"/>
+                                                                  TextWrapping="NoWrap">
+                                            <Controls:MathRichEditBox.ContextFlyout>
+                                                <MenuFlyout x:Name="MathRichEditContextMenu">
+                                                    <MenuFlyoutItem x:Name="FunctionAnalysisMenuItem">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xE3B5;"/>
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                    <MenuFlyoutItem x:Name="ChangeFunctionStyleMenuItem">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xE790;"/>
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                    <MenuFlyoutItem x:Name="RemoveFunctionMenuItem">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xECC9;"/>
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                </MenuFlyout>
+                                            </Controls:MathRichEditBox.ContextFlyout>
+                                        </Controls:MathRichEditBox>
                                         <!-- TODO: Use brush overrides here instead of a new style, use a new style for the EquationButton above once that has more functionality -->
                                         <Button x:Name="DeleteButton"
                                                 Grid.Column="3"
@@ -2197,14 +2217,14 @@
                                                 IsTabStop="False"
                                                 Visibility="Collapsed"/>
                                         <FontIcon x:Name="ErrorIcon"
-                                                Grid.Column="3"
-                                                MinWidth="34"
-                                                VerticalAlignment="Stretch"
-                                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                                AutomationProperties.AccessibilityView="Raw"
-                                                Glyph="&#xE783;"
-                                                FontSize="16"
-                                                Visibility="Collapsed"/>
+                                                  Grid.Column="3"
+                                                  MinWidth="34"
+                                                  VerticalAlignment="Stretch"
+                                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                  FontSize="16"
+                                                  AutomationProperties.AccessibilityView="Raw"
+                                                  Glyph="&#xE783;"
+                                                  Visibility="Collapsed"/>
                                         <Button x:Name="RemoveButton"
                                                 x:Uid="removeButton"
                                                 Grid.Column="3"

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -353,7 +353,7 @@ bool EquationTextBox::RichEditHasContent()
     return (!text->IsEmpty() && m_HasFocus);
 }
 
-void EquationTextBox::OnRichEditMenuOpening(Platform::Object ^ sender, Platform::Object ^ args)
+void EquationTextBox::OnRichEditMenuOpening(Object ^ /*sender*/, Object ^ /*args*/)
 {
     if (m_kgfEquationMenuItem != nullptr)
     {

--- a/src/Calculator/Controls/EquationTextBox.h
+++ b/src/Calculator/Controls/EquationTextBox.h
@@ -46,7 +46,7 @@ namespace CalculatorApp
         private:
             void UpdateCommonVisualState();
             void UpdateDeleteButtonVisualState();
-            bool ShouldDeleteButtonBeVisible();
+            bool RichEditHasContent();
 
             void OnRichEditBoxGotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
             void OnRichEditBoxLostFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
@@ -58,6 +58,7 @@ namespace CalculatorApp
             void OnRemoveButtonClicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
             void OnColorChooserButtonClicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
             void OnFunctionButtonClicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+            void OnRichEditMenuOpening(Platform::Object ^ sender, Platform::Object ^ args);
 
             void OnColorFlyoutOpened(Platform::Object^ sender, Platform::Object^ e);
             void OnColorFlyoutClosed(Platform::Object^ sender, Platform::Object^ e);
@@ -71,6 +72,11 @@ namespace CalculatorApp
             Windows::UI::Xaml::Controls::Button^ m_removeButton;
             Windows::UI::Xaml::Controls::Button^ m_functionButton;
             Windows::UI::Xaml::Controls::Primitives::ToggleButton^ m_colorChooserButton;
+
+            Windows::UI::Xaml::Controls::MenuFlyout^ m_richEditContextMenu;
+            Windows::UI::Xaml::Controls::MenuFlyoutItem^ m_kgfEquationMenuItem;
+            Windows::UI::Xaml::Controls::MenuFlyoutItem^ m_removeMenuItem;
+            Windows::UI::Xaml::Controls::MenuFlyoutItem^ m_colorChooserMenuItem;
 
             bool m_isPointerOver;
             bool m_isColorChooserFlyoutOpen;

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4142,6 +4142,10 @@
     <value>Analyze equation</value>
     <comment>This is the automation name for the analyze equation button</comment>
   </data>
+  <data name="functionAnalysisMenuItem" xml:space="preserve">
+    <value>Analyze equation</value>
+    <comment>This is the text for the for the analyze equation context menu command</comment>
+  </data>
   <data name="removeButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Remove equation</value>
     <comment>This is the tooltip for the graphing calculator remove equation buttons</comment>
@@ -4149,6 +4153,10 @@
   <data name="removeButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Remove equation</value>
     <comment>This is the automation name for the graphing calculator remove equation buttons</comment>
+  </data>
+  <data name="removeMenuItem" xml:space="preserve">
+    <value>Remove equation</value>
+    <comment>This is the text for the for the remove equation context menu command</comment>
   </data>
   <data name="shareButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Share</value>
@@ -4165,6 +4173,10 @@
   <data name="colorChooserButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Change equation style</value>
     <comment>This is the automation name for the graphing calculator equation style button</comment>
+  </data>
+  <data name="colorChooserMenuItem" xml:space="preserve">
+    <value>Change equation style</value>
+    <comment>This is the text for the for the equation style context menu command</comment>
   </data>
   <data name="showEquationButtonToolTip" xml:space="preserve">
     <value>Show</value>

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -119,10 +119,14 @@ void EquationInputArea::EquationTextBox_RemoveButtonClicked(Object ^ sender, Rou
 
 void EquationInputArea::EquationTextBox_KeyGraphFeaturesButtonClicked(Object ^ sender, RoutedEventArgs ^ e)
 {
-    // ensure the equation has been submitted before trying to get key graph features out of it
-    EquationInputArea::InputTextBox_Submitted(sender, e);
-
     auto tb = static_cast<EquationTextBox ^>(sender);
+
+    // ensure the equation has been submitted before trying to get key graph features out of it
+    if (tb->HasFocus)
+    {
+        EquationInputArea::InputTextBox_Submitted(sender, e);
+    }
+
     auto eq = static_cast<EquationViewModel ^>(tb->DataContext);
     EquationVM = eq;
 

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -36,7 +36,7 @@ EquationInputArea::EquationInputArea()
         ref new TypedEventHandler<AccessibilitySettings ^, Object ^>(this, &EquationInputArea::OnHighContrastChanged);
 
     ReloadAvailableColors(m_accessibilitySettings->HighContrast);
-  
+
     InitializeComponent();
 }
 
@@ -88,7 +88,12 @@ void EquationInputArea::InputTextBox_Submitted(Object ^ sender, RoutedEventArgs 
 {
     auto tb = static_cast<EquationTextBox ^>(sender);
     auto eq = static_cast<EquationViewModel ^>(tb->DataContext);
-    eq->Expression = tb->GetEquationText();
+
+    // eq can be null if the equation has been removed
+    if (eq != nullptr)
+    {
+        eq->Expression = tb->GetEquationText();
+    }
 
     if (tb->HasFocus)
     {
@@ -114,9 +119,13 @@ void EquationInputArea::EquationTextBox_RemoveButtonClicked(Object ^ sender, Rou
 
 void EquationInputArea::EquationTextBox_KeyGraphFeaturesButtonClicked(Object ^ sender, RoutedEventArgs ^ e)
 {
+    // ensure the equation has been submitted before trying to get key graph features out of it
+    EquationInputArea::InputTextBox_Submitted(sender, e);
+
     auto tb = static_cast<EquationTextBox ^>(sender);
     auto eq = static_cast<EquationViewModel ^>(tb->DataContext);
     EquationVM = eq;
+
     KeyGraphFeaturesRequested(EquationVM, ref new RoutedEventArgs());
 }
 


### PR DESCRIPTION
## Fixes part of #338.

### Description of the changes:
- Adds context menu for rich edit that allows for showing key graph features, changing colors of equations, removing equations.

### How changes were validated:
manually tested keyboard only interactions
manually tested mouse interactions
