### PR TITLE
Fix some focus issues in Graphing Calculator

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -97,8 +97,9 @@ void EquationInputArea::InputTextBox_Submitted(Object ^ sender, MathRichEditBoxS
         return;
     }
 
-    if (submission->Source == EquationSubmissionSource::ENTER_KEY ||
-        (submission->Source == EquationSubmissionSource::FOCUS_LOST && submission->HasTextChanged && eq->Expression != nullptr && eq->Expression->Length() > 0))
+    if (submission->Source == EquationSubmissionSource::ENTER_KEY
+        || (submission->Source == EquationSubmissionSource::FOCUS_LOST && submission->HasTextChanged && eq->Expression != nullptr
+            && eq->Expression->Length() > 0))
     {
         unsigned int index = 0;
         if (Equations->IndexOf(eq, &index))
@@ -110,8 +111,11 @@ void EquationInputArea::InputTextBox_Submitted(Object ^ sender, MathRichEditBoxS
             }
             else
             {
-                auto nextEquation = Equations->GetAt(index + 1);
-                FocusEquationTextBox(nextEquation);
+                if (submission->Source == EquationSubmissionSource::ENTER_KEY)
+                {
+                    auto nextEquation = Equations->GetAt(index + 1);
+                    FocusEquationTextBox(nextEquation);
+                }
             }
         }
     }
@@ -192,11 +196,12 @@ void EquationInputArea::InputTextBox_Loaded(Object ^ sender, RoutedEventArgs ^ e
 
     if (m_equationToFocus != nullptr && tb->DataContext == m_equationToFocus)
     {
+        auto copyEquationToFocus = m_equationToFocus;
         m_equationToFocus = nullptr;
         tb->FocusTextBox();
 
         unsigned int index;
-        if (Equations->IndexOf(m_equationToFocus, &index))
+        if (Equations->IndexOf(copyEquationToFocus, &index))
         {
             auto container = EquationInputList->TryGetElement(index);
             if (container != nullptr)

--- a/src/GraphControl/DirectX/RenderMain.cpp
+++ b/src/GraphControl/DirectX/RenderMain.cpp
@@ -197,7 +197,7 @@ namespace GraphControl::DX
                         {
                             auto lineColors = m_graph->GetOptions().GetGraphColors();
 
-                            if (formulaId >= 0 && formulaId < lineColors.size())
+                            if (formulaId >= 0 && static_cast<unsigned int>(formulaId) < lineColors.size())
                             {
                                 auto dotColor = lineColors[formulaId];
                                 m_nearestPointRenderer.SetColor(D2D1::ColorF(dotColor.R * 65536 + dotColor.G * 256 + dotColor.B, 1.0));


### PR DESCRIPTION
### Description of the changes:
-  Fix issue with bringing the new equation to the view (scrolling)
- Prevent the app to give the focus to the next equation when users modify an equation and click somewhere else  

### How changes were validated:
- manually