### PR TITLE
Cleaning up some UnitConverter code and making some of it more efficient

### DIFF
--- a/src/CalcManager/UnitConverter.h
+++ b/src/CalcManager/UnitConverter.h
@@ -50,10 +50,6 @@ namespace UnitConversionManager
             accessibleName = nameValue1 + L" " + nameValue2;
         }
 
-        virtual ~Unit()
-        {
-        }
-
         int id;
         std::wstring name;
         std::wstring accessibleName;
@@ -142,10 +138,6 @@ namespace UnitConversionManager
             : ratio(ratio)
             , offset(offset)
             , offsetFirst(offsetFirst)
-        {
-        }
-
-        virtual ~ConversionData()
         {
         }
 
@@ -238,7 +230,7 @@ namespace UnitConversionManager
         virtual void SetCurrentUnitTypes(const Unit& fromType, const Unit& toType) = 0;
         virtual void SwitchActive(const std::wstring& newValue) = 0;
         virtual std::wstring SaveUserPreferences() = 0;
-        virtual void RestoreUserPreferences(_In_ const std::wstring& userPreferences) = 0;
+        virtual void RestoreUserPreferences(_In_ std::wstring_view userPreferences) = 0;
         virtual void SendCommand(Command command) = 0;
         virtual void SetViewModelCallback(_In_ const std::shared_ptr<IUnitConverterVMCallback>& newCallback) = 0;
         virtual void SetViewModelCurrencyCallback(_In_ const std::shared_ptr<IViewModelCurrencyCallback>& newCallback) = 0;
@@ -261,7 +253,7 @@ namespace UnitConversionManager
         void SetCurrentUnitTypes(const Unit& fromType, const Unit& toType) override;
         void SwitchActive(const std::wstring& newValue) override;
         std::wstring SaveUserPreferences() override;
-        void RestoreUserPreferences(const std::wstring& userPreference) override;
+        void RestoreUserPreferences(std::wstring_view userPreference) override;
         void SendCommand(Command command) override;
         void SetViewModelCallback(_In_ const std::shared_ptr<IUnitConverterVMCallback>& newCallback) override;
         void SetViewModelCurrencyCallback(_In_ const std::shared_ptr<IViewModelCurrencyCallback>& newCallback) override;
@@ -270,20 +262,20 @@ namespace UnitConversionManager
         void ResetCategoriesAndRatios() override;
         // IUnitConverter
 
-        static std::vector<std::wstring> StringToVector(const std::wstring& w, const wchar_t* delimiter, bool addRemainder = false);
-        static std::wstring Quote(const std::wstring& s);
-        static std::wstring Unquote(const std::wstring& s);
+        static std::vector<std::wstring> StringToVector(std::wstring_view w, std::wstring_view delimiter, bool addRemainder = false);
+        static std::wstring Quote(std::wstring_view s);
+        static std::wstring Unquote(std::wstring_view s);
 
     private:
         bool CheckLoad();
-        double Convert(double value, ConversionData conversionData);
+        double Convert(double value, const ConversionData& conversionData);
         std::vector<std::tuple<std::wstring, Unit>> CalculateSuggested();
         void ClearValues();
         void InitializeSelectedUnits();
-        Category StringToCategory(const std::wstring& w);
-        std::wstring CategoryToString(const Category& c, const wchar_t* delimiter);
-        std::wstring UnitToString(const Unit& u, const wchar_t* delimiter);
-        Unit StringToUnit(const std::wstring& w);
+        Category StringToCategory(std::wstring_view w);
+        std::wstring CategoryToString(const Category& c, std::wstring_view delimiter);
+        std::wstring UnitToString(const Unit& u, std::wstring_view delimiter);
+        Unit StringToUnit(std::wstring_view w);
         void UpdateCurrencySymbols();
         void UpdateViewModel();
         bool AnyUnitIsEmpty();

