### PR TITLE
Save and restore the value of EquationInputArea when users scroll

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -2101,6 +2101,7 @@
                                                                   FontWeight="{TemplateBinding FontWeight}"
                                                                   AcceptsReturn="false"
                                                                   InputScope="Text"
+                                                                  MathText="{Binding MathEquation, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                                                                   MaxLength="2048"
                                                                   TextWrapping="NoWrap">
                                             <Controls:MathRichEditBox.ContextFlyout>

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -55,7 +55,7 @@ void EquationTextBox::OnApplyTemplate()
         m_richEditBox->LostFocus += ref new RoutedEventHandler(this, &EquationTextBox::OnRichEditBoxLostFocus);
         m_richEditBox->SelectionFlyout = nullptr;
         m_richEditBox->EquationSubmitted +=
-            ref new EventHandler<CalculatorApp::Controls::MathRichEditBoxSubmission ^>(this, &CalculatorApp::Controls::EquationTextBox::OnEquationSubmitted);
+            ref new EventHandler<MathRichEditBoxSubmission ^>(this, &EquationTextBox::OnEquationSubmitted);
     }
 
     if (m_equationButton != nullptr)
@@ -72,7 +72,7 @@ void EquationTextBox::OnApplyTemplate()
 
     if (m_richEditContextMenu != nullptr)
     {
-        m_richEditContextMenu->Opening += ref new Windows::Foundation::EventHandler<Platform::Object ^>(this, &EquationTextBox::OnRichEditMenuOpening);
+        m_richEditContextMenu->Opening += ref new EventHandler<Platform::Object ^>(this, &EquationTextBox::OnRichEditMenuOpening);
     }
 
     if (m_kgfEquationButton != nullptr)
@@ -381,7 +381,7 @@ void EquationTextBox::FocusTextBox()
     }
 }
 
-void CalculatorApp::Controls::EquationTextBox::OnEquationSubmitted(Platform::Object ^ sender, CalculatorApp::Controls::MathRichEditBoxSubmission ^ args)
+void EquationTextBox::OnEquationSubmitted(Platform::Object ^ sender, MathRichEditBoxSubmission ^ args)
 {
     if (args->HasTextChanged)
     {

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -377,7 +377,7 @@ void EquationTextBox::FocusTextBox()
 {
     if (m_richEditBox != nullptr)
     {
-        m_richEditBox->Focus(::FocusState::Programmatic);
+        FocusManager::TryFocusAsync(m_richEditBox, ::FocusState::Programmatic);
     }
 }
 

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -27,6 +27,7 @@ DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, ColorChooserFlyout);
 DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, EquationButtonContentIndex);
 DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, HasError);
 DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, IsAddEquationMode);
+DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, MathEquation);
 
 EquationTextBox::EquationTextBox()
 {
@@ -52,8 +53,9 @@ void EquationTextBox::OnApplyTemplate()
     {
         m_richEditBox->GotFocus += ref new RoutedEventHandler(this, &EquationTextBox::OnRichEditBoxGotFocus);
         m_richEditBox->LostFocus += ref new RoutedEventHandler(this, &EquationTextBox::OnRichEditBoxLostFocus);
-        m_richEditBox->TextChanged += ref new RoutedEventHandler(this, &EquationTextBox::OnRichEditBoxTextChanged);
         m_richEditBox->SelectionFlyout = nullptr;
+        m_richEditBox->EquationSubmitted +=
+            ref new EventHandler<CalculatorApp::Controls::MathRichEditBoxSubmission ^>(this, &CalculatorApp::Controls::EquationTextBox::OnEquationSubmitted);
     }
 
     if (m_equationButton != nullptr)
@@ -151,37 +153,6 @@ void EquationTextBox::OnPointerCaptureLost(PointerRoutedEventArgs ^ e)
     UpdateCommonVisualState();
 }
 
-void EquationTextBox::OnKeyDown(KeyRoutedEventArgs ^ e)
-{
-    if (e->Key == VirtualKey::Enter)
-    {
-        m_sourceSubmission = EquationSubmissionSource::ENTER_KEY;
-        // We will rely on OnLostFocus to submit the equation to prevent the launch of 2 events
-        if (!m_HasFocus || !FocusManager::TryMoveFocusAsync(::FocusNavigationDirection::Next))
-        {
-            m_sourceSubmission = EquationSubmissionSource::FOCUS_LOST;
-            EquationSubmitted(this, EquationSubmissionSource::ENTER_KEY);
-            if (m_functionButton && m_richEditBox->MathText != L"")
-            {
-                m_functionButton->IsEnabled = true;
-            }
-        }
-    }
-}
-
-void EquationTextBox::OnLostFocus(RoutedEventArgs ^ e)
-{
-    if (m_richEditBox == nullptr || m_richEditBox->ContextFlyout->IsOpen)
-    {
-        return;
-    }
-
-    if (m_functionButton && m_richEditBox->MathText != L"")
-    {
-        m_functionButton->IsEnabled = true;
-    }
-}
-
 void EquationTextBox::OnColorFlyoutOpened(Object ^ sender, Object ^ e)
 {
     m_isColorChooserFlyoutOpen = true;
@@ -195,15 +166,9 @@ void EquationTextBox::OnColorFlyoutClosed(Object ^ sender, Object ^ e)
     UpdateCommonVisualState();
 }
 
