### PR TITLE
High Contrast support for Graphing Calculator

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -3,7 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:Controls="using:CalculatorApp.Controls"
              xmlns:common="using:CalculatorApp.Common"
-             xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
              xmlns:local="using:CalculatorApp">
 
     <Application.Resources>
@@ -15,8 +14,6 @@
                 <ResourceDictionary x:Key="Default">
                     <Thickness x:Key="HighContrastThicknessTop">0,0,0,0</Thickness>
                     <x:Double x:Key="HighContrastStrokeThickness">0</x:Double>
-                    <x:Double x:Key="EquationButtonOverlayPointerOverOpacity">0.3</x:Double>
-                    <x:Double x:Key="EquationButtonOverlayPressedOpacity">0.5</x:Double>
                     <Color x:Key="AltHighColor">#FF000000</Color>
                     <Color x:Key="ChromeMediumLowColor">#FF2B2B2B</Color>
                     <Color x:Key="OperatorPanelScrollButtonBackgroundColor">#FF858585</Color>
@@ -69,22 +66,8 @@
                                   FallbackColor="{ThemeResource SystemChromeMediumColor}"
                                   TintColor="{ThemeResource SystemChromeLowColor}"
                                   TintOpacity="0.7"/>
-                    <SolidColorBrush x:Key="EquationBoxAddBackgroundBrush" Color="#9d000000"/>
-                    <SolidColorBrush x:Key="EquationBoxPointerOverBackgroundBrush" Color="{ThemeResource SystemControlBackgroundAltMediumBrush}"/>
-                    <SolidColorBrush x:Key="EquationBoxHoverButtonForegroundBrush" Color="{ThemeResource SystemBaseHighColor}"/>
                     <SolidColorBrush x:Key="AppChromeAcrylicOperatorFlyoutBackgroundBrush" Color="#FF2F2F2F"/>
-                    <SolidColorBrush x:Key="EquationBoxBorderBrush" Color="{ThemeResource TextControlBackground}"/>
-                    <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="White"/>
-                    <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="#33EB5757"/>
-                    <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="#FFEB5757"/>
-                    <SolidColorBrush x:Key="EquationButtonHideLineBackgroundBrush"
-                                     Opacity="0.4"
-                                     Color="#FFFFFF"/>
-                    <SolidColorBrush x:Key="EquationButtonHideLineForegroundBrush"
-                                     Opacity="0.6"
-                                     Color="{StaticResource SystemChromeWhiteColor}"/>
                     <SolidColorBrush x:Key="AppControlTransparentButtonBackgroundBrush" Color="Transparent"/>
-
                     <SolidColorBrush x:Key="EquationBrush1" Color="#FF0078D7"/>
                     <SolidColorBrush x:Key="EquationBrush2" Color="#FFFFB900"/>
                     <SolidColorBrush x:Key="EquationBrush3" Color="#FFFF8C00"/>
@@ -108,8 +91,6 @@
                     <x:Double x:Key="HighContrastStrokeThickness">0</x:Double>
                     <Color x:Key="AltHighColor">#FFF2F2F2</Color>
                     <Color x:Key="ChromeMediumLowColor">#FFE0E0E0</Color>
-                    <x:Double x:Key="EquationButtonOverlayPointerOverOpacity">0.2</x:Double>
-                    <x:Double x:Key="EquationButtonOverlayPressedOpacity">0.4</x:Double>
                     <Color x:Key="OperatorPanelScrollButtonBackgroundColor">#FF858585</Color>
                     <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="{StaticResource SystemAltHighColor}"/>
                     <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumLowBrush" Color="{StaticResource ChromeMediumLowColor}"/>
@@ -165,19 +146,7 @@
                                   FallbackColor="{ThemeResource SystemChromeMediumColor}"
                                   TintColor="{ThemeResource SystemChromeLowColor}"
                                   TintOpacity="0.8"/>
-                    <SolidColorBrush x:Key="EquationBoxAddBackgroundBrush" Color="#D0FFFFFF"/>
-                    <SolidColorBrush x:Key="EquationBoxPointerOverBackgroundBrush" Color="{ThemeResource SystemControlBackgroundAltMediumBrush}"/>
-                    <SolidColorBrush x:Key="EquationBoxHoverButtonForegroundBrush" Color="{ThemeResource SystemBaseHighColor}"/>
-                    <SolidColorBrush x:Key="EquationBoxBorderBrush" Color="{ThemeResource TextControlBackground}"/>
-                    <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="Black"/>
-                    <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="#33EB5757"/>
-                    <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="#FFEB5757"/>
-                    <SolidColorBrush x:Key="EquationButtonHideLineBackgroundBrush"
-                                     Opacity="0.4"
-                                     Color="#000000"/>
-                    <SolidColorBrush x:Key="EquationButtonHideLineForegroundBrush" Color="{StaticResource SystemChromeWhiteColor}"/>
                     <SolidColorBrush x:Key="AppControlTransparentButtonBackgroundBrush" Color="Transparent"/>
-
                     <SolidColorBrush x:Key="EquationBrush1" Color="#FF0078D7"/>
                     <SolidColorBrush x:Key="EquationBrush2" Color="#FFFFB900"/>
                     <SolidColorBrush x:Key="EquationBrush3" Color="#FFFF8C00"/>
@@ -198,8 +167,6 @@
                 <ResourceDictionary x:Key="HighContrast">
                     <Thickness x:Key="HighContrastThicknessTop">0,1,0,0</Thickness>
                     <x:Double x:Key="HighContrastStrokeThickness">2</x:Double>
-                    <x:Double x:Key="EquationButtonOverlayPointerOverOpacity">1.0</x:Double>
-                    <x:Double x:Key="EquationButtonOverlayPressedOpacity">1.0</x:Double>
                     <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
                     <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumLowBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
                     <SolidColorBrush x:Key="TitleBarForegroundBaseHighBrush" Color="{ThemeResource SystemColorCaptionTextColor}"/>
@@ -224,16 +191,7 @@
                     <SolidColorBrush x:Key="AppControlHighlightCalcButtonBrush" Color="{ThemeResource SystemColorWindowColor}"/>
                     <SolidColorBrush x:Key="AppControlHighlightCalcButtonToggledBrush" Color="{ThemeResource SystemColorHighlightColor}"/>
                     <SolidColorBrush x:Key="AppControlHighlightCalcButtonHoverBrush" Color="{ThemeResource SystemColorHighlightColor}"/>
-                    <SolidColorBrush x:Key="EquationBoxAddBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
-                    <SolidColorBrush x:Key="EquationBoxPointerOverBackgroundBrush" Color="{ThemeResource SystemColorHighlightColor}"/>
-                    <SolidColorBrush x:Key="EquationBoxHoverButtonForegroundBrush" Color="{ThemeResource SystemColorCaptionTextColor}"/>
-                    <SolidColorBrush x:Key="EquationBoxBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}"/>
                     <SolidColorBrush x:Key="AppControlTransparentButtonBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
-                    <SolidColorBrush x:Key="EquationButtonHideLineBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
-                    <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="Transparent"/>
-                    <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
-                    <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}"/>
-                    <SolidColorBrush x:Key="EquationButtonHideLineForegroundBrush" Color="{StaticResource SystemColorGrayTextColor}"/>
                     <!-- TODO: Figure out what colors we can use in high contrast -->
                     <SolidColorBrush x:Key="EquationBrush1" Color="{ThemeResource SystemColorGrayTextColor}"/>
                     <SolidColorBrush x:Key="EquationBrush2" Color="{ThemeResource SystemColorHighlightColor}"/>
@@ -1628,75 +1586,6 @@
                 </Setter>
             </Style>
 
-            <Style x:Name="EquationTextBoxButtonStyle" TargetType="Button">
-                <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="Foreground" Value="Transparent"/>
-                <Setter Property="FontSize" Value="16"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="Button">
-                            <Grid x:Name="ButtonLayoutGrid"
-                                  Background="Transparent"
-                                  BorderBrush="{ThemeResource TextControlButtonBorderBrush}"
-                                  BorderThickness="{TemplateBinding BorderThickness}">
-
-                                <VisualStateManager.VisualStateGroups>
-                                    <VisualStateGroup x:Name="CommonStates">
-                                        <VisualState x:Name="Normal"/>
-
-                                        <VisualState x:Name="PointerOver">
-                                            <Storyboard>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="Transparent"/>
-                                                </ObjectAnimationUsingKeyFrames>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPointerOver}"/>
-                                                </ObjectAnimationUsingKeyFrames>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="GlyphElement" Storyboard.TargetProperty="Foreground">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding Foreground, RelativeSource={RelativeSource TemplatedParent}}"/>
-                                                </ObjectAnimationUsingKeyFrames>
-                                            </Storyboard>
-                                        </VisualState>
-
-                                        <VisualState x:Name="Pressed">
-                                            <Storyboard>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding Background, RelativeSource={RelativeSource TemplatedParent}}"/>
-                                                </ObjectAnimationUsingKeyFrames>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ButtonLayoutGrid" Storyboard.TargetProperty="BorderBrush">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlButtonBorderBrushPressed}"/>
-                                                </ObjectAnimationUsingKeyFrames>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="GlyphElement" Storyboard.TargetProperty="Foreground">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SystemChromeWhiteColor}"/>
-                                                </ObjectAnimationUsingKeyFrames>
-                                            </Storyboard>
-                                        </VisualState>
-
-                                        <VisualState x:Name="Disabled">
-                                            <Storyboard>
-                                                <DoubleAnimation Duration="0"
-                                                                 Storyboard.TargetName="ButtonLayoutGrid"
-                                                                 Storyboard.TargetProperty="Opacity"
-                                                                 To="0"/>
-                                            </Storyboard>
-                                        </VisualState>
-                                    </VisualStateGroup>
-                                </VisualStateManager.VisualStateGroups>
-                                <TextBlock x:Name="GlyphElement"
-                                           HorizontalAlignment="Center"
-                                           VerticalAlignment="Center"
-                                           Foreground="{ThemeResource EquationBoxHoverButtonForegroundBrush}"
-                                           FontFamily="{TemplateBinding FontFamily}"
-                                           FontSize="{TemplateBinding FontSize}"
-                                           FontStyle="Normal"
-                                           AutomationProperties.AccessibilityView="Raw"
-                                           Text="{TemplateBinding Content}"/>
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
             <Style x:Key="MathRichEditBoxStyle" TargetType="Controls:MathRichEditBox">
                 <Setter Property="Foreground" Value="{ThemeResource TextControlForeground}"/>
                 <Setter Property="Background" Value="Transparent"/>
