### PR TITLE
Removing call to stripzeroesnum if no number exists.

### DIFF
--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -741,8 +741,10 @@ PNUMBER StringToNumber(wstring_view numberString, uint32_t radix, int32_t precis
         destroynum(pnumret);
         pnumret = nullptr;
     }
-
-    stripzeroesnum(pnumret, precision);
+    else
+    {
+        stripzeroesnum(pnumret, precision);
+    }
 
     return pnumret;
 }


### PR DESCRIPTION
## Fixes #876.

### Description of the changes:
- Removing call to stripzeroesnum if no number exists.

### Note
It could be possible that `stripzeroesnum` was supposed to be called before checking if a number exists.  I'm not very familiar with this code so I simply kept the logic the same except for skipping the `stripzeroesnum` if the number was nulled out.