-void EquationTextBox::OnRichEditBoxTextChanged(Object ^ sender, RoutedEventArgs ^ e)
-{
-    UpdateButtonsVisualState();
-}
-
 void EquationTextBox::OnRichEditBoxGotFocus(Object ^ sender, RoutedEventArgs ^ e)
 {
     m_HasFocus = true;
-    m_sourceSubmission = EquationSubmissionSource::FOCUS_LOST;
     UpdateCommonVisualState();
     UpdateButtonsVisualState();
 }
@@ -217,8 +182,6 @@ void EquationTextBox::OnRichEditBoxLostFocus(Object ^ sender, RoutedEventArgs ^ 
 
     UpdateCommonVisualState();
     UpdateButtonsVisualState();
-
-    EquationSubmitted(this, m_sourceSubmission);
 }
 
 void EquationTextBox::OnDeleteButtonClicked(Object ^ sender, RoutedEventArgs ^ e)
@@ -416,4 +379,17 @@ void EquationTextBox::FocusTextBox()
     {
         m_richEditBox->Focus(::FocusState::Programmatic);
     }
+}
+
+void CalculatorApp::Controls::EquationTextBox::OnEquationSubmitted(Platform::Object ^ sender, CalculatorApp::Controls::MathRichEditBoxSubmission ^ args)
+{
+    if (args->HasTextChanged)
+    {
+        if (m_functionButton && m_richEditBox->MathText != L"")
+        {
+            m_functionButton->IsEnabled = true;
+        }
+    }
+
+    EquationSubmitted(this, args);
 }

--- a/src/Calculator/Controls/EquationTextBox.h
+++ b/src/Calculator/Controls/EquationTextBox.h
@@ -12,13 +12,6 @@ namespace CalculatorApp
     namespace Controls
     {
     public
-        enum class EquationSubmissionSource
-        {
-            FOCUS_LOST,
-            ENTER_KEY
-        };
-
-    public
         ref class EquationTextBox sealed : public Windows::UI::Xaml::Controls::Control
         {
         public:
@@ -28,6 +21,7 @@ namespace CalculatorApp
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Media::SolidColorBrush ^, EquationColor);
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Controls::Flyout ^, ColorChooserFlyout);
             DEPENDENCY_PROPERTY(Platform::String ^, EquationButtonContentIndex);
+            DEPENDENCY_PROPERTY(Platform::String ^, MathEquation);
             DEPENDENCY_PROPERTY_WITH_CALLBACK(bool, HasError);
             DEPENDENCY_PROPERTY_WITH_CALLBACK(bool, IsAddEquationMode);
 
@@ -35,7 +29,7 @@ namespace CalculatorApp
 
             event Windows::UI::Xaml::RoutedEventHandler ^ RemoveButtonClicked;
             event Windows::UI::Xaml::RoutedEventHandler ^ KeyGraphFeaturesButtonClicked;
-            event Windows::Foundation::EventHandler<EquationSubmissionSource> ^ EquationSubmitted;
+            event Windows::Foundation::EventHandler<MathRichEditBoxSubmission ^> ^ EquationSubmitted;
             event Windows::UI::Xaml::RoutedEventHandler ^ EquationButtonClicked;
 
             Platform::String ^ GetEquationText();
@@ -48,8 +42,6 @@ namespace CalculatorApp
             virtual void OnPointerExited(Windows::UI::Xaml::Input::PointerRoutedEventArgs ^ e) override;
             virtual void OnPointerCanceled(Windows::UI::Xaml::Input::PointerRoutedEventArgs ^ e) override;
             virtual void OnPointerCaptureLost(Windows::UI::Xaml::Input::PointerRoutedEventArgs ^ e) override;
-            virtual void OnKeyDown(Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e) override;
-            virtual void OnLostFocus(Windows::UI::Xaml::RoutedEventArgs ^ e) override;
             void OnIsAddEquationModePropertyChanged(bool oldValue, bool newValue);
 
         private:
@@ -59,7 +51,6 @@ namespace CalculatorApp
 
             void OnRichEditBoxGotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
             void OnRichEditBoxLostFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
-            void OnRichEditBoxTextChanged(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 
             void OnDeleteButtonClicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
             void OnEquationButtonClicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
@@ -89,7 +80,7 @@ namespace CalculatorApp
 
             bool m_isPointerOver;
             bool m_isColorChooserFlyoutOpen;
-			EquationSubmissionSource m_sourceSubmission;
-		};
+            void OnEquationSubmitted(Platform::Object ^ sender, CalculatorApp::Controls::MathRichEditBoxSubmission ^ args);
+        };
     }
 }

--- a/src/Calculator/Controls/MathRichEditBox.h
+++ b/src/Calculator/Controls/MathRichEditBox.h
@@ -9,41 +9,44 @@ namespace CalculatorApp
     namespace Controls
     {
     public
+        enum class EquationSubmissionSource
+        {
+            FOCUS_LOST,
+            ENTER_KEY,
+        };
+
+    public
+        ref class MathRichEditBoxSubmission sealed
+        {
+        public:
+            PROPERTY_R(bool, HasTextChanged);
+            PROPERTY_R(EquationSubmissionSource, Source);
+        public:
+            MathRichEditBoxSubmission(bool hasTextChanged, EquationSubmissionSource source)
+                : m_HasTextChanged(hasTextChanged)
+                , m_Source(source)
+            {
+            }
+        };
+
+    public
         ref class MathRichEditBox sealed : Windows::UI::Xaml::Controls::RichEditBox
         {
         public:
             MathRichEditBox();
 
             DEPENDENCY_PROPERTY_OWNER(MathRichEditBox);
+            DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(Platform::String ^, MathText, L"");
 
-            static property Windows::UI::Xaml::DependencyProperty ^ MathTextProperty
-            {
-                Windows::UI::Xaml::DependencyProperty ^ get() {
-                    return s_MathTextProperty;
-                }
-            }      
-            property Platform::String ^ MathText
-            {
-                Platform::String ^ get()
-                {
-                    return GetMathTextProperty();
-                }
-                void set(Platform::String^ value)
-                {
-                    SetMathTextProperty(value);
-                }
-            
-            }
+            event Windows::Foundation::EventHandler<MathRichEditBoxSubmission^> ^ EquationSubmitted;
+            void OnMathTextPropertyChanged(Platform::String ^ oldValue, Platform::String ^ newValue);
 
-        private :
+        private:
             Platform::String ^ GetMathTextProperty();
             void SetMathTextProperty(Platform::String ^ newValue);
 
-            static Windows::UI::Xaml::DependencyProperty ^ s_MathTextProperty;
-            static Windows::UI::Xaml::DependencyProperty ^ InitializeMathTextProperty()
-            {
-                return Utils::RegisterDependencyProperty<DependencyPropertiesOwner, Platform::String ^>(L"MathText");
-            }
+            void OnLosingFocus(Windows::UI::Xaml::UIElement ^ sender, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ args);
+            void OnKeyUp(Platform::Object ^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e);
         };
     }
 }

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -243,6 +243,7 @@
                                                       KeyGraphFeaturesButtonClicked="EquationTextBox_KeyGraphFeaturesButtonClicked"
                                                       Loaded="InputTextBox_Loaded"
                                                       LostFocus="InputTextBox_LostFocus"
+                                                      MathEquation="{x:Bind Expression, Mode=TwoWay}"
                                                       RemoveButtonClicked="EquationTextBox_RemoveButtonClicked">
                                 <controls:EquationTextBox.ColorChooserFlyout>
                                     <Flyout x:Name="ColorChooserFlyout"

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -88,7 +88,7 @@ void EquationInputArea::InputTextBox_LostFocus(Object ^ sender, RoutedEventArgs 
     KeyboardShortcutManager::HonorShortcuts(true);
 }
 