@@ -1724,19 +1613,15 @@
                                     <RowDefinition Height="*"/>
                                     <RowDefinition Height="Auto"/>
                                 </Grid.RowDefinitions>
-
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*"/>
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="Auto"/>
                                     <ColumnDefinition Width="Auto"/>
                                 </Grid.ColumnDefinitions>
-
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
-
                                         <VisualState x:Name="Disabled">
-
                                             <Storyboard>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="HeaderContentPresenter" Storyboard.TargetProperty="Foreground">
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlHeaderForegroundDisabled}"/>
@@ -1756,9 +1641,7 @@
                                             </Storyboard>
                                         </VisualState>
                                         <VisualState x:Name="Normal"/>
-
                                         <VisualState x:Name="PointerOver">
-
                                             <Storyboard>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="BorderElement" Storyboard.TargetProperty="BorderBrush">
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlBorderBrushPointerOver}"/>
@@ -1797,7 +1680,6 @@
 
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
-
                                 <ContentPresenter x:Name="HeaderContentPresenter"
                                                   Grid.Row="0"
                                                   Grid.Column="0"
@@ -1860,341 +1742,11 @@
                                                   Content="{TemplateBinding Description}"
                                                   x:Load="False"/>
                             </Grid>
-
                         </ControlTemplate>
                     </Setter.Value>
                 </Setter>
             </Style>
 
