### PR TITLE
Add graph mode keyboard UI

### DIFF
--- a/src/Calculator/Calculator.vcxproj
+++ b/src/Calculator/Calculator.vcxproj
@@ -295,6 +295,9 @@
     <ClInclude Include="Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml.h">
       <DependentUpon>Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="Views\GraphingCalculator\GraphingNumPad.xaml.h">
+      <DependentUpon>Views\GraphingCalculator\GraphingNumPad.xaml</DependentUpon>
+    </ClInclude>
     <ClInclude Include="Views\HistoryList.xaml.h">
       <DependentUpon>Views\HistoryList.xaml</DependentUpon>
     </ClInclude>
@@ -357,6 +360,7 @@
     <Page Include="Views\GraphingCalculator\EquationInputArea.xaml" />
     <Page Include="Views\GraphingCalculator\GraphingCalculator.xaml" />
     <Page Include="Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml" />
+    <Page Include="Views\GraphingCalculator\GraphingNumPad.xaml"/>
     <Page Include="Views\HistoryList.xaml" />
     <Page Include="Views\MainPage.xaml" />
     <Page Include="Views\Memory.xaml" />
@@ -453,6 +457,9 @@
     </ClCompile>
     <ClCompile Include="Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml.cpp">
       <DependentUpon>Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml</DependentUpon>
+    </ClCompile>
+    <ClCompile Include="Views\GraphingCalculator\GraphingNumPad.xaml.cpp">
+      <DependentUpon>Views\GraphingCalculator\GraphingNumPad.xaml</DependentUpon>
     </ClCompile>
     <ClCompile Include="Views\HistoryList.xaml.cpp">
       <DependentUpon>Views\HistoryList.xaml</DependentUpon>

--- a/src/Calculator/Calculator.vcxproj.filters
+++ b/src/Calculator/Calculator.vcxproj.filters
@@ -317,8 +317,8 @@
       <Filter>Controls</Filter>
     </ClCompile>
     <ClCompile Include="Controls\MathRichEditBox.cpp" />
-    <ClCompile Include="Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml.cpp" >
-          <Filter>Views\GraphingCalculator</Filter>
+    <ClCompile Include="Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml.cpp">
+      <Filter>Views\GraphingCalculator</Filter>
     </ClCompile>
     <ClCompile Include="TemplateSelectors\KeyGraphFeaturesTemplateSelector.cpp" />
   </ItemGroup>
@@ -417,7 +417,7 @@
       <Filter>Controls</Filter>
     </ClInclude>
     <ClInclude Include="Controls\MathRichEditBox.h" />
-    <ClInclude Include="Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml.h" >
+    <ClInclude Include="Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml.h">
       <Filter>Views\GraphingCalculator</Filter>
     </ClInclude>
     <ClInclude Include="TemplateSelectors\KeyGraphFeaturesTemplateSelector.h" />
@@ -497,8 +497,11 @@
     <Page Include="Views\TitleBar.xaml">
       <Filter>Views</Filter>
     </Page>
-    <Page Include="Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml" >
-          <Filter>Views\GraphingCalculator</Filter>
+    <Page Include="Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml">
+      <Filter>Views\GraphingCalculator</Filter>
+    </Page>
+    <Page Include="Views\GraphingCalculator\GraphingNumPad.xaml">
+      <Filter>Views\GraphingCalculator</Filter>
     </Page>
   </ItemGroup>
   <ItemGroup>
@@ -1546,6 +1549,8 @@
     <ResourceCompile Include="Calculator.rc" />
   </ItemGroup>
   <ItemGroup>
+    <CopyFileToFolders Include="$(GraphingImplDll)" />
+    <CopyFileToFolders Include="$(GraphingEngineDll)" />
     <CopyFileToFolders Include="$(GraphingImplDll)" />
     <CopyFileToFolders Include="$(GraphingEngineDll)" />
   </ItemGroup>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3551,6 +3551,10 @@
     <value>Function</value>
     <comment>Displayed on the button that contains a flyout for the general functions in scientific mode.</comment>
   </data>
+  <data name="inequalityButton.Text" xml:space="preserve">
+    <value>Inequalities</value>
+    <comment>Displayed on the button that contains a flyout for the inequality functions.</comment>
+  </data>
   <data name="bitwiseButton.Text" xml:space="preserve">
     <value>Bitwise</value>
     <comment>Displayed on the button that contains a flyout for the bitwise functions in programmer mode.</comment>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -314,15 +314,6 @@
                 </Setter>
             </Style>
 
-            <Style x:Key="AccentCalcButtonStyle"
-                   BasedOn="{StaticResource SymbolOperatorButtonStyle}"
-                   TargetType="controls:CalculatorButton">
-                <Setter Property="HoverBackground" Value="{ThemeResource AppControlHighlightAccentRevealBackgroundBrush}"/>
-                <Setter Property="HoverForeground" Value="{ThemeResource SystemControlHighlightAltAltHighBrush}"/>
-                <Setter Property="PressBackground" Value="{ThemeResource AppControlBackgroundListAccentHighRevealBackgroundBrush}"/>
-                <Setter Property="PressForeground" Value="{ThemeResource SystemControlHighlightAltAltHighBrush}"/>
-            </Style>
-
             <converters:BooleanToVisibilityConverter x:Name="BooleanToVisibilityConverter"/>
             <converters:BooleanToVisibilityNegationConverter x:Name="BooleanToVisibilityNegationConverter"/>
             <ResourceDictionary.ThemeDictionaries>
@@ -687,8 +678,8 @@
                         <TranslateTransform x:Name="TraceValuePopupTransform"/>
                     </Border.RenderTransform>
                     <TextBlock x:Name="TraceValue"
-                               AutomationProperties.LiveSetting="Polite"
                                Foreground="{ThemeResource ToolTipForeground}"
+                               AutomationProperties.LiveSetting="Polite"
                                Text="x=0,y=0"/>
                 </Border>
             </Grid>
@@ -702,8 +693,8 @@
               Grid.Column="1"
               Visibility="{x:Bind local:GraphingCalculator.ShouldDisplayPanel(IsSmallState, SwitchModeToggleButton.IsChecked.Value, x:False), Mode=OneWay}">
             <Grid.RowDefinitions>
-                <RowDefinition Height="5*"/>
-                <RowDefinition Height="3*"/>
+                <RowDefinition Height="*"/>
+                <RowDefinition Height="1.8*"/>
             </Grid.RowDefinitions>
 
             <!-- Ideally the KeyGraphFeaturesPanel should be a frame so that navigation to and from the panel could be handled nicely -->
@@ -721,190 +712,10 @@
                                      KeyGraphFeaturesRequested="OnEquationKeyGraphFeaturesRequested"
                                      Visibility="{x:Bind IsKeyGraphFeaturesVisible, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
 
-            <Grid x:Name="ButtonContainerGrid"
-                  Grid.Row="1"
-                  Margin="2,0,2,2"
-                  UseLayoutRounding="False"
-                  Visibility="{x:Bind IsKeyGraphFeaturesVisible, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}">
-                <Grid.RowDefinitions>
-                    <RowDefinition/>
-                    <RowDefinition/>
-                    <RowDefinition/>
-                    <RowDefinition/>
-                    <RowDefinition/>
-                    <RowDefinition/>
-                </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition/>
-                    <ColumnDefinition/>
-                    <ColumnDefinition/>
-                    <ColumnDefinition/>
-                    <ColumnDefinition/>
-                </Grid.ColumnDefinitions>
+            <local:GraphingNumPad Grid.Row="1"
+                                  Margin="2,0,2,2"
+                                  Visibility="{x:Bind IsKeyGraphFeaturesVisible, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
 