-void EquationInputArea::InputTextBox_Submitted(Object ^ sender, EquationSubmissionSource source)
+void EquationInputArea::InputTextBox_Submitted(Object ^ sender, MathRichEditBoxSubmission ^ submission)
 {
     auto tb = static_cast<EquationTextBox ^>(sender);
     if (tb == nullptr)
@@ -101,16 +101,8 @@ void EquationInputArea::InputTextBox_Submitted(Object ^ sender, EquationSubmissi
         return;
     }
 
-    auto expressionText = tb->GetEquationText();
-    if (source == EquationSubmissionSource::FOCUS_LOST && eq->Expression == expressionText)
-    {
-        // The expression didn't change.
-        return;
-    }
-
-    eq->Expression = expressionText;
-
-    if (source == EquationSubmissionSource::ENTER_KEY || eq->Expression != nullptr && eq->Expression->Length() > 0)
+    if (submission->Source == EquationSubmissionSource::ENTER_KEY ||
+        (submission->Source == EquationSubmissionSource::FOCUS_LOST && submission->HasTextChanged && eq->Expression != nullptr && eq->Expression->Length() > 0))
     {
         unsigned int index = 0;
         if (Equations->IndexOf(eq, &index))
@@ -184,13 +176,6 @@ void EquationInputArea::EquationTextBox_RemoveButtonClicked(Object ^ sender, Rou
 void EquationInputArea::EquationTextBox_KeyGraphFeaturesButtonClicked(Object ^ sender, RoutedEventArgs ^ e)
 {
     auto tb = static_cast<EquationTextBox ^>(sender);
-
-    // ensure the equation has been submitted before trying to get key graph features out of it
-    if (tb->HasFocus)
-    {
-        EquationInputArea::InputTextBox_Submitted(sender, EquationSubmissionSource::FOCUS_LOST);
-    }
-
     auto eq = static_cast<EquationViewModel ^>(tb->DataContext);
     EquationVM = eq;
     KeyGraphFeaturesRequested(EquationVM, ref new RoutedEventArgs());

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
@@ -36,9 +36,9 @@ namespace CalculatorApp
 
         void AddNewEquation();
 
-        void InputTextBox_GotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-        void InputTextBox_LostFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
-        void InputTextBox_Submitted(Platform::Object ^ sender, CalculatorApp::Controls::EquationSubmissionSource e);
+        void InputTextBox_GotFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void InputTextBox_LostFocus(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
+        void InputTextBox_Submitted(Platform::Object ^ sender, CalculatorApp::Controls::MathRichEditBoxSubmission ^ e);
 
         void OnHighContrastChanged(Windows::UI::ViewManagement::AccessibilitySettings ^ sender, Platform::Object ^ args);
         void ReloadAvailableColors(bool isHighContrast);

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -460,7 +460,7 @@ void GraphingCalculator::TraceValuePopup_SizeChanged(Object ^ sender, SizeChange
 
 void CalculatorApp::GraphingCalculator::ActiveTracing_Checked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e)
 {
-    GraphingControl->Focus(::FocusState::Programmatic);
+    FocusManager::TryFocusAsync(GraphingControl, ::FocusState::Programmatic);
 
     m_activeTracingKeyUpToken = Window::Current->CoreWindow->KeyUp +=
         ref new Windows::Foundation::TypedEventHandler<Windows::UI::Core::CoreWindow ^, Windows::UI::Core::KeyEventArgs ^>(

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.cpp
@@ -32,7 +32,7 @@ void GraphingNumPad::ShiftButton_Uncheck(_In_ Platform::Object ^ /*sender*/, _In
 {
     ShiftButton->IsChecked = false;
     SetOperatorRowVisibility();
-    ShiftButton->Focus(::FocusState::Programmatic);
+    FocusManager::TryFocusAsync(ShiftButton, ::FocusState::Programmatic);
 }
 
 void GraphingNumPad::TrigFlyoutShift_Toggle(_In_ Platform::Object ^ /*sender*/, _In_ Windows::UI::Xaml::RoutedEventArgs ^ /*e*/)

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -296,7 +296,7 @@ void MainPage::SetDefaultFocus()
     }
     if (m_graphingCalculator != nullptr && m_graphingCalculator->Visibility == ::Visibility::Visible)
     {
-        m_graphingCalculator->Focus(::FocusState::Programmatic);
+        FocusManager::TryFocusAsync(m_graphingCalculator, ::FocusState::Programmatic);
     }
     if (m_converter != nullptr && m_converter->Visibility == ::Visibility::Visible)
     {


### PR DESCRIPTION
The current implementation never saved/restored the value of EquationInputAreas when users scrolled the list and DataTemplate where recycled by the list virtualization

### Description of the changes:
- Refactor MathRichEditBox and add a (real) dependency property (the existing one were used a regular property) we can use for bindings.
- Move submission detection from EquationInputArea to MathRichEditBox

Also: 
- Because the submission detection is faster, other items don't get the focus when users press many times Enter.

### How to test?


- Enter 4-5 equations
- Type `Enter` many times to add more than 16 'empty' equations
**Before**: Because of the virtualization, new equations will be initialized with some of the first equations you typed (and vice-versa, the first equations will disappear if you scroll up)
**After**: The equations won't be mixed up

### How changes were validated:
- manually