-            <Style x:Key="EquationTextBoxStyle" TargetType="Controls:EquationTextBox">
-                <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="BorderThickness" Value="0,1,1,1"/>
-                <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
-                <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
-                <Setter Property="FontWeight" Value="Normal"/>
-                <Setter Property="Foreground" Value="{ThemeResource TextBoxForegroundThemeBrush}"/>
-                <Setter Property="Padding" Value="{ThemeResource TextControlThemePadding}"/>
-                <Setter Property="IsTabStop" Value="False"/>
-                <Setter Property="Typography.StylisticSet20" Value="True"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="Controls:EquationTextBox">
-                            <Grid>
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto"/>
-                                    <ColumnDefinition Width="*"/>
-                                </Grid.ColumnDefinitions>
-
-                                <VisualStateManager.VisualStateGroups>
-                                    <VisualStateGroup x:Name="CommonStates">
-                                        <VisualState x:Name="Normal">
-                                            <VisualState.Setters>
-                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationBoxBorderBrush}"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="AddEquation">
-                                            <VisualState.Setters>
-                                                <Setter Target="MathRichEditBox.PlaceholderText" Value="Enter an equation"/>
-                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource EquationBoxAddBackgroundBrush}"/>
-                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationBoxBorderBrush}"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="Error">
-                                            <VisualState.Setters>
-                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationBoxErrorBorderBrush}"/>
-                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource EquationBoxErrorBackgroundBrush}"/>
-                                                <Setter Target="ErrorIcon.Visibility" Value="Visible"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="PointerOver">
-                                            <VisualState.Setters>
-                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor}"/>
-                                                <Setter Target="ColorChooserButton.Visibility" Value="Visible"/>
-                                                <Setter Target="FunctionButton.Visibility" Value="Visible"/>
-                                                <Setter Target="RemoveButton.Visibility" Value="Visible"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="PointerOverError">
-                                            <VisualState.Setters>
-                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationBoxErrorBorderBrush}"/>
-                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource EquationBoxErrorBackgroundBrush}"/>
-                                                <Setter Target="RemoveButton.Visibility" Value="Visible"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="Disabled">
-                                            <VisualState.Setters>
-                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource TextBoxDisabledBackgroundThemeBrush}"/>
-                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource TextBoxDisabledBorderThemeBrush}"/>
-                                                <Setter Target="EquationTextBox.Background" Value="{ThemeResource AppControlTransparentButtonBackgroundBrush}"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="Focused">
-                                            <VisualState.Setters>
-                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor}"/>
-                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource TextBoxBackgroundThemeBrush}"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="FocusedError">
-                                            <VisualState.Setters>
-                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationBoxErrorBorderBrush}"/>
-                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource TextBoxBackgroundThemeBrush}"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                    </VisualStateGroup>
-                                    <VisualStateGroup x:Name="ButtonStates">
-                                        <VisualState x:Name="ButtonVisible">
-                                            <VisualState.Setters>
-                                                <Setter Target="DeleteButton.Visibility" Value="Visible"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="ButtonHideRemove">
-                                            <VisualState.Setters>
-                                                <Setter Target="RemoveButtonPanel.Visibility" Value="Collapsed"/>
-                                                <Setter Target="RemoveFunctionMenuItem.IsEnabled" Value="False"/>
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                        <VisualState x:Name="ButtonCollapsed"/>
-                                    </VisualStateGroup>
-                                </VisualStateManager.VisualStateGroups>
-
-                                <ToggleButton x:Name="EquationButton"
-                                              MinWidth="44"
-                                              MinHeight="44"
-                                              VerticalAlignment="Stretch"
-                                              Background="{TemplateBinding EquationColor}"
-                                              Foreground="{StaticResource SystemChromeWhiteColor}"
-                                              BorderBrush="{TemplateBinding EquationColor}">
-                                    <StackPanel x:Name="FunctionNumberLabel"
-                                                HorizontalAlignment="Center"
-                                                VerticalAlignment="Center"
-                                                Orientation="Horizontal">
-                                        <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xF893;"/>
-                                        <TextBlock Margin="-5,19,0,0"
-                                                   FontSize="11"
-                                                   Text="{TemplateBinding EquationButtonContentIndex}"/>
-                                    </StackPanel>
-                                    <ToggleButton.Resources>
-                                        <SolidColorBrush x:Name="ButtonBackgroundBrush" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                        <SolidColorBrush x:Name="ButtonBorderBrush" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                    </ToggleButton.Resources>
-                                    <ToggleButton.Style>
-                                        <Style TargetType="ToggleButton">
-                                            <Setter Property="Template">
-                                                <Setter.Value>
-                                                    <ControlTemplate TargetType="ToggleButton">
-                                                        <Grid x:Name="RootGrid">
-                                                            <VisualStateManager.VisualStateGroups>
-                                                                <VisualStateGroup x:Name="CommonStates">
-                                                                    <VisualState x:Name="Normal">
-                                                                        <VisualState.Setters>
-                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource ButtonBackgroundBrush}"/>
-                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ButtonBorderBrush}"/>
-                                                                            <Setter Target="Overlay.Opacity" Value="0.0"/>
-                                                                        </VisualState.Setters>
-                                                                    </VisualState>
-                                                                    <VisualState x:Name="PointerOver">
-                                                                        <VisualState.Setters>
-                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource ButtonBackgroundBrush}"/>
-                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ButtonBorderBrush}"/>
-                                                                            <Setter Target="Overlay.Opacity" Value="{StaticResource EquationButtonOverlayPointerOverOpacity}"/>
-                                                                            <Setter Target="ContentPresenter.Visibility" Value="Collapsed"/>
-                                                                            <Setter Target="ShowHideIcon.Visibility" Value="Visible"/>
-                                                                            <Setter Target="ShowHideIcon.Glyph" Value="&#xF6AC;"/>
-                                                                        </VisualState.Setters>
-                                                                    </VisualState>
-                                                                    <VisualState x:Name="Pressed">
-                                                                        <VisualState.Setters>
-                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource ButtonBackgroundBrush}"/>
-                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ButtonBorderBrush}"/>
-                                                                            <Setter Target="Overlay.Opacity" Value="{StaticResource EquationButtonOverlayPressedOpacity}"/>
-                                                                            <Setter Target="ContentPresenter.Visibility" Value="Collapsed"/>
-                                                                            <Setter Target="ShowHideIcon.Visibility" Value="Visible"/>
-                                                                            <Setter Target="ShowHideIcon.Glyph" Value="&#xF6AC;"/>
-                                                                        </VisualState.Setters>
-                                                                    </VisualState>
-                                                                    <VisualState x:Name="Checked">
-                                                                        <VisualState.Setters>
-                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
-                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
-                                                                            <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource EquationButtonHideLineForegroundBrush}"/>
-                                                                        </VisualState.Setters>
-                                                                    </VisualState>
-                                                                    <VisualState x:Name="CheckedPointerOver">
-                                                                        <VisualState.Setters>
-                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
-                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
-                                                                            <Setter Target="ShowHideIcon.Foreground" Value="{ThemeResource EquationButtonHideLineForegroundBrush}"/>
-                                                                            <Setter Target="Overlay.Opacity" Value="{StaticResource EquationButtonOverlayPointerOverOpacity}"/>
-                                                                            <Setter Target="ContentPresenter.Visibility" Value="Collapsed"/>
-                                                                            <Setter Target="ShowHideIcon.Visibility" Value="Visible"/>
-                                                                            <Setter Target="ShowHideIcon.Glyph" Value="&#xE890;"/>
-                                                                        </VisualState.Setters>
-                                                                    </VisualState>
-                                                                    <VisualState x:Name="CheckedPressed">
-                                                                        <VisualState.Setters>
-                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
-                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
-                                                                            <Setter Target="ShowHideIcon.Foreground" Value="{ThemeResource EquationButtonHideLineForegroundBrush}"/>
-                                                                            <Setter Target="Overlay.Opacity" Value="{StaticResource EquationButtonOverlayPressedOpacity}"/>
-                                                                            <Setter Target="ContentPresenter.Visibility" Value="Collapsed"/>
-                                                                            <Setter Target="ShowHideIcon.Visibility" Value="Visible"/>
-                                                                            <Setter Target="ShowHideIcon.Glyph" Value="&#xE890;"/>
-                                                                        </VisualState.Setters>
-                                                                    </VisualState>
-                                                                </VisualStateGroup>
-                                                            </VisualStateManager.VisualStateGroups>
-                                                            <Rectangle x:Name="Overlay"
-                                                                       Fill="{ThemeResource EquationButtonOverlayBackgroundBrush}"
-                                                                       Opacity="0"
-                                                                       IsHitTestVisible="False"/>
-                                                            <ContentPresenter x:Name="ContentPresenter"
-                                                                              AutomationProperties.AccessibilityView="Raw"
-                                                                              IsHitTestVisible="False"/>
-                                                            <FontIcon x:Name="ShowHideIcon"
-                                                                      FontFamily="{StaticResource CalculatorFontFamily}"
-                                                                      Visibility="Collapsed"/>
-                                                        </Grid>
-                                                    </ControlTemplate>
-                                                </Setter.Value>
-                                            </Setter>
-                                        </Style>
-                                    </ToggleButton.Style>
-                                </ToggleButton>
-                                <Border x:Name="EquationBoxBorder"
-                                        Grid.Column="1"
-                                        Background="{ThemeResource TextControlBackground}"
-                                        BorderBrush="{TemplateBinding EquationColor}"
-                                        BorderThickness="{TemplateBinding BorderThickness}"
-                                        contract7Present:BackgroundSizing="OuterBorderEdge">
-                                    <Grid>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
-                                        <Controls:MathRichEditBox x:Name="MathRichEditBox"
-                                                                  MinHeight="44"
-                                                                  Padding="{TemplateBinding Padding}"
-                                                                  VerticalAlignment="Stretch"
-                                                                  Style="{StaticResource MathRichEditBoxStyle}"
-                                                                  BorderThickness="0"
-                                                                  FontFamily="{TemplateBinding FontFamily}"
-                                                                  FontSize="{TemplateBinding FontSize}"
-                                                                  FontWeight="{TemplateBinding FontWeight}"
-                                                                  AcceptsReturn="false"
-                                                                  InputScope="Text"
-                                                                  MathText="{Binding MathEquation, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
-                                                                  MaxLength="2048"
-                                                                  TextWrapping="NoWrap">
-                                            <Controls:MathRichEditBox.ContextFlyout>
-                                                <MenuFlyout x:Name="MathRichEditContextMenu">
-                                                    <MenuFlyoutItem x:Name="FunctionAnalysisMenuItem">
-                                                        <MenuFlyoutItem.Icon>
-                                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xE3B5;"/>
-                                                        </MenuFlyoutItem.Icon>
-                                                    </MenuFlyoutItem>
-                                                    <MenuFlyoutItem x:Name="ChangeFunctionStyleMenuItem">
-                                                        <MenuFlyoutItem.Icon>
-                                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xE790;"/>
-                                                        </MenuFlyoutItem.Icon>
-                                                    </MenuFlyoutItem>
-                                                    <MenuFlyoutItem x:Name="RemoveFunctionMenuItem">
-                                                        <MenuFlyoutItem.Icon>
-                                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xECC9;"/>
-                                                        </MenuFlyoutItem.Icon>
-                                                    </MenuFlyoutItem>
-                                                </MenuFlyout>
-                                            </Controls:MathRichEditBox.ContextFlyout>
-                                        </Controls:MathRichEditBox>
-                                        <!-- TODO: Use brush overrides here instead of a new style, use a new style for the EquationButton above once that has more functionality -->
-                                        <Button x:Name="DeleteButton"
-                                                Grid.Column="3"
-                                                MinWidth="34"
-                                                Margin="{ThemeResource HelperButtonThemePadding}"
-                                                VerticalAlignment="Stretch"
-                                                Style="{StaticResource EquationTextBoxButtonStyle}"
-                                                Background="{TemplateBinding EquationColor}"
-                                                Foreground="{TemplateBinding EquationColor}"
-                                                BorderThickness="0"
-                                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                                FontSize="12"
-                                                AutomationProperties.AccessibilityView="Raw"
-                                                Content="&#xE10A;"
-                                                IsTabStop="False"
-                                                Visibility="Collapsed"/>
-                                        <FontIcon x:Name="ErrorIcon"
-                                                  Grid.Column="3"
-                                                  MinWidth="28"
-                                                  VerticalAlignment="Stretch"
-                                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                                  FontSize="16"
-                                                  AutomationProperties.AccessibilityView="Raw"
-                                                  Glyph="&#xE783;"
-                                                  Visibility="Collapsed"/>
-                                        <Grid x:Name="RemoveButtonPanel" Grid.Column="3">
-                                            <Button x:Name="RemoveButton"
-                                                    x:Uid="removeButton"
-                                                    MinWidth="34"
-                                                    Margin="{ThemeResource HelperButtonThemePadding}"
-                                                    VerticalAlignment="Stretch"
-                                                    Style="{StaticResource EquationTextBoxButtonStyle}"
-                                                    Background="{TemplateBinding EquationColor}"
-                                                    Foreground="{TemplateBinding EquationColor}"
-                                                    BorderThickness="0"
-                                                    FontFamily="{StaticResource CalculatorFontFamily}"
-                                                    AutomationProperties.AccessibilityView="Raw"
-                                                    Content="&#xECC9;"
-                                                    IsTabStop="False"
-                                                    Visibility="Collapsed"/>
-                                        </Grid>
-                                        <ToggleButton x:Name="ColorChooserButton"
-                                                      x:Uid="colorChooserButton"
-                                                      Grid.Column="2"
-                                                      MinWidth="34"
-                                                      Margin="{ThemeResource HelperButtonThemePadding}"
-                                                      VerticalAlignment="Stretch"
-                                                      Background="{ThemeResource AppControlTransparentButtonBackgroundBrush}"
-                                                      BorderThickness="0"
-                                                      FontFamily="{StaticResource CalculatorFontFamily}"
-                                                      AutomationProperties.AccessibilityView="Raw"
-                                                      Content="&#xE790;"
-                                                      IsTabStop="False"
-                                                      Visibility="Collapsed">
-                                            <ToggleButton.Resources>
-                                                <SolidColorBrush x:Name="ToggleButtonBackgroundPointerOver" Color="{ThemeResource AppControlTransparentButtonBackgroundBrush}"/>
-                                                <SolidColorBrush x:Name="ToggleButtonBorderBrushPointerOver" Color="{ThemeResource AppControlTransparentButtonBackgroundBrush}"/>
-                                                <SolidColorBrush x:Name="ToggleButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
-                                                <SolidColorBrush x:Name="ToggleButtonForegroundChecked" Color="{ThemeResource SystemChromeWhiteColor}"/>
-                                                <SolidColorBrush x:Name="ToggleButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                <SolidColorBrush x:Name="ToggleButtonBackgroundChecked" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                <SolidColorBrush x:Name="ToggleButtonBackgroundCheckedPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                <SolidColorBrush x:Name="ToggleButtonBackgroundCheckedPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                <SolidColorBrush x:Name="ToggleButtonBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                            </ToggleButton.Resources>
-                                        </ToggleButton>
-                                        <Button x:Name="FunctionButton"
-                                                x:Uid="functionAnalysisButton"
-                                                Grid.Column="1"
-                                                MinWidth="34"
-                                                Margin="{ThemeResource HelperButtonThemePadding}"
-                                                VerticalAlignment="Stretch"
-                                                Style="{StaticResource EquationTextBoxButtonStyle}"
-                                                Background="{TemplateBinding EquationColor}"
-                                                Foreground="{TemplateBinding EquationColor}"
-                                                BorderThickness="{TemplateBinding BorderThickness}"
-                                                FontFamily="{StaticResource CalculatorFontFamily}"
-                                                AutomationProperties.AccessibilityView="Raw"
-                                                Content="&#xE3B5;"
-                                                IsTabStop="False"
-                                                Visibility="Collapsed"/>
-                                    </Grid>
-                                </Border>
-                            </Grid>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -196,7 +196,7 @@
                     <SolidColorBrush x:Key="EquationBrush1" Color="{ThemeResource SystemColorGrayTextColor}"/>
                     <SolidColorBrush x:Key="EquationBrush2" Color="{ThemeResource SystemColorHighlightColor}"/>
                     <SolidColorBrush x:Key="EquationBrush3" Color="{ThemeResource SystemColorHotlightColor}"/>
-                    <SolidColorBrush x:Key="EquationBrush4" Color="{ThemeResource SystemColorWindowColor}"/>
+                    <SolidColorBrush x:Key="EquationBrush4" Color="{ThemeResource SystemColorWindowTextColor}"/>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
 
@@ -1658,7 +1658,6 @@
                                             </Storyboard>
                                         </VisualState>
                                         <VisualState x:Name="Focused">