-                <controls:CalculatorButton x:Name="XButton"
-                                           x:Uid="xButton"
-                                           Grid.Row="0"
-                                           Grid.Column="0"
-                                           Style="{StaticResource OperatorButtonStyle}"
-                                           FontSize="16"
-                                           ButtonId="X"
-                                           Content="𝑥"
-                                           FlowDirection="LeftToRight"/>
-                <controls:CalculatorButton x:Name="YButton"
-                                           x:Uid="yButton"
-                                           Grid.Row="0"
-                                           Grid.Column="1"
-                                           Style="{StaticResource OperatorButtonStyle}"
-                                           FontSize="16"
-                                           ButtonId="Y"
-                                           Content="𝑦"
-                                           FlowDirection="LeftToRight"/>
-                <controls:CalculatorButton x:Name="PowerButton"
-                                           x:Uid="graphingPowerButton"
-                                           Grid.Row="0"
-                                           Grid.Column="2"
-                                           Style="{StaticResource OperatorButtonStyle}"
-                                           ButtonId="XPowerY"
-                                           Content="^"/>
-                <controls:CalculatorButton x:Name="squareRootButton"
-                                           x:Uid="squareRootButton"
-                                           Grid.Row="0"
-                                           Grid.Column="3"
-                                           Style="{StaticResource SymbolOperatorButtonStyle}"
-                                           FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                           ButtonId="Sqrt"
-                                           Content="&#xE94B;"/>
-
-                <!-- Display controls -->
-                <controls:CalculatorButton x:Name="ClearButton"
-                                           x:Uid="clearButton"
-                                           Grid.Row="1"
-                                           Grid.Column="2"
-                                           Style="{StaticResource OperatorButtonStyle}"
-                                           FontSize="16"
-                                           ButtonId="Clear"
-                                           Content="C"/>
-                <controls:CalculatorButton x:Name="BackSpaceButton"
-                                           x:Uid="backSpaceButton"
-                                           Grid.Row="1"
-                                           Grid.Column="3"
-                                           Style="{StaticResource SymbolOperatorButtonStyle}"
-                                           FontSize="16"
-                                           ButtonId="Backspace"
-                                           Content="&#xE94F;"/>
-
-                <!-- Basic operators -->
-                <controls:CalculatorButton x:Name="EqualButton"
-                                           x:Uid="graphingEqualButton"
-                                           Grid.Row="0"
-                                           Grid.Column="4"
-                                           Style="{StaticResource AccentCalcButtonStyle}"
-                                           ButtonId="Equals"
-                                           Content="&#xE94E;"/>
-                <controls:CalculatorButton x:Name="DivideButton"
-                                           x:Uid="divideButton"
-                                           Grid.Row="1"
-                                           Grid.Column="4"
-                                           Style="{StaticResource AccentCalcButtonStyle}"
-                                           ButtonId="Divide"
-                                           Content="&#xE94A;"/>
-                <controls:CalculatorButton x:Name="MultiplyButton"
-                                           x:Uid="multiplyButton"
-                                           Grid.Row="2"
-                                           Grid.Column="4"
-                                           Style="{StaticResource AccentCalcButtonStyle}"
-                                           ButtonId="Multiply"
-                                           Content="&#xE947;"/>
-                <controls:CalculatorButton x:Name="MinusButton"
-                                           x:Uid="minusButton"
-                                           Grid.Row="3"
-                                           Grid.Column="4"
-                                           Style="{StaticResource AccentCalcButtonStyle}"
-                                           ButtonId="Subtract"
-                                           Content="&#xE949;"/>
-                <controls:CalculatorButton x:Name="PlusButton"
-                                           x:Uid="plusButton"
-                                           Grid.Row="4"
-                                           Grid.Column="4"
-                                           Style="{StaticResource AccentCalcButtonStyle}"
-                                           ButtonId="Add"
-                                           Content="&#xE948;"/>
-
-
-                <controls:CalculatorButton x:Name="logBase10Button"
-                                           x:Uid="logBase10Button"
-                                           Grid.Row="1"
-                                           Grid.Column="0"
-                                           Style="{StaticResource OperatorButtonStyle}"
-                                           ButtonId="LogBase10"
-                                           Content="log"/>
-                <controls:CalculatorButton x:Name="logBaseEButton"
-                                           x:Uid="logBaseEButton"
-                                           Grid.Row="1"
-                                           Grid.Column="1"
-                                           Style="{StaticResource OperatorButtonStyle}"
-                                           ButtonId="LogBaseE"
-                                           Content="ln"/>
-                <controls:CalculatorButton x:Name="powerOf10Button"
-                                           x:Uid="powerOf10Button"
-                                           Grid.Row="2"
-                                           Grid.Column="0"
-                                           Style="{StaticResource SymbolOperatorButtonStyle}"
-                                           AutomationProperties.AutomationId="powerOf10Button"
-                                           ButtonId="TenPowerX"
-                                           Content="&#xF7CC;"/>
-                <controls:CalculatorButton x:Name="powerOfEButton"
-                                           x:Uid="powerOfEButton"
-                                           Grid.Row="3"
-                                           Grid.Column="0"
-                                           Style="{StaticResource SymbolOperatorButtonStyle}"
-                                           ButtonId="EPowerX"
-                                           Content="&#xf7ce;"/>
-                <controls:CalculatorButton x:Name="piButton"
-                                           x:Uid="piButton"
-                                           Grid.Row="4"
-                                           Grid.Column="0"
-                                           Style="{StaticResource SymbolOperatorButtonStyle}"
-                                           FontSize="14"
-                                           ButtonId="Pi"
-                                           Content="&#xf7cf;"/>
-
-                <controls:CalculatorButton x:Name="openParenthesisButton"
-                                           x:Uid="openParenthesisButton"
-                                           Grid.Row="5"
-                                           Grid.Column="0"
-                                           Style="{StaticResource ParenthesisCalcButtonStyle}"
-                                           FontSize="19"
-                                           ButtonId="OpenParenthesis"
-                                           Content="("/>
-                <controls:CalculatorButton x:Name="closeParenthesisButton"
-                                           x:Uid="closeParenthesisButton"
-                                           Grid.Row="5"
-                                           Grid.Column="1"
-                                           Style="{StaticResource OperatorButtonStyle}"
-                                           FontSize="19"
-                                           ButtonId="CloseParenthesis"
-                                           Content=")"/>
-
-                <!-- The Numberpad -->
-                <local:NumberPad x:Name="NumberPad"
-                                 x:Uid="NumberPad"
-                                 Grid.Row="2"
-                                 Grid.RowSpan="4"
-                                 Grid.Column="1"
-                                 Grid.ColumnSpan="3"
-                                 ButtonStyle="{StaticResource NumericButtonStyle24}"/>
-
-                <controls:CalculatorButton x:Name="PlotButton"
-                                           x:Uid="plotButton"
-                                           Grid.Row="5"
-                                           Grid.Column="4"
-                                           Style="{StaticResource AccentCalcButtonStyle}"
-                                           FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                           ButtonId="Plot"
-                                           Content="&#xE72A;"/>
-            </Grid>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -7,6 +7,7 @@
 #include "CalcViewModel\GraphingCalculator\GraphingCalculatorViewModel.h"
 #include "Views\NumberPad.xaml.h"
 #include "Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml.h"