--- a/src/CalculatorUnitTests/UnitConverterTest.cpp
+++ b/src/CalculatorUnitTests/UnitConverterTest.cpp
@@ -327,12 +327,12 @@ namespace UnitConverterUnitTests
     // Test input escaping
     void UnitConverterTest::UnitConverterTestQuote()
     {
-        wstring input1 = L"Weight";
-        wstring output1 = L"Weight";
-        wstring input2 = L"{p}Weig;[ht|";
-        wstring output2 = L"{lb}p{rb}Weig{sc}{lc}ht{p}";
-        wstring input3 = L"{{{t;s}}},:]";
-        wstring output3 = L"{lb}{lb}{lb}t{sc}s{rb}{rb}{rb}{cm}{co}{rc}";
+        constexpr wstring_view input1 = L"Weight";
+        constexpr wstring_view output1 = L"Weight";
+        constexpr wstring_view input2 = L"{p}Weig;[ht|";
+        constexpr wstring_view output2 = L"{lb}p{rb}Weig{sc}{lc}ht{p}";
+        constexpr wstring_view input3 = L"{{{t;s}}},:]";
+        constexpr wstring_view output3 = L"{lb}{lb}{lb}t{sc}s{rb}{rb}{rb}{cm}{co}{rc}";
         VERIFY_IS_TRUE(UnitConverter::Quote(input1) == output1);
         VERIFY_IS_TRUE(UnitConverter::Quote(input2) == output2);
         VERIFY_IS_TRUE(UnitConverter::Quote(input3) == output3);
@@ -341,9 +341,9 @@ namespace UnitConverterUnitTests
     // Test output unescaping
     void UnitConverterTest::UnitConverterTestUnquote()
     {
-        wstring input1 = L"Weight";
-        wstring input2 = L"{p}Weig;[ht|";
-        wstring input3 = L"{{{t;s}}},:]";
+        constexpr wstring_view input1 = L"Weight";
+        constexpr wstring_view input2 = L"{p}Weig;[ht|";
+        constexpr wstring_view input3 = L"{{{t;s}}},:]";
         VERIFY_IS_TRUE(UnitConverter::Unquote(input1) == input1);
         VERIFY_IS_TRUE(UnitConverter::Unquote(UnitConverter::Quote(input1)) == input1);
         VERIFY_IS_TRUE(UnitConverter::Unquote(UnitConverter::Quote(input2)) == input2);

--- a/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.cpp
@@ -227,7 +227,7 @@ void UnitConverterMock::SwitchActive(const std::wstring& newValue)
         return L"TEST";
     };
 
-void UnitConverterMock::RestoreUserPreferences(_In_ const std::wstring& /*userPreferences*/){};
+void UnitConverterMock::RestoreUserPreferences(_In_ std::wstring_view /*userPreferences*/){};
 
 void UnitConverterMock::SendCommand(UCM::Command command)
 {

--- a/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.h
+++ b/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.h
@@ -35,7 +35,7 @@ namespace CalculatorUnitTests
         void SetCurrentUnitTypes(const UCM::Unit& fromType, const UCM::Unit& toType) override;
         void SwitchActive(const std::wstring& newValue);
         std::wstring SaveUserPreferences() override;
-        void RestoreUserPreferences(_In_ const std::wstring& userPreferences) override;
+        void RestoreUserPreferences(_In_ std::wstring_view userPreferences) override;
         void SendCommand(UCM::Command command) override;
         void SetViewModelCallback(const std::shared_ptr<UCM::IUnitConverterVMCallback>& newCallback) override;
         void SetViewModelCurrencyCallback(_In_ const std::shared_ptr<UCM::IViewModelCurrencyCallback>& /*newCallback*/) override


### PR DESCRIPTION
## Fixes #874.

### Description of the changes:
- Using range-for loops where appropriate
- Stop using wstringstream where a wstring could be used instead
- Take advantage of wstring_view where appropriate


### How changes were validated:
- Manual testing
- Ran existing unit tests