-
                                             <Storyboard>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PlaceholderTextContentPresenter" Storyboard.TargetProperty="Foreground">
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlPlaceholderForegroundFocused}"/>
@@ -1672,12 +1671,8 @@
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="Foreground">
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextControlForegroundFocused}"/>
                                                 </ObjectAnimationUsingKeyFrames>
-                                                <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentElement" Storyboard.TargetProperty="RequestedTheme">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="Light"/>
-                                                </ObjectAnimationUsingKeyFrames>
                                             </Storyboard>
                                         </VisualState>
-
                                     </VisualStateGroup>
                                 </VisualStateManager.VisualStateGroups>
                                 <ContentPresenter x:Name="HeaderContentPresenter"

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -66,6 +66,7 @@
                                   FallbackColor="{ThemeResource SystemChromeMediumColor}"
                                   TintColor="{ThemeResource SystemChromeLowColor}"
                                   TintOpacity="0.7"/>
+                    <ApplicationTheme x:Key="CalcApplicationTheme">Dark</ApplicationTheme>
                     <SolidColorBrush x:Key="AppChromeAcrylicOperatorFlyoutBackgroundBrush" Color="#FF2F2F2F"/>
                     <SolidColorBrush x:Key="AppControlTransparentButtonBackgroundBrush" Color="Transparent"/>
                     <SolidColorBrush x:Key="EquationBrush1" Color="#FF0078D7"/>
@@ -146,6 +147,7 @@
                                   FallbackColor="{ThemeResource SystemChromeMediumColor}"
                                   TintColor="{ThemeResource SystemChromeLowColor}"
                                   TintOpacity="0.8"/>
+                    <ApplicationTheme x:Key="CalcApplicationTheme">Light</ApplicationTheme>
                     <SolidColorBrush x:Key="AppControlTransparentButtonBackgroundBrush" Color="Transparent"/>
                     <SolidColorBrush x:Key="EquationBrush1" Color="#FF0078D7"/>
                     <SolidColorBrush x:Key="EquationBrush2" Color="#FFFFB900"/>
@@ -192,7 +194,7 @@
                     <SolidColorBrush x:Key="AppControlHighlightCalcButtonToggledBrush" Color="{ThemeResource SystemColorHighlightColor}"/>
                     <SolidColorBrush x:Key="AppControlHighlightCalcButtonHoverBrush" Color="{ThemeResource SystemColorHighlightColor}"/>
                     <SolidColorBrush x:Key="AppControlTransparentButtonBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
-                    <!-- TODO: Figure out what colors we can use in high contrast -->
+                    <ApplicationTheme x:Key="CalcApplicationTheme">Dark</ApplicationTheme>
                     <SolidColorBrush x:Key="EquationBrush1" Color="{ThemeResource SystemColorGrayTextColor}"/>
                     <SolidColorBrush x:Key="EquationBrush2" Color="{ThemeResource SystemColorHighlightColor}"/>
                     <SolidColorBrush x:Key="EquationBrush3" Color="{ThemeResource SystemColorHotlightColor}"/>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -1109,9 +1109,9 @@
     <value>Delete</value>
     <comment>Text string for the Calculator Delete swipe button in the History list</comment>
   </data>
-  <data name="CopyHistoryMenuItem.Text" xml:space="preserve"> 
-     <value>Copy</value> 
-     <comment>Text string for the Calculator Copy option in the History list context menu</comment> 
+  <data name="CopyHistoryMenuItem.Text" xml:space="preserve">
+    <value>Copy</value>
+    <comment>Text string for the Calculator Copy option in the History list context menu</comment>
   </data>
   <data name="DeleteHistoryMenuItem.Text" xml:space="preserve">
     <value>Delete</value>
@@ -3517,7 +3517,7 @@
   </data>
   <data name="CalculationFailed" xml:space="preserve">
     <value>Calculation failed</value>
-    <comment>Text displayed when the application is not able to do a calculation</comment>  
+    <comment>Text displayed when the application is not able to do a calculation</comment>
   </data>
   <data name="logBaseX.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Log base X</value>
@@ -4118,7 +4118,7 @@
     <value>Back</value>
     <comment>This is the tooltip for the back button in the equation analysis page in the graphing calculator</comment>
   </data>
-    <data name="equationAnalysisBack.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+  <data name="equationAnalysisBack.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Back</value>
     <comment>This is the automation name for the back button in the equation analysis page in the graphing calculator</comment>
   </data>
@@ -4213,5 +4213,9 @@
   <data name="equationMathRichEditBox.PlaceholderText" xml:space="preserve">
     <value>Enter an equation</value>
     <comment>Used in the Graphing Calculator to indicate to users that they can enter an equation in the textbox</comment>
+  </data>
+  <data name="mathRichEditBox.PlaceholderText" xml:space="preserve">
+    <value>Enter an equation</value>
+    <comment>this is the placeholder text used by the textbox to enter an equation</comment>
   </data>
 </root>

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -1,6 +1,7 @@
 <UserControl x:Class="CalculatorApp.EquationInputArea"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
              xmlns:controls="using:CalculatorApp.Controls"
              xmlns:converters="using:CalculatorApp.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -8,7 +9,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:mux="using:Microsoft.UI.Xaml.Controls"
              xmlns:vm="using:CalculatorApp.ViewModel"
-             xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
              d:DesignHeight="300"
              d:DesignWidth="400"
              mc:Ignorable="d">
@@ -603,11 +603,22 @@
                                                 <ResourceDictionary>
                                                     <ResourceDictionary.ThemeDictionaries>
                                                         <ResourceDictionary x:Key="Default">
+                                                            <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
                                                             <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                             <SolidColorBrush x:Key="ButtonRevealBackgroundPointerOver" Color="Transparent"/>
                                                             <SolidColorBrush x:Key="ButtonRevealBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                             <SolidColorBrush x:Key="ButtonRevealBackground" Color="Transparent"/>
                                                             <SolidColorBrush x:Key="ButtonRevealBackgroundDisabled" Color="Transparent"/>
+                                                            <RevealBorderBrush x:Key="ButtonRevealBorderBrush"
+                                                                               Opacity="0.33"
+                                                                               FallbackColor="Transparent"
+                                                                               TargetTheme="{ThemeResource CalcApplicationTheme}"
+                                                                               Color="Transparent"/>
+                                                            <RevealBorderBrush x:Key="ButtonRevealBorderBrushPointerOver"
+                                                                               Opacity="0.33"
+                                                                               FallbackColor="{StaticResource SystemBaseMediumLowColor}"
+                                                                               TargetTheme="{ThemeResource CalcApplicationTheme}"
+                                                                               Color="{StaticResource SystemRevealBaseMediumLowColor}"/>
                                                         </ResourceDictionary>
                                                         <ResourceDictionary x:Key="HighContrast"/>
                                                     </ResourceDictionary.ThemeDictionaries>
@@ -639,6 +650,16 @@
                                                             <SolidColorBrush x:Name="ToggleButtonRevealBackgroundCheckedPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                             <SolidColorBrush x:Name="ToggleButtonRevealBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                             <SolidColorBrush x:Name="ToggleButtonRevealBackgroundPointerOver" Color="{ThemeResource AppControlTransparentButtonBackgroundBrush}"/>
+                                                            <RevealBorderBrush x:Key="ToggleButtonRevealBorderBrush"
+                                                                               Opacity="0.33"
+                                                                               FallbackColor="Transparent"
+                                                                               TargetTheme="{ThemeResource CalcApplicationTheme}"
+                                                                               Color="Transparent"/>
+                                                            <RevealBorderBrush x:Key="ToggleButtonRevealBorderBrushPointerOver"
+                                                                               Opacity="0.33"
+                                                                               FallbackColor="{StaticResource SystemBaseMediumLowColor}"
+                                                                               TargetTheme="{ThemeResource CalcApplicationTheme}"
+                                                                               Color="{StaticResource SystemRevealBaseMediumLowColor}"/>
                                                         </ResourceDictionary>
                                                         <ResourceDictionary x:Key="HighContrast"/>
                                                     </ResourceDictionary.ThemeDictionaries>
@@ -661,10 +682,21 @@
                                                     <ResourceDictionary>
                                                         <ResourceDictionary.ThemeDictionaries>
                                                             <ResourceDictionary x:Key="Default">
+                                                                <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
                                                                 <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                                 <SolidColorBrush x:Key="ButtonRevealBackgroundPointerOver" Color="Transparent"/>
                                                                 <SolidColorBrush x:Key="ButtonRevealBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                                 <SolidColorBrush x:Key="ButtonRevealBackground" Color="Transparent"/>
+                                                                <RevealBorderBrush x:Key="ButtonRevealBorderBrush"
+                                                                                   Opacity="0.33"
+                                                                                   FallbackColor="Transparent"
+                                                                                   TargetTheme="{ThemeResource CalcApplicationTheme}"
+                                                                                   Color="Transparent"/>
+                                                                <RevealBorderBrush x:Key="ButtonRevealBorderBrushPointerOver"
+                                                                                   Opacity="0.33"
+                                                                                   FallbackColor="{StaticResource SystemBaseMediumLowColor}"
+                                                                                   TargetTheme="{ThemeResource CalcApplicationTheme}"
+                                                                                   Color="{StaticResource SystemRevealBaseMediumLowColor}"/>
                                                             </ResourceDictionary>
                                                             <ResourceDictionary x:Key="HighContrast"/>
                                                         </ResourceDictionary.ThemeDictionaries>
@@ -689,10 +721,21 @@
                                                 <ResourceDictionary>
                                                     <ResourceDictionary.ThemeDictionaries>
                                                         <ResourceDictionary x:Key="Default">
+                                                            <SolidColorBrush x:Key="ButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
                                                             <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                             <SolidColorBrush x:Key="ButtonRevealBackgroundPointerOver" Color="Transparent"/>
                                                             <SolidColorBrush x:Key="ButtonRevealBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                             <SolidColorBrush x:Key="ButtonRevealBackground" Color="Transparent"/>