+#include "Views\GraphingCalculator\GraphingNumPad.xaml.h"
 
 namespace CalculatorApp
 {

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
@@ -1,0 +1,1194 @@
+<UserControl x:Class="CalculatorApp.GraphingNumPad"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:Windows10version1803="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract, 7)"
+             xmlns:Windows10version1809="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 7)"
+             xmlns:controls="using:CalculatorApp.Controls"
+             xmlns:converters="using:CalculatorApp.Converters"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:local="using:CalculatorApp"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:triggers="using:CalculatorApp.Views.StateTriggers"
+             d:DesignHeight="300"
+             d:DesignWidth="400"
+             XYFocusKeyboardNavigation="Enabled"
+             mc:Ignorable="d">
+    <UserControl.Resources>
+        <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <converters:BooleanToVisibilityNegationConverter x:Key="BooleanToVisibilityNegationConverter"/>
+    </UserControl.Resources>
+
+    <Grid x:Name="GraphingOperators" UseLayoutRounding="False">
+        <Grid.RowDefinitions>
+            <RowDefinition x:Name="OperatorPanelRow" Height="Auto"/>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="1*"/>
+        </Grid.RowDefinitions>
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="1*"/>
+        </Grid.ColumnDefinitions>
+
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup x:Name="SizeLayouts">
+                <VisualState x:Name="Large">
+                    <VisualState.StateTriggers>
+                        <triggers:ControlSizeTrigger MinWidth="878"
+                                                     MinHeight="851"
+                                                     Source="{x:Bind GraphingOperators}"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="NegateButton.FontSize" Value="{StaticResource CalcStandardOperatorCaptionSizeExtraLarge}"/>
+                        <Setter Target="PiButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="OpenParenthesisButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="CloseParenthesisButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+
+                        <Setter Target="SinButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="CosButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="TanButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="SinhButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="CoshButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="TanhButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvsinButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvcosButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvtanButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvsinhButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvcoshButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvtanhButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+
+                        <Setter Target="PowerButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="PowerOf10Button.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="LogBase10Button.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="XButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="YButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="YSquareRootButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="PowerOfEButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="LogBaseEButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="XPower2Button.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="XPower3Button.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="SquareRootButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvertButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+
+                        <Setter Target="ClearButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="BackSpaceButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="DivideButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="MultiplyButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="MinusButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="PlusButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="EqualButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="SubmitButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="NumberPad.ButtonStyle" Value="{ThemeResource NumericButtonStyle38}"/>
+
+                        <Setter Target="EulerButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="AbsButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="LogBaseX.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="TwoPowerXButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="CubeRootButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+
+                        <Setter Target="ShiftButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="TrigShiftButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="HypButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="SecButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="CscButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="CotButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvsecButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvcscButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvcotButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="SechButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="CschButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="CothButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvsechButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvcschButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+                        <Setter Target="InvcothButton.FontSize" Value="{ThemeResource CalcButtonCaptionSize}"/>
+
+                        <Setter Target="AbsFlyoutButton.FontSize" Value="{ThemeResource CalcButtonTextIconCaptionSize}"/>
+                        <Setter Target="FloorButton.FontSize" Value="{ThemeResource CalcButtonTextIconCaptionSize}"/>
+                        <Setter Target="CeilButton.FontSize" Value="{ThemeResource CalcButtonTextIconCaptionSize}"/>
+
+                        <Setter Target="LessThanFlyoutButton.FontSize" Value="{ThemeResource CalcButtonTextIconCaptionSize}"/>
+                        <Setter Target="LessThanOrEqualFlyoutButton.FontSize" Value="{ThemeResource CalcButtonTextIconCaptionSize}"/>
+                        <Setter Target="EqualsFlyoutButton.FontSize" Value="{ThemeResource CalcButtonTextIconCaptionSize}"/>
+                        <Setter Target="GreaterThanOrEqualFlyoutButton.FontSize" Value="{ThemeResource CalcButtonTextIconCaptionSize}"/>
+                        <Setter Target="GreaterThanFlyoutButton.FontSize" Value="{ThemeResource CalcButtonTextIconCaptionSize}"/>
+
+                        <Setter Target="OperatorPanelRow.MinHeight" Value="{StaticResource OperatorPanelButtonRowSizeLarge}"/>
+
+                        <Setter Target="TrigButton.ChevronFontSize" Value="{ThemeResource OperatorPanelChevronFontSizeLarge}"/>
+                        <Setter Target="TrigButton.GlyphFontSize" Value="{ThemeResource OperatorPanelGlyphFontSizeLarge}"/>
+                        <Setter Target="TrigButton.FontSize" Value="{ThemeResource OperatorPanelFontSizeLarge}"/>
+
+                        <Setter Target="InequalityButton.ChevronFontSize" Value="{ThemeResource OperatorPanelChevronFontSizeLarge}"/>
+                        <Setter Target="InequalityButton.GlyphFontSize" Value="{ThemeResource OperatorPanelGlyphFontSizeLarge}"/>
+                        <Setter Target="InequalityButton.FontSize" Value="{ThemeResource OperatorPanelFontSizeLarge}"/>
+
+                        <Setter Target="FuncButton.ChevronFontSize" Value="{ThemeResource OperatorPanelChevronFontSizeLarge}"/>
+                        <Setter Target="FuncButton.GlyphFontSize" Value="{ThemeResource OperatorPanelGlyphFontSizeLarge}"/>
+                        <Setter Target="FuncButton.FontSize" Value="{ThemeResource OperatorPanelFontSizeLarge}"/>
+
+                        <Setter Target="TrigGrid.MinWidth" Value="516"/>
+                        <Setter Target="TrigGrid.MinHeight" Value="192"/>
+                        <Setter Target="FuncGrid.MinWidth" Value="387"/>
+                        <Setter Target="FuncGrid.MinHeight" Value="96"/>
+
+                        <Setter Target="InequalityGrid.MinWidth" Value="628"/>
+                        <Setter Target="InequalityGrid.MinHeight" Value="96"/>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Medium">
+                    <VisualState.StateTriggers>
+                        <triggers:ControlSizeTrigger MinWidth="527"
+                                                     MinHeight="523"
+                                                     Source="{x:Bind GraphingOperators}"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="NegateButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSizeLarge}"/>
+                        <Setter Target="PiButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="OpenParenthesisButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="CloseParenthesisButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+
+                        <Setter Target="SinButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="CosButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="TanButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="SinhButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="CoshButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="TanhButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvsinButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvcosButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvtanButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvsinhButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvcoshButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvtanhButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+
+                        <Setter Target="PowerButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="PowerOf10Button.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="LogBase10Button.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="XButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="YButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="YSquareRootButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="PowerOfEButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="LogBaseEButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="XPower2Button.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="XPower3Button.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="SquareRootButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvertButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+
+                        <Setter Target="ClearButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="BackSpaceButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="DivideButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="MultiplyButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="MinusButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="PlusButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="EqualButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="SubmitButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="NumberPad.ButtonStyle" Value="{ThemeResource NumericButtonStyle24}"/>
+
+                        <Setter Target="EulerButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="AbsButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="LogBaseX.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="TwoPowerXButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="CubeRootButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+
+                        <Setter Target="ShiftButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="TrigShiftButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="HypButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="SecButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="CscButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="CotButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvsecButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvcscButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvcotButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="SechButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="CschButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="CothButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvsechButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvcschButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="InvcothButton.FontSize" Value="{ThemeResource CalcStandardOperatorCaptionSize}"/>
+
+                        <Setter Target="AbsFlyoutButton.FontSize" Value="{ThemeResource CalcStandardOperatorTextIconCaptionSize}"/>
+                        <Setter Target="FloorButton.FontSize" Value="{ThemeResource CalcStandardOperatorTextIconCaptionSize}"/>
+                        <Setter Target="CeilButton.FontSize" Value="{ThemeResource CalcStandardOperatorTextIconCaptionSize}"/>
+
+                        <Setter Target="LessThanFlyoutButton.FontSize" Value="{ThemeResource CalcStandardOperatorTextIconCaptionSize}"/>
+                        <Setter Target="LessThanOrEqualFlyoutButton.FontSize" Value="{ThemeResource CalcStandardOperatorTextIconCaptionSize}"/>
+                        <Setter Target="EqualsFlyoutButton.FontSize" Value="{ThemeResource CalcStandardOperatorTextIconCaptionSize}"/>
+                        <Setter Target="GreaterThanOrEqualFlyoutButton.FontSize" Value="{ThemeResource CalcStandardOperatorTextIconCaptionSize}"/>
+                        <Setter Target="GreaterThanFlyoutButton.FontSize" Value="{ThemeResource CalcStandardOperatorTextIconCaptionSize}"/>
+
+                        <Setter Target="OperatorPanelRow.MinHeight" Value="{StaticResource OperatorPanelButtonRowSizeMedium}"/>
+
+                        <Setter Target="TrigButton.ChevronFontSize" Value="{ThemeResource OperatorPanelChevronFontSizeMedium}"/>
+                        <Setter Target="TrigButton.GlyphFontSize" Value="{ThemeResource OperatorPanelGlyphFontSizeMedium}"/>
+                        <Setter Target="TrigButton.FontSize" Value="{ThemeResource OperatorPanelFontSizeMedium}"/>
+
+                        <Setter Target="InequalityButton.ChevronFontSize" Value="{ThemeResource OperatorPanelChevronFontSizeMedium}"/>
+                        <Setter Target="InequalityButton.GlyphFontSize" Value="{ThemeResource OperatorPanelGlyphFontSizeMedium}"/>
+                        <Setter Target="InequalityButton.FontSize" Value="{ThemeResource OperatorPanelFontSizeMedium}"/>
+
+                        <Setter Target="FuncButton.ChevronFontSize" Value="{ThemeResource OperatorPanelChevronFontSizeMedium}"/>
+                        <Setter Target="FuncButton.GlyphFontSize" Value="{ThemeResource OperatorPanelGlyphFontSizeMedium}"/>
+                        <Setter Target="FuncButton.FontSize" Value="{ThemeResource OperatorPanelFontSizeMedium}"/>
+
+                        <Setter Target="TrigGrid.MinWidth" Value="480"/>
+                        <Setter Target="TrigGrid.MinHeight" Value="144"/>
+                        <Setter Target="FuncGrid.MinWidth" Value="360"/>
+                        <Setter Target="FuncGrid.MinHeight" Value="72"/>
+                        <Setter Target="InequalityGrid.MinWidth" Value="585"/>
+                        <Setter Target="InequalityGrid.MinHeight" Value="72"/>
+
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Small">
+                    <VisualState.StateTriggers>
+                        <AdaptiveTrigger MinWindowHeight="0" MinWindowWidth="0"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="NegateButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="PiButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="OpenParenthesisButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="CloseParenthesisButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+
+                        <Setter Target="SinButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="CosButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="TanButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="SinhButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="CoshButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="TanhButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvsinButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvcosButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvtanButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvsinhButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvcoshButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvtanhButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+
+                        <Setter Target="PowerButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="PowerOf10Button.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="LogBase10Button.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="XButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="YButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="YSquareRootButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="PowerOfEButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="LogBaseEButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="XPower2Button.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="XPower3Button.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="SquareRootButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvertButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+
+                        <Setter Target="ClearButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="BackSpaceButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="DivideButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="MultiplyButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="MinusButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="PlusButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="EqualButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="SubmitButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="NumberPad.ButtonStyle" Value="{ThemeResource NumericButtonStyle18}"/>
+
+                        <Setter Target="EulerButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="AbsButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="LogBaseX.FontSize" Value="16"/>
+                        <Setter Target="TwoPowerXButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="CubeRootButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+
+                        <Setter Target="ShiftButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="TrigShiftButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="HypButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="SecButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="CscButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="CotButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvsecButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvcscButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvcotButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="SechButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="CschButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="CothButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvsechButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvcschButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+                        <Setter Target="InvcothButton.FontSize" Value="{ThemeResource CalcOperatorCaptionSize}"/>
+
+                        <Setter Target="AbsFlyoutButton.FontSize" Value="{ThemeResource CalcOperatorTextIconCaptionSize}"/>
+                        <Setter Target="FloorButton.FontSize" Value="{ThemeResource CalcOperatorTextIconCaptionSize}"/>
+                        <Setter Target="CeilButton.FontSize" Value="{ThemeResource CalcOperatorTextIconCaptionSize}"/>
+
+                        <Setter Target="LessThanFlyoutButton.FontSize" Value="{ThemeResource CalcOperatorTextIconCaptionSize}"/>
+                        <Setter Target="LessThanOrEqualFlyoutButton.FontSize" Value="{ThemeResource CalcOperatorTextIconCaptionSize}"/>
+                        <Setter Target="EqualsFlyoutButton.FontSize" Value="{ThemeResource CalcOperatorTextIconCaptionSize}"/>
+                        <Setter Target="GreaterThanOrEqualFlyoutButton.FontSize" Value="{ThemeResource CalcOperatorTextIconCaptionSize}"/>
+                        <Setter Target="GreaterThanFlyoutButton.FontSize" Value="{ThemeResource CalcOperatorTextIconCaptionSize}"/>
+
+                        <Setter Target="OperatorPanelRow.MinHeight" Value="{ThemeResource OperatorPanelButtonRowSizeSmall}"/>
+
+                        <Setter Target="TrigButton.ChevronFontSize" Value="{ThemeResource OperatorPanelChevronFontSizeSmall}"/>
+                        <Setter Target="TrigButton.GlyphFontSize" Value="{ThemeResource OperatorPanelGlyphFontSizeSmall}"/>
+                        <Setter Target="TrigButton.FontSize" Value="{ThemeResource OperatorPanelFontSizeSmall}"/>
+
+                        <Setter Target="InequalityButton.ChevronFontSize" Value="{ThemeResource OperatorPanelChevronFontSizeSmall}"/>
+                        <Setter Target="InequalityButton.GlyphFontSize" Value="{ThemeResource OperatorPanelGlyphFontSizeSmall}"/>
+                        <Setter Target="InequalityButton.FontSize" Value="{ThemeResource OperatorPanelFontSizeSmall}"/>
+
+                        <Setter Target="FuncButton.ChevronFontSize" Value="{ThemeResource OperatorPanelChevronFontSizeSmall}"/>
+                        <Setter Target="FuncButton.GlyphFontSize" Value="{ThemeResource OperatorPanelGlyphFontSizeSmall}"/>
+                        <Setter Target="FuncButton.FontSize" Value="{ThemeResource OperatorPanelFontSizeSmall}"/>
+
+                        <Setter Target="TrigGrid.MinWidth" Value="258"/>
+                        <Setter Target="TrigGrid.MinHeight" Value="96"/>
+                        <Setter Target="FuncGrid.MinWidth" Value="194"/>
+                        <Setter Target="FuncGrid.MinHeight" Value="48"/>
+                        <Setter Target="InequalityGrid.MinWidth" Value="312"/>
+                        <Setter Target="InequalityGrid.MinHeight" Value="48"/>
+
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+
+        <controls:OperatorPanelListView x:Uid="ScientificOperatorPanel"
+                                        Grid.ColumnSpan="5"
+                                        Background="{ThemeResource AppOperatorPanelBackground}"
+                                        AutomationProperties.HeadingLevel="Level1">
+
+            <controls:OperatorPanelButton x:Name="TrigButton"
+                                          x:Uid="trigButton"
+                                          Style="{StaticResource OperatorPanelButtonStyle}"
+                                          AutomationProperties.AutomationId="trigButton"
+                                          Glyph="&#xF892;">
+
+                <controls:OperatorPanelButton.FlyoutMenu>
+                    <Flyout x:Name="Trigflyout"
+                            Windows10version1803:Placement="Bottom"
+                            Windows10version1809:AreOpenCloseAnimationsEnabled="False"
+                            Windows10version1809:Placement="BottomEdgeAlignedLeft"
+                            FlyoutPresenterStyle="{ThemeResource OperatorPanelFlyoutStyle}">
+                        <Grid x:Name="TrigGrid"
+                              MinWidth="258"
+                              MinHeight="96"
+                              XYFocusKeyboardNavigation="Enabled">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="1*"/>
+                                <RowDefinition Height="1*"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                            </Grid.ColumnDefinitions>
+                            <!--
+                                Because of the way we handle keyboard shortcuts, the IsEnabled property must be bound to a button outside the flyout.
+                                This is because the content from within the Flyout do not inherit the IsEnabled property of the flyout parent,
+                                causing the shortcut keys to be used when the control would normally be disabled.
+                            -->
+                            <ToggleButton x:Name="TrigShiftButton"
+                                          x:Uid="trigShiftButton"
+                                          Style="{StaticResource CaptionToggleEmphasizedButtonStyle}"
+                                          FontFamily="{StaticResource CalculatorFontFamily}"
+                                          AutomationProperties.AutomationId="trigShiftButton"
+                                          Checked="TrigFlyoutShift_Toggle"
+                                          Content="&#xF897;"
+                                          Unchecked="TrigFlyoutShift_Toggle"
+                                          IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                            <ToggleButton x:Name="HypButton"
+                                          x:Uid="hypButton"
+                                          Grid.Row="1"
+                                          Style="{StaticResource CaptionToggleEmphasizedButtonStyle}"
+                                          AutomationProperties.AutomationId="hypShiftButton"
+                                          Checked="TrigFlyoutHyp_Toggle"
+                                          Content="hyp"
+                                          IsEnabledChanged="ShiftButton_IsEnabledChanged"
+                                          Unchecked="TrigFlyoutHyp_Toggle"
+                                          IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                            <Grid x:Name="TrigFunctions"
+                                  Grid.RowSpan="2"
+                                  Grid.Column="1"
+                                  Grid.ColumnSpan="3">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="1*"/>
+                                    <RowDefinition Height="1*"/>
+                                </Grid.RowDefinitions>
+
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <controls:CalculatorButton x:Name="SinButton"
+                                                           x:Uid="sinButton"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="sinButton"
+                                                           ButtonId="Sin"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="sin"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="CosButton"
+                                                           x:Uid="cosButton"
+                                                           Grid.Column="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="cosButton"
+                                                           ButtonId="Cos"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="cos"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="TanButton"
+                                                           x:Uid="tanButton"
+                                                           Grid.Column="2"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="tanButton"
+                                                           ButtonId="Tan"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="tan"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="SecButton"
+                                                           x:Uid="secButton"
+                                                           Grid.Row="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="secButton"
+                                                           ButtonId="Sec"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="sec"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="CscButton"
+                                                           x:Uid="cscButton"
+                                                           Grid.Row="1"
+                                                           Grid.Column="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="cscButton"
+                                                           ButtonId="Csc"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="csc"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="CotButton"
+                                                           x:Uid="cotButton"
+                                                           Grid.Row="1"
+                                                           Grid.Column="2"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="cotButton"
+                                                           ButtonId="Cot"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="cot"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+                            </Grid>
+
+                            <Grid x:Name="InverseTrigFunctions"
+                                  Grid.RowSpan="2"
+                                  Grid.Column="1"
+                                  Grid.ColumnSpan="3"
+                                  Visibility="Collapsed">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="1*"/>
+                                    <RowDefinition Height="1*"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <controls:CalculatorButton x:Name="InvsinButton"
+                                                           x:Uid="invsinButton"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invsinButton"
+                                                           ButtonId="InvSin"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="sin⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvcosButton"
+                                                           x:Uid="invcosButton"
+                                                           Grid.Column="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invcosButton"
+                                                           ButtonId="InvCos"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="cos⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvtanButton"
+                                                           x:Uid="invtanButton"
+                                                           Grid.Column="2"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invtanButton"
+                                                           ButtonId="InvTan"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="tan⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvsecButton"
+                                                           x:Uid="invsecButton"
+                                                           Grid.Row="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invsecButton"
+                                                           ButtonId="InvSec"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="sec⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvcscButton"
+                                                           x:Uid="invcscButton"
+                                                           Grid.Row="1"
+                                                           Grid.Column="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invcscButton"
+                                                           ButtonId="InvCsc"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="csc⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvcotButton"
+                                                           x:Uid="invcotButton"
+                                                           Grid.Row="1"
+                                                           Grid.Column="2"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invcotButton"
+                                                           ButtonId="InvCot"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="cot⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+                            </Grid>
+
+                            <Grid x:Name="HyperbolicTrigFunctions"
+                                  Grid.RowSpan="2"
+                                  Grid.Column="1"
+                                  Grid.ColumnSpan="3"
+                                  Visibility="Collapsed">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="1*"/>
+                                    <RowDefinition Height="1*"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <controls:CalculatorButton x:Name="SinhButton"
+                                                           x:Uid="sinhButton"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="sinhButton"
+                                                           ButtonId="Sinh"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="sinh"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="CoshButton"
+                                                           x:Uid="coshButton"
+                                                           Grid.Column="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="coshButton"
+                                                           ButtonId="Cosh"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="cosh"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="TanhButton"
+                                                           x:Uid="tanhButton"
+                                                           Grid.Column="2"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="tanhButton"
+                                                           ButtonId="Tanh"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="tanh"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="SechButton"
+                                                           x:Uid="sechButton"
+                                                           Grid.Row="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="sechButton"
+                                                           ButtonId="Sech"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="sech"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="CschButton"
+                                                           x:Uid="cschButton"
+                                                           Grid.Row="1"
+                                                           Grid.Column="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="cschButton"
+                                                           ButtonId="Csch"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="csch"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="CothButton"
+                                                           x:Uid="cothButton"
+                                                           Grid.Row="1"
+                                                           Grid.Column="2"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="cothButton"
+                                                           ButtonId="Coth"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="coth"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+                            </Grid>
+
+                            <Grid x:Name="InverseHyperbolicTrigFunctions"
+                                  Grid.RowSpan="2"
+                                  Grid.Column="1"
+                                  Grid.ColumnSpan="3"
+                                  Visibility="Collapsed">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="1*"/>
+                                    <RowDefinition Height="1*"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                </Grid.ColumnDefinitions>
+                                <controls:CalculatorButton x:Name="InvsinhButton"
+                                                           x:Uid="invsinhButton"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invsinhButton"
+                                                           ButtonId="InvSinh"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="sinh⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvcoshButton"
+                                                           x:Uid="invcoshButton"
+                                                           Grid.Column="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invcoshButton"
+                                                           ButtonId="InvCosh"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="cosh⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvtanhButton"
+                                                           x:Uid="invtanhButton"
+                                                           Grid.Column="2"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invtanhButton"
+                                                           ButtonId="InvTanh"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="tanh⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvsechButton"
+                                                           x:Uid="invsechButton"
+                                                           Grid.Row="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invsechButton"
+                                                           ButtonId="InvSech"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="sech⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvcschButton"
+                                                           x:Uid="invcschButton"
+                                                           Grid.Row="1"
+                                                           Grid.Column="1"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invcschButton"
+                                                           ButtonId="InvCsch"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="csch⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+
+                                <controls:CalculatorButton x:Name="InvcothButton"
+                                                           x:Uid="invcothButton"
+                                                           Grid.Row="1"
+                                                           Grid.Column="2"
+                                                           Style="{StaticResource OperatorButtonStyle}"
+                                                           AutomationProperties.AutomationId="invcothButton"
+                                                           ButtonId="InvCoth"
+                                                           Click="FlyoutButton_Clicked"
+                                                           Content="coth⁻¹"
+                                                           IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
+                            </Grid>
+                        </Grid>
+                    </Flyout>
+                </controls:OperatorPanelButton.FlyoutMenu>
+            </controls:OperatorPanelButton>
+
+            <controls:OperatorPanelButton x:Name="InequalityButton"
+                                          x:Uid="inequalityButton"
+                                          Style="{StaticResource OperatorPanelButtonStyle}"
+                                          AutomationProperties.AutomationId="inequalityButton"
+                                          Glyph="&#xF894;">
+                <controls:OperatorPanelButton.FlyoutMenu>
+
+                    <Flyout x:Name="InequalityFlyout"
+                            Windows10version1809:AreOpenCloseAnimationsEnabled="False"
+                            FlyoutPresenterStyle="{ThemeResource OperatorPanelFlyoutStyle}"
+                            Placement="Bottom">
+
+                        <Grid x:Name="InequalityGrid"
+                              MinWidth="312"
+                              MinHeight="48"
+                              XYFocusKeyboardNavigation="Enabled">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="1*"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                            </Grid.ColumnDefinitions>
+
+                            <controls:CalculatorButton x:Name="LessThanFlyoutButton"
+                                                       x:Uid="lessThanFlyoutButton"
+                                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                                       AutomationProperties.AutomationId="lessThanFlyoutButton"
+                                                       Click="FlyoutButton_Clicked"
+                                                       Content="&#xF88A;"
+                                                       IsEnabled="{x:Bind InequalityButton.IsEnabled, Mode=OneWay}"/>
+
+                            <controls:CalculatorButton x:Name="LessThanOrEqualFlyoutButton"
+                                                       x:Uid="lessThanOrEqualFlyoutButton"
+                                                       Grid.Column="1"
+                                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                                       AutomationProperties.AutomationId="lessThanOrEqualFlyoutButton"
+                                                       Click="FlyoutButton_Clicked"
+                                                       Content="&#xF88B;"
+                                                       IsEnabled="{x:Bind InequalityButton.IsEnabled, Mode=OneWay}"/>
+
+                            <controls:CalculatorButton x:Name="EqualsFlyoutButton"
+                                                       x:Uid="equalsFlyoutButton"
+                                                       Grid.Column="2"
+                                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                                       AutomationProperties.AutomationId="equalsFlyoutButton"
+                                                       Click="FlyoutButton_Clicked"
+                                                       Content="&#xE94E;"
+                                                       IsEnabled="{x:Bind InequalityButton.IsEnabled, Mode=OneWay}"/>
+
+                            <controls:CalculatorButton x:Name="GreaterThanOrEqualFlyoutButton"
+                                                       x:Uid="greaterThanOrEqualFlyoutButton"
+                                                       Grid.Column="3"
+                                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                                       AutomationProperties.AutomationId="greaterThanOrEqualFlyoutButton"
+                                                       Click="FlyoutButton_Clicked"
+                                                       Content="&#xF88D;"
+                                                       IsEnabled="{x:Bind InequalityButton.IsEnabled, Mode=OneWay}"/>
+
+                            <controls:CalculatorButton x:Name="GreaterThanFlyoutButton"
+                                                       x:Uid="greaterThanFlyoutButton"
+                                                       Grid.Column="4"
+                                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                                       AutomationProperties.AutomationId="greaterThanFlyoutButton"
+                                                       Click="FlyoutButton_Clicked"
+                                                       Content="&#xF88C;"
+                                                       IsEnabled="{x:Bind InequalityButton.IsEnabled, Mode=OneWay}"/>
+
+                        </Grid>
+                    </Flyout>
+                </controls:OperatorPanelButton.FlyoutMenu>
+            </controls:OperatorPanelButton>
+
+            <controls:OperatorPanelButton x:Name="FuncButton"
+                                          x:Uid="funcButton"
+                                          Style="{StaticResource OperatorPanelButtonStyle}"
+                                          AutomationProperties.AutomationId="funcButton"
+                                          Glyph="&#xF893;">
+
+                <controls:OperatorPanelButton.FlyoutMenu>
+                    <Flyout x:Name="FuncFlyout"
+                            Windows10version1809:AreOpenCloseAnimationsEnabled="False"
+                            FlyoutPresenterStyle="{ThemeResource OperatorPanelFlyoutStyle}"
+                            Placement="Bottom">
+
+                        <Grid x:Name="FuncGrid"
+                              MinWidth="194"
+                              MinHeight="48"
+                              XYFocusKeyboardNavigation="Enabled">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="1*"/>
+                            </Grid.RowDefinitions>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                                <ColumnDefinition Width="1*"/>
+                            </Grid.ColumnDefinitions>
+                            <controls:CalculatorButton x:Name="AbsFlyoutButton"
+                                                       x:Uid="absButton"
+                                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                                       AutomationProperties.AutomationId="absButton"
+                                                       ButtonId="Abs"
+                                                       Click="FlyoutButton_Clicked"
+                                                       Content="&#xF884;"
+                                                       IsEnabled="{x:Bind FuncButton.IsEnabled, Mode=OneWay}"/>
+
+                            <controls:CalculatorButton x:Name="FloorButton"
+                                                       x:Uid="floorButton"
+                                                       Grid.Column="1"
+                                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                                       AutomationProperties.AutomationId="floorButton"
+                                                       ButtonId="Floor"
+                                                       Click="FlyoutButton_Clicked"
+                                                       Content="&#xF885;"
+                                                       IsEnabled="{x:Bind FuncButton.IsEnabled, Mode=OneWay}"/>
+
+                            <controls:CalculatorButton x:Name="CeilButton"
+                                                       x:Uid="ceilButton"
+                                                       Grid.Column="2"
+                                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                                       AutomationProperties.AutomationId="ceilButton"
+                                                       ButtonId="Ceil"
+                                                       Click="FlyoutButton_Clicked"
+                                                       Content="&#xF886;"
+                                                       IsEnabled="{x:Bind FuncButton.IsEnabled, Mode=OneWay}"/>
+                        </Grid>
+                    </Flyout>
+                </controls:OperatorPanelButton.FlyoutMenu>
+            </controls:OperatorPanelButton>
+        </controls:OperatorPanelListView>
+
+        <ToggleButton x:Name="ShiftButton"
+                      x:Uid="shiftButton"
+                      Grid.Row="1"
+                      Style="{StaticResource CaptionToggleEmphasizedButtonStyle}"
+                      FontFamily="{StaticResource CalculatorFontFamily}"
+                      FontSize="20"
+                      AutomationProperties.AutomationId="shiftButton"
+                      Checked="ShiftButton_Check"
+                      Content="&#xF897;"
+                      IsEnabledChanged="ShiftButton_IsEnabledChanged"
+                      Unchecked="ShiftButton_Check"/>
+
+        <controls:CalculatorButton x:Name="PiButton"
+                                   x:Uid="piButton"
+                                   Grid.Row="1"
+                                   Grid.Column="1"
+                                   Style="{StaticResource SymbolOperatorButtonStyle}"
+                                   FontSize="14"
+                                   AutomationProperties.AutomationId="piButton"
+                                   ButtonId="Pi"
+                                   Content="&#xf7cf;"/>
+
+        <controls:CalculatorButton x:Name="EulerButton"
+                                   x:Uid="eulerButton"
+                                   Grid.Row="1"
+                                   Grid.Column="2"
+                                   Style="{StaticResource OperatorButtonStyle}"
+                                   FontSize="14"
+                                   AutomationProperties.AutomationId="eulerButton"
+                                   ButtonId="Euler"
+                                   Content="e"/>
+        <Grid x:Name="DisplayControls"
+              x:Uid="DisplayControls"
+              Grid.Row="1"
+              Grid.Column="2"
+              Grid.ColumnSpan="3"
+              AutomationProperties.HeadingLevel="Level1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition/>
+                <ColumnDefinition/>
+                <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+
+            <controls:CalculatorButton x:Name="ClearButton"
+                                       x:Uid="clearButton"
+                                       Grid.Column="1"
+                                       Style="{StaticResource OperatorButtonStyle}"
+                                       FontSize="16"
+                                       AutomationProperties.AutomationId="clearButton"
+                                       ButtonId="Clear"
+                                       Content="C"/>
+
+            <controls:CalculatorButton x:Name="BackSpaceButton"
+                                       x:Uid="backSpaceButton"
+                                       Grid.Column="2"
+                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                       FontFamily="{StaticResource CalculatorFontFamily}"
+                                       FontSize="16"
+                                       AutomationProperties.AutomationId="backSpaceButton"
+                                       ButtonId="Backspace"
+                                       Content="&#xE94F;"/>
+        </Grid>
+
+        <Grid x:Uid="ScientificFunctions"
+              Grid.Row="2"
+              Grid.RowSpan="6"
+              AutomationProperties.HeadingLevel="Level1">
+            <!-- Scientific Row 1 -->
+            <Grid x:Name="Row1">
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+
+                <controls:CalculatorButton x:Name="XPower2Button"
+                                           x:Uid="xpower2Button"
+                                           Style="{StaticResource SymbolOperatorButtonStyle}"
+                                           AutomationProperties.AutomationId="xpower2Button"
+                                           ButtonId="XPower2"
+                                           Content="&#xf7c8;"/>
+
+                <controls:CalculatorButton x:Name="XPower3Button"
+                                           x:Uid="xpower3Button"
+                                           Grid.Row="1"
+                                           Style="{StaticResource SymbolOperatorButtonStyle}"
+                                           AutomationProperties.AutomationId="xpower3Button"
+                                           ButtonId="Cube"
+                                           Content="&#xf7cb;"/>
+
+                <controls:CalculatorButton x:Name="PowerButton"
+                                           x:Uid="powerButton"
+                                           Grid.Row="2"
+                                           Style="{StaticResource SymbolOperatorButtonStyle}"
+                                           AutomationProperties.AutomationId="powerButton"
+                                           ButtonId="XPowerY"
+                                           Content="&#xf7ca;"/>
+
+                <controls:CalculatorButton x:Name="PowerOf10Button"
+                                           x:Uid="powerOf10Button"
+                                           Grid.Row="3"
+                                           Style="{StaticResource SymbolOperatorButtonStyle}"
+                                           AutomationProperties.AutomationId="powerOf10Button"
+                                           ButtonId="TenPowerX"
+                                           Content="&#xF7CC;"/>
+
+                <controls:CalculatorButton x:Name="LogBase10Button"
+                                           x:Uid="logBase10Button"
+                                           Grid.Row="4"
+                                           Style="{StaticResource OperatorButtonStyle}"
+                                           AutomationProperties.AutomationId="logBase10Button"
+                                           ButtonId="LogBase10"
+                                           Content="log"/>
+
+                <controls:CalculatorButton x:Name="LogBaseEButton"
+                                           x:Uid="logBaseEButton"
+                                           Grid.Row="5"
+                                           Style="{StaticResource OperatorButtonStyle}"
+                                           AutomationProperties.AutomationId="logBaseEButton"
+                                           ButtonId="LogBaseE"
+                                           Content="ln"/>
+            </Grid>
+
+            <!-- Scientific INV Row 1 -->
+            <Grid x:Name="InvRow1" Visibility="Collapsed">
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+                <controls:CalculatorButton x:Name="SquareRootButton"
+                                           x:Uid="squareRootButton"
+                                           Style="{StaticResource EmphasizedCalcButtonStyle}"
+                                           AutomationProperties.AutomationId="squareRootButton"
+                                           ButtonId="Sqrt"
+                                           Click="ShiftButton_Uncheck"
+                                           Content="&#xF899;"/>
+
+                <controls:CalculatorButton x:Name="CubeRootButton"
+                                           x:Uid="cubeRootButton"
+                                           Grid.Row="1"
+                                           Style="{StaticResource EmphasizedCalcButtonStyle}"
+                                           AutomationProperties.AutomationId="cubeRootButton"
+                                           ButtonId="CubeRoot"
+                                           Click="ShiftButton_Uncheck"
+                                           Content="&#xF881;"/>
+
+                <controls:CalculatorButton x:Name="YSquareRootButton"
+                                           x:Uid="ySquareRootButton"
+                                           Grid.Row="2"
+                                           Style="{StaticResource EmphasizedCalcButtonStyle}"
+                                           AutomationProperties.AutomationId="ySquareRootButton"
+                                           ButtonId="YRootX"
+                                           Click="ShiftButton_Uncheck"
+                                           Content="&#xf7cd;"/>
+
+                <controls:CalculatorButton x:Name="TwoPowerXButton"
+                                           x:Uid="twoPowerXButton"
+                                           Grid.Row="3"
+                                           Style="{StaticResource EmphasizedCalcButtonStyle}"
+                                           AutomationProperties.AutomationId="twoPowerXButton"
+                                           ButtonId="TwoPowerX"
+                                           Click="ShiftButton_Uncheck"
+                                           Content="&#xF882;"/>
+
+                <controls:CalculatorButton x:Name="LogBaseX"
+                                           x:Uid="logBaseX"
+                                           Grid.Row="4"
+                                           Style="{StaticResource EmphasizedCalcButtonStyle}"
+                                           AutomationProperties.AutomationId="logBaseX"
+                                           ButtonId="LogBaseX"
+                                           Click="ShiftButton_Uncheck"
+                                           Content="&#xF883;"/>
+
+                <controls:CalculatorButton x:Name="PowerOfEButton"
+                                           x:Uid="powerOfEButton"
+                                           Grid.Row="5"
+                                           Style="{StaticResource EmphasizedCalcButtonStyle}"
+                                           AutomationProperties.AutomationId="powerOfEButton"
+                                           ButtonId="EPowerX"
+                                           Click="ShiftButton_Uncheck"
+                                           Content="&#xf7ce;"/>
+            </Grid>
+        </Grid>
+        <!-- Scientific Row 2 -->
+        <Grid x:Name="Row2"
+              Grid.Row="2"
+              Grid.Column="1"
+              Grid.ColumnSpan="4">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="1*"/>
+                <ColumnDefinition Width="1*"/>
+            </Grid.ColumnDefinitions>
+
+            <controls:CalculatorButton x:Name="InvertButton"
+                                       x:Uid="invertButton"
+                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                       AutomationProperties.AutomationId="invertButton"
+                                       ButtonId="Invert"
+                                       Content="&#xf7c9;"/>
+
+            <controls:CalculatorButton x:Name="AbsButton"
+                                       x:Uid="absButton"
+                                       Grid.Column="1"
+                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                       AutomationProperties.AutomationId="absButton"
+                                       ButtonId="Abs"
+                                       Content="&#xF884;"/>
+
+            <controls:CalculatorButton x:Name="XButton"
+                                       x:Uid="xButton"
+                                       Grid.Column="2"
+                                       Style="{StaticResource OperatorButtonStyle}"
+                                       FontSize="16"
+                                       AutomationProperties.AutomationId="xButton"
+                                       ButtonId="X"
+                                       Content="𝑥"/>
+
+            <controls:CalculatorButton x:Name="YButton"
+                                       x:Uid="yButton"
+                                       Grid.Column="3"
+                                       Style="{StaticResource OperatorButtonStyle}"
+                                       FontSize="16"
+                                       AutomationProperties.AutomationId="yButton"
+                                       ButtonId="Y"
+                                       Content="𝑦"/>
+        </Grid>
+
+        <controls:CalculatorButton x:Name="OpenParenthesisButton"
+                                   x:Uid="openParenthesisButton"
+                                   Grid.Row="3"
+                                   Grid.Column="1"
+                                   Style="{StaticResource ParenthesisCalcButtonStyle}"
+                                   FontSize="19"
+                                   AutomationProperties.AutomationId="openParenthesisButton"
+                                   ButtonId="OpenParenthesis"
+                                   Content="("/>
+
+        <controls:CalculatorButton x:Name="CloseParenthesisButton"
+                                   x:Uid="closeParenthesisButton"
+                                   Grid.Row="3"
+                                   Grid.Column="2"
+                                   Style="{StaticResource OperatorButtonStyle}"
+                                   FontSize="19"
+                                   AutomationProperties.AutomationId="closeParenthesisButton"
+                                   ButtonId="CloseParenthesis"
+                                   Content=")"/>
+
+        <controls:CalculatorButton x:Name="EqualButton"
+                                   x:Uid="equalButton"
+                                   Grid.Row="3"
+                                   Grid.Column="3"
+                                   Style="{StaticResource SymbolOperatorButtonStyle}"
+                                   AutomationProperties.AutomationId="equalButton"
+                                   ButtonId="Equals"
+                                   Content="&#xE94E;"/>
+
+        <Grid x:Name="StandardOperators"
+              x:Uid="StandardOperators"
+              Grid.Row="3"
+              Grid.RowSpan="5"
+              Grid.Column="4"
+              AutomationProperties.HeadingLevel="Level1">
+            <Grid.RowDefinitions>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+                <RowDefinition/>
+            </Grid.RowDefinitions>
+            <controls:CalculatorButton x:Name="DivideButton"
+                                       x:Uid="divideButton"
+                                       Grid.Row="0"
+                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                       AutomationProperties.AutomationId="divideButton"
+                                       ButtonId="Divide"
+                                       Content="&#xE94A;"/>
+
+            <controls:CalculatorButton x:Name="MultiplyButton"
+                                       x:Uid="multiplyButton"
+                                       Grid.Row="1"
+                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                       AutomationProperties.AutomationId="multiplyButton"
+                                       ButtonId="Multiply"
+                                       Content="&#xE947;"/>
+
+            <controls:CalculatorButton x:Name="MinusButton"
+                                       x:Uid="minusButton"
+                                       Grid.Row="2"
+                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                       AutomationProperties.AutomationId="minusButton"
+                                       ButtonId="Subtract"
+                                       Content="&#xE949;"/>
+
+            <controls:CalculatorButton x:Name="PlusButton"
+                                       x:Uid="plusButton"
+                                       Grid.Row="3"
+                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                       AutomationProperties.AutomationId="plusButton"
+                                       ButtonId="Add"
+                                       Content="&#xE948;"/>
+
+            <controls:CalculatorButton x:Name="SubmitButton"
+                                       x:Uid="submitButton"
+                                       Grid.Row="4"
+                                       Style="{StaticResource AccentEmphasizedCalcButtonStyle}"
+                                       FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                       AutomationProperties.AutomationId="submitButton"
+                                       ButtonId="Equals"
+                                       Content="&#xE751;"/>
+        </Grid>
+
+        <controls:CalculatorButton x:Name="NegateButton"
+                                   x:Uid="negateButton"
+                                   Grid.Row="7"
+                                   Grid.Column="1"
+                                   Style="{StaticResource SymbolOperatorKeypadButtonStyle}"
+                                   FontSize="16"
+                                   FontWeight="Normal"
+                                   AutomationProperties.AutomationId="negateButton"
+                                   ButtonId="Negate"
+                                   Content="&#xF898;"/>
+
+        <local:NumberPad x:Name="NumberPad"
+                         x:Uid="NumberPad"
+                         Grid.Row="4"
+                         Grid.RowSpan="4"
+                         Grid.Column="1"
+                         Grid.ColumnSpan="3"
+                         AutomationProperties.HeadingLevel="Level1"
+                         ButtonStyle="{StaticResource NumericButtonStyle24}"/>
+    </Grid>
+</UserControl>

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "GraphingNumPad.xaml.h"
+#include "Views/NumberPad.xaml.h"
+
+using namespace CalculatorApp;
+
+using namespace Platform;
+using namespace Windows::Foundation;
+using namespace Windows::Foundation::Collections;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Data;
+using namespace Windows::UI::Xaml::Input;
+using namespace Windows::UI::Xaml::Media;
+using namespace Windows::UI::Xaml::Navigation;
+
+GraphingNumPad::GraphingNumPad()
+{
+    InitializeComponent();
+}
+
+void GraphingNumPad::ShiftButton_Check(_In_ Platform::Object ^ /*sender*/, _In_ Windows::UI::Xaml::RoutedEventArgs ^ /*e*/)
+{
+    SetOperatorRowVisibility();
+}
+
+void GraphingNumPad::ShiftButton_Uncheck(_In_ Platform::Object ^ /*sender*/, _In_ Windows::UI::Xaml::RoutedEventArgs ^ /*e*/)
+{
+    ShiftButton->IsChecked = false;
+    SetOperatorRowVisibility();
+    ShiftButton->Focus(::FocusState::Programmatic);
+}
+
+void GraphingNumPad::TrigFlyoutShift_Toggle(_In_ Platform::Object ^ /*sender*/, _In_ Windows::UI::Xaml::RoutedEventArgs ^ /*e*/)
+{
+    SetTrigRowVisibility();
+}
+
+void GraphingNumPad::TrigFlyoutHyp_Toggle(_In_ Platform::Object ^ /*sender*/, _In_ Windows::UI::Xaml::RoutedEventArgs ^ /*e*/)
+{
+    SetTrigRowVisibility();
+}
+
+void GraphingNumPad::FlyoutButton_Clicked(_In_ Platform::Object ^ /*sender*/, _In_ Windows::UI::Xaml::RoutedEventArgs ^ /*e*/)
+{
+    this->HypButton->IsChecked = false;
+    this->TrigShiftButton->IsChecked = false;
+    this->Trigflyout->Hide();
+    this->FuncFlyout->Hide();
+    this->InequalityFlyout->Hide();
+}
+
+void GraphingNumPad::ShiftButton_IsEnabledChanged(_In_ Platform::Object ^ /*sender*/, _In_ Windows::UI::Xaml::DependencyPropertyChangedEventArgs ^ /*e*/)
+{
+    SetOperatorRowVisibility();
+}
+
+void GraphingNumPad::SetTrigRowVisibility()
+{
+    bool isShiftChecked = TrigShiftButton->IsChecked->Value;
+    bool isHypeChecked = HypButton->IsChecked->Value;
+
+    InverseHyperbolicTrigFunctions->Visibility = ::Visibility::Collapsed;
+    InverseTrigFunctions->Visibility = ::Visibility::Collapsed;
+    HyperbolicTrigFunctions->Visibility = ::Visibility::Collapsed;
+    TrigFunctions->Visibility = ::Visibility::Collapsed;
+
+    if (isShiftChecked && isHypeChecked)
+    {
+        InverseHyperbolicTrigFunctions->Visibility = ::Visibility::Visible;
+    }
+    else if (isShiftChecked && !isHypeChecked)
+    {
+        InverseTrigFunctions->Visibility = ::Visibility::Visible;
+    }
+    else if (!isShiftChecked && isHypeChecked)
+    {
+        HyperbolicTrigFunctions->Visibility = ::Visibility::Visible;
+    }
+    else
+    {
+        TrigFunctions->Visibility = ::Visibility::Visible;
+    }
+}
+
+void GraphingNumPad::SetOperatorRowVisibility()
+{
+    ::Visibility rowVis, invRowVis;
+    if (ShiftButton->IsChecked->Value)
+    {
+        rowVis = ::Visibility::Collapsed;
+        invRowVis = ::Visibility::Visible;
+    }
+    else
+    {
+        rowVis = ::Visibility::Visible;
+        invRowVis = ::Visibility::Collapsed;
+    }
+
+    Row1->Visibility = rowVis;
+    InvRow1->Visibility = invRowVis;
+}

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.h
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "Views\GraphingCalculator\GraphingNumPad.g.h"
+#include "CalcViewModel/GraphingCalculator/GraphingCalculatorViewModel.h"
+
+namespace CalculatorApp
+{
+	[Windows::Foundation::Metadata::WebHostHidden]
+	public ref class GraphingNumPad sealed 
+	{
+	public:
+		GraphingNumPad();
+
+    private:
+        void ShiftButton_Check(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void ShiftButton_Uncheck(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void TrigFlyoutShift_Toggle(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void TrigFlyoutHyp_Toggle(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void FlyoutButton_Clicked(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void ShiftButton_IsEnabledChanged(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::DependencyPropertyChangedEventArgs ^ e);
+        void SetOperatorRowVisibility();
+        void SetTrigRowVisibility();
+	};
+}


### PR DESCRIPTION
## Fixes part of #338 


### Description of the changes:
- Adds the graphing mode keyboard UI, does not yet function, that will be added in a separate PR
- Added Trigonometry, Inequality, and Function operator panels
- Added visual states for small, medium, and large screens
- Updated icons, tab order, and enabled xy navigation

### How changes were validated:
- Manual testing

