### PR TITLE
Fix graph rendering of inequalities

### DIFF
--- a/src/GraphControl/Control/Equation.cpp
+++ b/src/GraphControl/Control/Equation.cpp
@@ -404,6 +404,8 @@ namespace GraphControl
     wstring Equation::GetRequestHeader()
     {
         wstring expr{ Expression->Data() };
+
+        // Check for unicode characters of less than, less than or equal to, greater than and greater than or equal to.
         if (expr.find(L">&#x3E;<") != wstring::npos || expr.find(L">&#x3C;<") != wstring::npos || expr.find(L">&#x2265;<") != wstring::npos
             || expr.find(L">&#x2264;<") != wstring::npos)
         {

--- a/src/GraphControl/Control/Equation.cpp
+++ b/src/GraphControl/Control/Equation.cpp
@@ -404,7 +404,12 @@ namespace GraphControl
     wstring Equation::GetRequestHeader()
     {
         wstring expr{ Expression->Data() };
-        if (expr.find(L">=<") != wstring::npos)
+        if (expr.find(L">&#x3E;<") != wstring::npos || expr.find(L">&#x3C;<") != wstring::npos || expr.find(L">&#x2265;<") != wstring::npos
+            || expr.find(L">&#x2264;<") != wstring::npos)
+        {
+            return L"<mrow><mi>plotIneq2D</mi><mfenced separators=\"\">"s;
+        }
+        else if (expr.find(L">=<") != wstring::npos)
         {
             return L"<mrow><mi>plotEq2d</mi><mfenced separators=\"\">"s;
         }


### PR DESCRIPTION
## Fixes part of #338 


### Description of the changes:
- Use command plotIneq2D instead of plotEq2d when the equation contains an inequality

### How changes were validated:
- Manual test