+                                                            <RevealBorderBrush x:Key="ButtonRevealBorderBrush"
+                                                                               Opacity="0.33"
+                                                                               FallbackColor="Transparent"
+                                                                               TargetTheme="{ThemeResource CalcApplicationTheme}"
+                                                                               Color="Transparent"/>
+                                                            <RevealBorderBrush x:Key="ButtonRevealBorderBrushPointerOver"
+                                                                               Opacity="0.33"
+                                                                               FallbackColor="{StaticResource SystemBaseMediumLowColor}"
+                                                                               TargetTheme="{ThemeResource CalcApplicationTheme}"
+                                                                               Color="{StaticResource SystemRevealBaseMediumLowColor}"/>
                                                         </ResourceDictionary>
                                                         <ResourceDictionary x:Key="HighContrast"/>
                                                     </ResourceDictionary.ThemeDictionaries>

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -8,6 +8,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:mux="using:Microsoft.UI.Xaml.Controls"
              xmlns:vm="using:CalculatorApp.ViewModel"
+             xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
              d:DesignHeight="300"
              d:DesignWidth="400"
              mc:Ignorable="d">
@@ -218,6 +219,503 @@
                 </Grid>
             </DataTemplate>
 
+            <Style x:Key="EquationTextBoxStyle" TargetType="controls:EquationTextBox">
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
+                <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
+                <Setter Property="FontWeight" Value="Normal"/>
+                <Setter Property="Foreground" Value="{ThemeResource TextBoxForegroundThemeBrush}"/>
+                <Setter Property="Padding" Value="{ThemeResource TextControlThemePadding}"/>
+                <Setter Property="IsTabStop" Value="False"/>
+                <Setter Property="Typography.StylisticSet20" Value="True"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="controls:EquationTextBox">
+                            <Grid>
+                                <Grid.Resources>
+                                    <ResourceDictionary>
+                                        <ResourceDictionary.ThemeDictionaries>
+                                            <ResourceDictionary x:Key="Default">
+                                                <Visibility x:Key="ColorRectangleVisibility">Collapsed</Visibility>
+                                                <SolidColorBrush x:Key="EquationTextBoxBorderBrush" Color="Transparent"/>
+                                                <SolidColorBrush x:Key="EquationTextBoxBorderBrushPointerOver" Color="{Binding EquationColor.Color, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                                <SolidColorBrush x:Key="EquationTextBoxBorderBrushFocused" Color="{Binding EquationColor.Color, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                                <SolidColorBrush x:Key="EquationTextBoxBorderBrushDisabled" Color="{Binding EquationColor.Color, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                                <SolidColorBrush x:Key="EquationBoxAddBackgroundBrush" Color="#9d000000"/>
+                                                <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="#33EB5757"/>
+                                                <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="#FFEB5757"/>
+                                                <Thickness x:Key="EquationTextBoxBorderThickness">0,1,1,1</Thickness>
+                                            </ResourceDictionary>
+                                            <ResourceDictionary x:Key="Light">
+                                                <Visibility x:Key="ColorRectangleVisibility">Collapsed</Visibility>
+                                                <SolidColorBrush x:Key="EquationTextBoxBorderBrush" Color="Transparent"/>
+                                                <SolidColorBrush x:Key="EquationTextBoxBorderBrushPointerOver" Color="{Binding EquationColor.Color, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                                <SolidColorBrush x:Key="EquationTextBoxBorderBrushFocused" Color="{Binding EquationColor.Color, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                                <SolidColorBrush x:Key="EquationTextBoxBorderBrushDisabled" Color="{Binding EquationColor.Color, RelativeSource={RelativeSource TemplatedParent}}"/>
+                                                <SolidColorBrush x:Key="EquationBoxAddBackgroundBrush" Color="#D0FFFFFF"/>
+                                                <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="#33EB5757"/>
+                                                <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="#FFEB5757"/>
+                                                <Thickness x:Key="EquationTextBoxBorderThickness">0,1,1,1</Thickness>
+                                            </ResourceDictionary>
+                                            <ResourceDictionary x:Key="HighContrast">
+                                                <Visibility x:Key="ColorRectangleVisibility">Visible</Visibility>
+                                                <StaticResource x:Key="EquationTextBoxBorderBrush" ResourceKey="TextControlBorderBrush"/>
+                                                <StaticResource x:Key="EquationTextBoxBorderBrushPointerOver" ResourceKey="TextControlBorderBrushPointerOver"/>
+                                                <StaticResource x:Key="EquationTextBoxBorderBrushFocused" ResourceKey="TextControlBorderBrushFocused"/>
+                                                <StaticResource x:Key="EquationTextBoxBorderBrushDisabled" ResourceKey="TextControlBorderBrushDisabled"/>
+                                                <SolidColorBrush x:Key="EquationBoxAddBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                                <SolidColorBrush x:Key="EquationBoxErrorBackgroundBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
+                                                <SolidColorBrush x:Key="EquationBoxErrorBorderBrush" Color="{ThemeResource SystemColorButtonTextColor}"/>
+                                                <Thickness x:Key="EquationTextBoxBorderThickness">1</Thickness>
+                                            </ResourceDictionary>
+                                        </ResourceDictionary.ThemeDictionaries>
+                                    </ResourceDictionary>
+                                </Grid.Resources>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition MinHeight="44"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal">
+                                            <VisualState.Setters>
+                                                <Setter Target="MathRichEditBox.PlaceholderText" Value=""/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="AddEquation">
+                                            <VisualState.Setters>
+                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource EquationBoxAddBackgroundBrush}"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Error">
+                                            <VisualState.Setters>
+                                                <Setter Target="MathRichEditBox.PlaceholderText" Value=""/>
+                                                <Setter Target="EquationBoxBorder.BorderThickness" Value="1"/>
+                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationBoxErrorBorderBrush}"/>
+                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource EquationBoxErrorBackgroundBrush}"/>
+                                                <Setter Target="ErrorIcon.Visibility" Value="Visible"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="PointerOver">
+                                            <VisualState.Setters>
+                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationTextBoxBorderBrushPointerOver}"/>
+                                                <Setter Target="ColorChooserButton.Visibility" Value="Visible"/>
+                                                <Setter Target="FunctionButton.Visibility" Value="Visible"/>
+                                                <Setter Target="RemoveButton.Visibility" Value="Visible"/>
+                                                <Setter Target="ErrorIcon.Visibility" Value="Collapsed"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="PointerOverError">
+                                            <VisualState.Setters>
+                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationBoxErrorBorderBrush}"/>
+                                                <Setter Target="EquationBoxBorder.BorderThickness" Value="1"/>
+                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource EquationBoxErrorBackgroundBrush}"/>
+                                                <Setter Target="ColorChooserButton.Visibility" Value="Collapsed"/>
+                                                <Setter Target="FunctionButton.Visibility" Value="Collapsed"/>
+                                                <Setter Target="RemoveButton.Visibility" Value="Visible"/>
+                                                <Setter Target="ErrorIcon.Visibility" Value="Collapsed"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Disabled">
+                                            <VisualState.Setters>
+                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource TextBoxDisabledBackgroundThemeBrush}"/>
+                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationTextBoxBorderBrushPointerOver}"/>
+                                                <Setter Target="EquationTextBox.Background" Value="{ThemeResource AppControlTransparentButtonBackgroundBrush}"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="Focused">
+                                            <VisualState.Setters>
+                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationTextBoxBorderBrushFocused}"/>
+                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource TextBoxBackgroundThemeBrush}"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="FocusedError">
+                                            <VisualState.Setters>
+                                                <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationBoxErrorBorderBrush}"/>
+                                                <Setter Target="EquationBoxBorder.BorderThickness" Value="1"/>
+                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource TextBoxBackgroundThemeBrush}"/>
+                                                <Setter Target="ErrorIcon.Visibility" Value="Collapsed"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                    <VisualStateGroup x:Name="ButtonStates">
+                                        <VisualState x:Name="ButtonVisible">
+                                            <VisualState.Setters>
+                                                <Setter Target="DeleteButton.Visibility" Value="Visible"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="ButtonHideRemove">
+                                            <VisualState.Setters>
+                                                <Setter Target="RemoveButtonPanel.Visibility" Value="Collapsed"/>
+                                                <Setter Target="RemoveFunctionMenuItem.IsEnabled" Value="False"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                        <VisualState x:Name="ButtonCollapsed"/>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+
+                                <Rectangle Grid.Column="0"
+                                           Width="10"
+                                           Margin="0,0,2,0"
+                                           Fill="{TemplateBinding EquationColor}"
+                                           Visibility="{ThemeResource ColorRectangleVisibility}"/>
+                                <ToggleButton x:Name="EquationButton"
+                                              Grid.Column="1"
+                                              MinWidth="44"
+                                              MinHeight="44"
+                                              VerticalAlignment="Stretch">
+                                    <ToggleButton.Content>
+                                        <StackPanel x:Name="FunctionNumberLabel"
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"
+                                                    Background="Transparent"
+                                                    Orientation="Horizontal">
+                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xF893;"/>
+                                            <TextBlock Margin="-5,19,0,0"
+                                                       FontSize="11"
+                                                       Text="{TemplateBinding EquationButtonContentIndex}"/>
+                                        </StackPanel>
+                                    </ToggleButton.Content>
+                                    <ToggleButton.Resources>
+                                        <ResourceDictionary>
+                                            <ResourceDictionary.ThemeDictionaries>
+                                                <ResourceDictionary x:Key="Default">
+                                                    <x:Double x:Key="EquationButtonOverlayPointerOverOpacity">0.3</x:Double>
+                                                    <x:Double x:Key="EquationButtonOverlayPressedOpacity">0.5</x:Double>
+                                                    <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="White"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBackground" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBorderBrush" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForeground" Color="White"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBackgroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPointerOver" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBorderBrushPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBorderBrushPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="EquationButtonHideLineForegroundBrush"
+                                                                     Opacity="0.6"
+                                                                     Color="{StaticResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="EquationButtonHideLineBackgroundBrush"
+                                                                     Opacity="0.4"
+                                                                     Color="#FFFFFF"/>
+                                                    <StaticResource x:Key="ToggleButtonBackgroundChecked" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBorderBrushChecked" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonForegroundChecked" ResourceKey="EquationButtonHideLineForegroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBackgroundCheckedPointerOver" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBorderBrushCheckedPointerOver" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonForegroundCheckedPointerOver" ResourceKey="EquationButtonHideLineForegroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBackgroundCheckedPressed" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBorderBrushCheckedPressed" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonForegroundCheckedPressed" ResourceKey="EquationButtonHideLineForegroundBrush"/>
+                                                </ResourceDictionary>
+                                                <ResourceDictionary x:Key="Light">
+                                                    <x:Double x:Key="EquationButtonOverlayPointerOverOpacity">0.2</x:Double>
+                                                    <x:Double x:Key="EquationButtonOverlayPressedOpacity">0.4</x:Double>
+                                                    <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="Black"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBackground" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBorderBrush" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForeground" Color="White"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBackgroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPointerOver" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBorderBrushPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonBorderBrushPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                    <SolidColorBrush x:Key="EquationButtonHideLineForegroundBrush" Color="{StaticResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="EquationButtonHideLineBackgroundBrush"
+                                                                     Opacity="0.4"
+                                                                     Color="#000000"/>
+                                                    <StaticResource x:Key="ToggleButtonBackgroundChecked" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBorderBrushChecked" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonForegroundChecked" ResourceKey="EquationButtonHideLineForegroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBackgroundCheckedPointerOver" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBorderBrushCheckedPointerOver" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonForegroundCheckedPointerOver" ResourceKey="EquationButtonHideLineForegroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBackgroundCheckedPressed" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonBorderBrushCheckedPressed" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
+                                                    <StaticResource x:Key="ToggleButtonForegroundCheckedPressed" ResourceKey="EquationButtonHideLineForegroundBrush"/>
+                                                </ResourceDictionary>
+                                                <ResourceDictionary x:Key="HighContrast">
+                                                    <x:Double x:Key="EquationButtonOverlayPointerOverOpacity">0</x:Double>
+                                                    <x:Double x:Key="EquationButtonOverlayPressedOpacity">0</x:Double>
+                                                    <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="Transparent"/>
+                                                </ResourceDictionary>
+                                            </ResourceDictionary.ThemeDictionaries>
+                                        </ResourceDictionary>
+                                    </ToggleButton.Resources>
+                                    <ToggleButton.Style>
+                                        <Style TargetType="ToggleButton">
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="ToggleButton">
+                                                        <Grid x:Name="RootGrid"
+                                                              Background="Transparent"
+                                                              BorderBrush="Transparent"
+                                                              BorderThickness="1">
+                                                            <VisualStateManager.VisualStateGroups>
+                                                                <VisualStateGroup x:Name="CommonStates">
+                                                                    <VisualState x:Name="Normal">
+                                                                        <VisualState.Setters>
+                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource ToggleButtonBackground}"/>
+                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ToggleButtonBorderBrush}"/>
+                                                                            <Setter Target="Overlay.Opacity" Value="0.0"/>
+                                                                            <Setter Target="ContentPresenter.Visibility" Value="Visible"/>
+                                                                            <Setter Target="ShowHideIcon.Visibility" Value="Collapsed"/>
+                                                                        </VisualState.Setters>
+                                                                    </VisualState>
+                                                                    <VisualState x:Name="PointerOver">
+                                                                        <VisualState.Setters>
+                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource ToggleButtonBackgroundPointerOver}"/>
+                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ToggleButtonBorderBrushPointerOver}"/>
+                                                                            <Setter Target="ShowHideIcon.Foreground" Value="{ThemeResource ToggleButtonForegroundPointerOver}"/>
+                                                                            <Setter Target="Overlay.Opacity" Value="{StaticResource EquationButtonOverlayPointerOverOpacity}"/>
+                                                                            <Setter Target="ContentPresenter.Visibility" Value="Collapsed"/>
+                                                                            <Setter Target="ShowHideIcon.Visibility" Value="Visible"/>
+                                                                            <Setter Target="ShowHideIcon.Glyph" Value="&#xF6AC;"/>
+                                                                        </VisualState.Setters>
+                                                                    </VisualState>
+                                                                    <VisualState x:Name="Pressed">
+                                                                        <VisualState.Setters>
+                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource ToggleButtonBackgroundPressed}"/>
+                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ToggleButtonBorderBrush}"/>
+                                                                            <Setter Target="Overlay.Opacity" Value="{StaticResource EquationButtonOverlayPressedOpacity}"/>
+                                                                            <Setter Target="ShowHideIcon.Foreground" Value="{ThemeResource ToggleButtonForegroundPressed}"/>
+                                                                            <Setter Target="ContentPresenter.Visibility" Value="Collapsed"/>
+                                                                            <Setter Target="ShowHideIcon.Visibility" Value="Visible"/>
+                                                                            <Setter Target="ShowHideIcon.Glyph" Value="&#xF6AC;"/>
+                                                                        </VisualState.Setters>
+                                                                    </VisualState>
+                                                                    <VisualState x:Name="Checked">
+                                                                        <VisualState.Setters>
+                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource ToggleButtonBackgroundChecked}"/>
+                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ToggleButtonBorderBrushChecked}"/>
+                                                                            <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource ToggleButtonForegroundChecked}"/>
+                                                                        </VisualState.Setters>
+                                                                    </VisualState>
+                                                                    <VisualState x:Name="CheckedPointerOver">
+                                                                        <VisualState.Setters>
+                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource ToggleButtonBackgroundCheckedPointerOver}"/>
+                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ToggleButtonBorderBrushCheckedPointerOver}"/>
+                                                                            <Setter Target="ShowHideIcon.Foreground" Value="{ThemeResource ToggleButtonForegroundCheckedPointerOver}"/>
+                                                                            <Setter Target="Overlay.Opacity" Value="{StaticResource EquationButtonOverlayPointerOverOpacity}"/>
+                                                                            <Setter Target="ContentPresenter.Visibility" Value="Collapsed"/>
+                                                                            <Setter Target="ShowHideIcon.Visibility" Value="Visible"/>
+                                                                            <Setter Target="ShowHideIcon.Glyph" Value="&#xE890;"/>
+                                                                        </VisualState.Setters>
+                                                                    </VisualState>
+                                                                    <VisualState x:Name="CheckedPressed">
+                                                                        <VisualState.Setters>
+                                                                            <Setter Target="RootGrid.Background" Value="{ThemeResource ToggleButtonBackgroundCheckedPressed}"/>
+                                                                            <Setter Target="RootGrid.BorderBrush" Value="{ThemeResource ToggleButtonBorderBrushCheckedPressed}"/>
+                                                                            <Setter Target="ShowHideIcon.Foreground" Value="{ThemeResource ToggleButtonForegroundCheckedPressed}"/>
+                                                                            <Setter Target="Overlay.Opacity" Value="{StaticResource EquationButtonOverlayPressedOpacity}"/>
+                                                                            <Setter Target="ContentPresenter.Visibility" Value="Collapsed"/>
+                                                                            <Setter Target="ShowHideIcon.Visibility" Value="Visible"/>
+                                                                            <Setter Target="ShowHideIcon.Glyph" Value="&#xE890;"/>
+                                                                        </VisualState.Setters>
+                                                                    </VisualState>
+                                                                </VisualStateGroup>
+                                                            </VisualStateManager.VisualStateGroups>
+                                                            <Rectangle x:Name="Overlay"
+                                                                       Fill="{ThemeResource EquationButtonOverlayBackgroundBrush}"
+                                                                       Opacity="0"
+                                                                       IsHitTestVisible="False"/>
+                                                            <ContentPresenter x:Name="ContentPresenter"
+                                                                              AutomationProperties.AccessibilityView="Raw"
+                                                                              IsHitTestVisible="False"/>
+                                                            <FontIcon x:Name="ShowHideIcon"
+                                                                      FontFamily="{StaticResource CalculatorFontFamily}"
+                                                                      Visibility="Collapsed"/>
+                                                        </Grid>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                    </ToggleButton.Style>
+                                </ToggleButton>
+                                <Border x:Name="EquationBoxBorder"
+                                        Grid.Column="2"
+                                        Background="{ThemeResource TextControlBackground}"
+                                        BorderBrush="{ThemeResource EquationTextBoxBorderBrush}"
+                                        BorderThickness="{ThemeResource EquationTextBoxBorderThickness}"
+                                        contract7Present:BackgroundSizing="OuterBorderEdge">
+                                    <Grid contract7Present:Margin="{TemplateBinding BorderThickness}">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <controls:MathRichEditBox x:Name="MathRichEditBox"
+                                                                  x:Uid="mathRichEditBox"
+                                                                  MinHeight="44"
+                                                                  Padding="{TemplateBinding Padding}"
+                                                                  VerticalAlignment="Stretch"
+                                                                  Style="{StaticResource MathRichEditBoxStyle}"
+                                                                  BorderThickness="0"
+                                                                  FontFamily="{TemplateBinding FontFamily}"
+                                                                  FontSize="{TemplateBinding FontSize}"
+                                                                  FontWeight="{TemplateBinding FontWeight}"
+                                                                  AcceptsReturn="false"
+                                                                  InputScope="Text"
+                                                                  MathText="{Binding MathEquation, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
+                                                                  MaxLength="2048"
+                                                                  TextWrapping="NoWrap">
+                                            <controls:MathRichEditBox.ContextFlyout>
+                                                <MenuFlyout x:Name="MathRichEditContextMenu">
+                                                    <MenuFlyoutItem x:Name="FunctionAnalysisMenuItem">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xE3B5;"/>
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                    <MenuFlyoutItem x:Name="ChangeFunctionStyleMenuItem">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xE790;"/>
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                    <MenuFlyoutItem x:Name="RemoveFunctionMenuItem">
+                                                        <MenuFlyoutItem.Icon>
+                                                            <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xECC9;"/>
+                                                        </MenuFlyoutItem.Icon>
+                                                    </MenuFlyoutItem>
+                                                </MenuFlyout>
+                                            </controls:MathRichEditBox.ContextFlyout>
+                                        </controls:MathRichEditBox>
+
+                                        <Button x:Name="FunctionButton"
+                                                x:Uid="functionAnalysisButton"
+                                                Grid.Column="1"
+                                                MinWidth="34"
+                                                Margin="1,2"
+                                                VerticalAlignment="Stretch"
+                                                Style="{ThemeResource ButtonRevealStyle}"
+                                                FontFamily="{StaticResource CalculatorFontFamily}"
+                                                AutomationProperties.AccessibilityView="Raw"
+                                                Content="&#xE3B5;"
+                                                IsTabStop="False"
+                                                Visibility="Collapsed">
+                                            <Button.Resources>
+                                                <ResourceDictionary>
+                                                    <ResourceDictionary.ThemeDictionaries>
+                                                        <ResourceDictionary x:Key="Default">
+                                                            <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                            <SolidColorBrush x:Key="ButtonRevealBackgroundPointerOver" Color="Transparent"/>
+                                                            <SolidColorBrush x:Key="ButtonRevealBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                            <SolidColorBrush x:Key="ButtonRevealBackground" Color="Transparent"/>
+                                                            <SolidColorBrush x:Key="ButtonRevealBackgroundDisabled" Color="Transparent"/>
+                                                        </ResourceDictionary>
+                                                        <ResourceDictionary x:Key="HighContrast"/>
+                                                    </ResourceDictionary.ThemeDictionaries>
+                                                </ResourceDictionary>
+                                            </Button.Resources>
+                                        </Button>
+                                        <ToggleButton x:Name="ColorChooserButton"
+                                                      x:Uid="colorChooserButton"
+                                                      Grid.Column="2"
+                                                      MinWidth="34"
+                                                      Margin="1,2"
+                                                      VerticalAlignment="Stretch"
+                                                      Style="{ThemeResource ToggleButtonRevealStyle}"
+                                                      FontFamily="{StaticResource CalculatorFontFamily}"
+                                                      AutomationProperties.AccessibilityView="Raw"
+                                                      Content="&#xE790;"
+                                                      IsTabStop="False"
+                                                      Visibility="Collapsed">
+                                            <ToggleButton.Resources>
+                                                <ResourceDictionary>
+                                                    <ResourceDictionary.ThemeDictionaries>
+                                                        <ResourceDictionary x:Key="Default">
+                                                            <SolidColorBrush x:Name="ToggleButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                            <SolidColorBrush x:Name="ToggleButtonForegroundChecked" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                            <SolidColorBrush x:Name="ToggleButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                            <SolidColorBrush x:Name="ToggleButtonRevealBorderBrushPointerOver" Color="{ThemeResource AppControlTransparentButtonBackgroundBrush}"/>
+                                                            <SolidColorBrush x:Name="ToggleButtonRevealBackground" Color="Transparent"/>
+                                                            <SolidColorBrush x:Name="ToggleButtonRevealBackgroundChecked" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                            <SolidColorBrush x:Name="ToggleButtonRevealBackgroundCheckedPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                            <SolidColorBrush x:Name="ToggleButtonRevealBackgroundCheckedPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                            <SolidColorBrush x:Name="ToggleButtonRevealBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                            <SolidColorBrush x:Name="ToggleButtonRevealBackgroundPointerOver" Color="{ThemeResource AppControlTransparentButtonBackgroundBrush}"/>
+                                                        </ResourceDictionary>
+                                                        <ResourceDictionary x:Key="HighContrast"/>
+                                                    </ResourceDictionary.ThemeDictionaries>
+                                                </ResourceDictionary>
+                                            </ToggleButton.Resources>
+                                        </ToggleButton>
+                                        <Grid x:Name="RemoveButtonPanel" Grid.Column="3">
+                                            <Button x:Name="RemoveButton"
+                                                    x:Uid="removeButton"
+                                                    MinWidth="34"
+                                                    Margin="1,2"
+                                                    VerticalAlignment="Stretch"
+                                                    Style="{StaticResource ButtonRevealStyle}"
+                                                    FontFamily="{StaticResource CalculatorFontFamily}"
+                                                    AutomationProperties.AccessibilityView="Raw"
+                                                    Content="&#xECC9;"
+                                                    IsTabStop="False"
+                                                    Visibility="Collapsed">
+                                                <Button.Resources>
+                                                    <ResourceDictionary>
+                                                        <ResourceDictionary.ThemeDictionaries>
+                                                            <ResourceDictionary x:Key="Default">
+                                                                <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                                <SolidColorBrush x:Key="ButtonRevealBackgroundPointerOver" Color="Transparent"/>
+                                                                <SolidColorBrush x:Key="ButtonRevealBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                                <SolidColorBrush x:Key="ButtonRevealBackground" Color="Transparent"/>
+                                                            </ResourceDictionary>
+                                                            <ResourceDictionary x:Key="HighContrast"/>
+                                                        </ResourceDictionary.ThemeDictionaries>
+                                                    </ResourceDictionary>
+                                                </Button.Resources>
+                                            </Button>
+                                        </Grid>
+                                        <Button x:Name="DeleteButton"
+                                                Grid.Column="3"
+                                                MinWidth="34"
+                                                Margin="1,2"
+                                                VerticalAlignment="Stretch"
+                                                Style="{StaticResource ButtonRevealStyle}"
+                                                Foreground="{ThemeResource TextControlForegroundFocused}"
+                                                FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                FontSize="12"
+                                                AutomationProperties.AccessibilityView="Raw"
+                                                Content="&#xE10A;"
+                                                IsTabStop="False"
+                                                Visibility="Collapsed">
+                                            <Button.Resources>
+                                                <ResourceDictionary>
+                                                    <ResourceDictionary.ThemeDictionaries>
+                                                        <ResourceDictionary x:Key="Default">
+                                                            <SolidColorBrush x:Key="ButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                            <SolidColorBrush x:Key="ButtonRevealBackgroundPointerOver" Color="Transparent"/>
+                                                            <SolidColorBrush x:Key="ButtonRevealBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
+                                                            <SolidColorBrush x:Key="ButtonRevealBackground" Color="Transparent"/>
+                                                        </ResourceDictionary>
+                                                        <ResourceDictionary x:Key="HighContrast"/>
+                                                    </ResourceDictionary.ThemeDictionaries>
+                                                </ResourceDictionary>
+                                            </Button.Resources>
+                                        </Button>
+                                        <FontIcon x:Name="ErrorIcon"
+                                                  Grid.Column="3"
+                                                  MinWidth="28"
+                                                  VerticalAlignment="Stretch"
+                                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                  FontSize="16"
+                                                  AutomationProperties.AccessibilityView="Raw"
+                                                  Glyph="&#xE783;"
+                                                  Visibility="Collapsed"/>
+                                    </Grid>
+                                </Border>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
         </ResourceDictionary>
     </UserControl.Resources>
     <mux:ItemsRepeaterScrollHost>

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -633,7 +633,6 @@
                                                             <SolidColorBrush x:Name="ToggleButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
                                                             <SolidColorBrush x:Name="ToggleButtonForegroundChecked" Color="{ThemeResource SystemChromeWhiteColor}"/>
                                                             <SolidColorBrush x:Name="ToggleButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                            <SolidColorBrush x:Name="ToggleButtonRevealBorderBrushPointerOver" Color="{ThemeResource AppControlTransparentButtonBackgroundBrush}"/>
                                                             <SolidColorBrush x:Name="ToggleButtonRevealBackground" Color="Transparent"/>
                                                             <SolidColorBrush x:Name="ToggleButtonRevealBackgroundChecked" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                             <SolidColorBrush x:Name="ToggleButtonRevealBackgroundCheckedPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -11,10 +11,8 @@
              x:Name="Control"
              DataContextChanged="GraphingCalculator_DataContextChanged"
              mc:Ignorable="d">
-
     <UserControl.Resources>
         <ResourceDictionary>
-
             <Style x:Key="GraphToggleButtonStyle" TargetType="ToggleButton">
                 <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
                 <Setter Property="Background" Value="Transparent"/>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -353,32 +353,37 @@
                             <CornerRadius x:Key="BottomButtonCornerRadius">0,0,4,4</CornerRadius>
                             <CornerRadius x:Key="LeftButtonCornerRadius">4,0,0,4</CornerRadius>
                             <CornerRadius x:Key="RightButtonCornerRadius">0,4,4,0</CornerRadius>
-                            <Color x:Key="GrapherAxesColor">Black</Color>
-                            <Color x:Key="GrapherBackground">White</Color>
+                            <Style x:Key="ThemedGrapherStyle" TargetType="graphControl:Grapher">
+                                <Setter Property="AxesColor" Value="Black"/>
+                                <Setter Property="GraphBackground" Value="White"/>
+                            </Style>
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="Dark">
                             <CornerRadius x:Key="TopButtonCornerRadius">4,4,0,0</CornerRadius>
                             <CornerRadius x:Key="BottomButtonCornerRadius">0,0,4,4</CornerRadius>
                             <CornerRadius x:Key="LeftButtonCornerRadius">4,0,0,4</CornerRadius>
                             <CornerRadius x:Key="RightButtonCornerRadius">0,4,4,0</CornerRadius>
-                            <Color x:Key="GrapherAxesColor">White</Color>
-                            <Color x:Key="GrapherBackground">Black</Color>
+                            <Style x:Key="ThemedGrapherStyle" TargetType="graphControl:Grapher">
+                                <Setter Property="AxesColor" Value="White"/>
+                                <Setter Property="GraphBackground" Value="Black"/>
+                            </Style>
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="HighContrast">
                             <CornerRadius x:Key="TopButtonCornerRadius">0</CornerRadius>
                             <CornerRadius x:Key="BottomButtonCornerRadius">0</CornerRadius>
                             <CornerRadius x:Key="LeftButtonCornerRadius">0</CornerRadius>
                             <CornerRadius x:Key="RightButtonCornerRadius">0</CornerRadius>
-                            <StaticResource x:Key="GrapherAxesColor" ResourceKey="SystemColorWindowTextColor"/>
-                            <StaticResource x:Key="GrapherBackground" ResourceKey="SystemColorWindowColor"/>
+                            <Style x:Key="ThemedGrapherStyle" TargetType="graphControl:Grapher">
+                                <Setter Property="AxesColor" Value="{ThemeResource SystemColorWindowTextColor}"/>
+                                <Setter Property="GraphBackground" Value="{ThemeResource SystemColorWindowColor}"/>
+                            </Style>
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>
             </Grid.Resources>
             <graphControl:Grapher Name="GraphingControl"
-                                  AxesColor="{ThemeResource GrapherAxesColor}"
+                                  Style="{ThemeResource ThemedGrapherStyle}"
                                   ForceProportionalAxes="True"
-                                  GraphBackground="{ThemeResource GrapherBackground}"
                                   LosingFocus="GraphingControl_LosingFocus"
                                   LostFocus="GraphingControl_LostFocus"
                                   RequestedTheme="Light"

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -217,7 +217,9 @@
                            BasedOn="{StaticResource SwitchModeToggleButtonStyle}"
                            TargetType="ToggleButton"/>
                     <Style x:Key="GraphControlCommandPanel" TargetType="Border">
-                        <Setter Property="Background" Value="#80000000"/>
+                        <Setter Property="Background" Value="{StaticResource SystemControlAcrylicElementBrush}"/>
+                        <Setter Property="BorderBrush" Value="Transparent"/>
+                        <Setter Property="BorderThickness" Value="0"/>
                         <Setter Property="CornerRadius" Value="4"/>
                     </Style>
                     <Style x:Key="ThemedGraphRepeatButtonStyle"
@@ -351,39 +353,42 @@
                             <CornerRadius x:Key="BottomButtonCornerRadius">0,0,4,4</CornerRadius>
                             <CornerRadius x:Key="LeftButtonCornerRadius">4,0,0,4</CornerRadius>
                             <CornerRadius x:Key="RightButtonCornerRadius">0,4,4,0</CornerRadius>
+                            <Color x:Key="GrapherAxesColor">Black</Color>
+                            <Color x:Key="GrapherBackground">White</Color>
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="Dark">
                             <CornerRadius x:Key="TopButtonCornerRadius">4,4,0,0</CornerRadius>
                             <CornerRadius x:Key="BottomButtonCornerRadius">0,0,4,4</CornerRadius>
                             <CornerRadius x:Key="LeftButtonCornerRadius">4,0,0,4</CornerRadius>
                             <CornerRadius x:Key="RightButtonCornerRadius">0,4,4,0</CornerRadius>
+                            <Color x:Key="GrapherAxesColor">White</Color>
+                            <Color x:Key="GrapherBackground">Black</Color>
                         </ResourceDictionary>
                         <ResourceDictionary x:Key="HighContrast">
                             <CornerRadius x:Key="TopButtonCornerRadius">0</CornerRadius>
                             <CornerRadius x:Key="BottomButtonCornerRadius">0</CornerRadius>
                             <CornerRadius x:Key="LeftButtonCornerRadius">0</CornerRadius>
                             <CornerRadius x:Key="RightButtonCornerRadius">0</CornerRadius>
+                            <StaticResource x:Key="GrapherAxesColor" ResourceKey="SystemColorWindowTextColor"/>
+                            <StaticResource x:Key="GrapherBackground" ResourceKey="SystemColorWindowColor"/>
                         </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>
             </Grid.Resources>
             <graphControl:Grapher Name="GraphingControl"
+                                  AxesColor="{ThemeResource GrapherAxesColor}"
                                   ForceProportionalAxes="True"
+                                  GraphBackground="{ThemeResource GrapherBackground}"
                                   LosingFocus="GraphingControl_LosingFocus"
                                   LostFocus="GraphingControl_LostFocus"
+                                  RequestedTheme="Light"
                                   UseSystemFocusVisuals="True"
-                                  VariablesUpdated="GraphingControl_VariablesUpdated">
-                <graphControl:Grapher.Background>
-                    <SolidColorBrush Color="White"/>
-                </graphControl:Grapher.Background>
-            </graphControl:Grapher>
-
+                                  VariablesUpdated="GraphingControl_VariablesUpdated"/>
             <Border MinHeight="36"
                     Margin="0,12,12,0"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Top"
-                    Style="{ThemeResource GraphControlCommandPanel}"
-                    RequestedTheme="Light">
+                    Style="{ThemeResource GraphControlCommandPanel}">
                 <StackPanel Orientation="Horizontal">
                     <ToggleButton x:Name="ActiveTracing"
                                   MinWidth="40"
@@ -418,8 +423,7 @@
                     Margin="0,0,12,12"
                     HorizontalAlignment="Right"
                     VerticalAlignment="Bottom"
-                    Style="{ThemeResource GraphControlCommandPanel}"
-                    RequestedTheme="Light">
+                    Style="{ThemeResource GraphControlCommandPanel}">
                 <StackPanel Orientation="Vertical">
 
                     <RepeatButton x:Uid="zoomInButton"

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -21,7 +21,9 @@ public
 public
     delegate void TracingValueChangedEventHandler(Windows::Foundation::Point value);
 
-    [Windows::UI::Xaml::Markup::ContentPropertyAttribute(Name = L"Equations")] public ref class Grapher sealed : public Windows::UI::Xaml::Controls::Control, public Windows::UI::Xaml::Data::INotifyPropertyChanged
+    [Windows::UI::Xaml::Markup::ContentPropertyAttribute(Name = L"Equations")] public ref class Grapher sealed
+        : public Windows::UI::Xaml::Controls::Control,
+          public Windows::UI::Xaml::Data::INotifyPropertyChanged
     {
     public:
         event TracingValueChangedEventHandler ^ TracingValueChangedEvent;
@@ -38,8 +40,10 @@ public
             Variables,
             SINGLE_ARG(ref new Platform::Collections::Map<Platform::String ^, double>()));
         DEPENDENCY_PROPERTY_R_WITH_DEFAULT_AND_CALLBACK(GraphControl::EquationCollection ^, Equations, nullptr);
-        // Pass active tracing turned on or off down to the renderer
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(Windows::UI::Color, AxesColor, Windows::UI::Colors::Transparent);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(Windows::UI::Color, GraphBackground, Windows::UI::Colors::Transparent);
 
+        // Pass active tracing turned on or off down to the renderer
         property bool ActiveTracing
         {
             bool get()
@@ -115,13 +119,10 @@ public
 #pragma endregion
 
     private:
-        void OnLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ args);
-        void OnUnloaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ args);
-
         void OnForceProportionalAxesPropertyChanged(bool oldValue, bool newValue);
         void OnEquationsPropertyChanged(EquationCollection ^ oldValue, EquationCollection ^ newValue);
-        void OnDependencyPropertyChanged(Windows::UI::Xaml::DependencyObject ^ obj, Windows::UI::Xaml::DependencyProperty ^ p);
-
+        void OnAxesColorPropertyChanged(Windows::UI::Color oldValue, Windows::UI::Color newValue);
+        void OnGraphBackgroundPropertyChanged(Windows::UI::Color oldValue, Windows::UI::Color newValue);
         void OnEquationChanged(Equation ^ equation);
         void OnEquationStyleChanged(Equation ^ equation);
         void OnEquationLineEnabledChanged(Equation ^ equation);
@@ -132,8 +133,6 @@ public
         void SetGraphArgs();
         std::shared_ptr<Graphing::IGraph> GetGraph(GraphControl::Equation ^ equation);
         void UpdateVariables();
-
-        void OnBackgroundColorChanged(const Windows::UI::Color& color);
 
         void ScaleRange(double centerX, double centerY, double scale);
 


### PR DESCRIPTION

### Description of the changes:
- Add high contrast support to GraphControl
- Add high contrast support to EquationInputTextArea

Also:
- Rewrite button styles used in EquationInputTextArea to only modify their brushes instead of fully modify their templates (easier to maintain + less verbose)
- Make EquationInputTextArea buttons more fluent.
- localize the string "Enter an equation"
- slighly modify the error state of EquationInputTextArea (display all 4 borders instead of only 3)
- move all resources only used by Graphing Calculator from App.xaml to GraphingCalculator.xaml

Note: we want to keep the graph white background, black lines with dark theme for the moment.

### How changes were validated:
- Manually

