### PR TITLE
Using wstring instead of wstringstream where appropriate

### DIFF
--- a/src/CalcManager/CEngine/CalcInput.cpp
+++ b/src/CalcManager/CEngine/CalcInput.cpp
@@ -269,34 +269,47 @@ bool CalcInput::IsEmpty()
 wstring CalcInput::ToString(uint32_t radix)
 {
     // In theory both the base and exponent could be C_NUM_MAX_DIGITS long.
-    wstringstream resStream;
-
     if ((m_base.value.size() > MAX_STRLEN) || (m_hasExponent && m_exponent.value.size() > MAX_STRLEN))
     {
         return wstring();
     }
 
+    wstring result;
+
     if (m_base.IsNegative())
     {
-        resStream << L'-';
+        result += L'-';
     }
 
-    resStream << (m_base.IsEmpty() ? L"0" : m_base.value);
+    if (m_base.IsEmpty())
+    {
+        result += L'0';
+    }
+    else
+    {
+        result += m_base.value;
+    }
 
     if (m_hasExponent)
     {
         // Add a decimal point if it is not already there
         if (!m_hasDecimal)
         {
-            resStream << m_decSymbol;
+            result += m_decSymbol;
         }
 
-        resStream << ((radix == 10) ? L'e' : L'^');
-        resStream << (m_exponent.IsNegative() ? L'-' : L'+');
-        resStream << (m_exponent.IsEmpty() ? L"0" : m_exponent.value);
-    }
+        result += ((radix == 10) ? L'e' : L'^');
+        result += (m_exponent.IsNegative() ? L'-' : L'+');
 
-    auto result = resStream.str();
+        if (m_exponent.IsEmpty())
+        {
+            result += L'0';
+        }
+        else
+        {
+            result += m_exponent.value;
+        }
+    }
 
     // Base and Exp can each be up to C_NUM_MAX_DIGITS in length, plus 4 characters for sign, dec, exp, and expSign.
     if (result.size() > C_NUM_MAX_DIGITS * 2 + 4)

--- a/src/CalcManager/CEngine/CalcInput.cpp
+++ b/src/CalcManager/CEngine/CalcInput.cpp
@@ -278,7 +278,7 @@ wstring CalcInput::ToString(uint32_t radix)
 
     if (m_base.IsNegative())
     {
-        result += L'-';
+        result = L'-';
     }
 
     if (m_base.IsEmpty())

--- a/src/CalcManager/CEngine/scidisp.cpp
+++ b/src/CalcManager/CEngine/scidisp.cpp
@@ -312,7 +312,7 @@ wstring CCalcEngine::GroupDigits(wstring_view delimiter, vector<uint32_t> const&
         ritr = displayString.rbegin();
     }
 
-    wstringstream groupedStream{};
+    wstring result;
     uint32_t groupingSize = 0;
 
     auto groupItr = grouping.begin();
@@ -323,7 +323,7 @@ wstring CCalcEngine::GroupDigits(wstring_view delimiter, vector<uint32_t> const&
     auto reverse_end = displayString.rend() - (isNumNegative ? 1 : 0);
     while (ritr != reverse_end)
     {
-        groupedStream << *ritr++;
+        result += *ritr++;
         groupingSize++;
 
         // If a group is complete, add a separator
@@ -332,7 +332,7 @@ wstring CCalcEngine::GroupDigits(wstring_view delimiter, vector<uint32_t> const&
         // - we are at the end of the digit string
         if (currGrouping != 0 && (groupingSize % currGrouping) == 0 && ritr != reverse_end)
         {
-            groupedStream << wstring{ delimiter };
+            result += delimiter;
             groupingSize = 0; // reset for a new group
 
             // Shift the grouping to next values if they exist
@@ -364,11 +364,10 @@ wstring CCalcEngine::GroupDigits(wstring_view delimiter, vector<uint32_t> const&
     // now copy the negative sign if it is there
     if (isNumNegative)
     {
-        groupedStream << displayString[0];
+        result += displayString[0];
     }
 
-    auto groupedString = groupedStream.str();
-    wstring result(groupedString.rbegin(), groupedString.rend());
+    std::reverse(result.begin(), result.end());
     // Add the right (fractional or exponential) part of the number to the final string.
     if (hasDecimal)
     {

--- a/src/CalcManager/CEngine/scidisp.cpp
+++ b/src/CalcManager/CEngine/scidisp.cpp
@@ -367,7 +367,7 @@ wstring CCalcEngine::GroupDigits(wstring_view delimiter, vector<uint32_t> const&
         result += displayString[0];
     }
 
-    std::reverse(result.begin(), result.end());
+    reverse(result.begin(), result.end());
     // Add the right (fractional or exponential) part of the number to the final string.
     if (hasDecimal)
     {

--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -1204,78 +1204,73 @@ wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_
     }
 
     // Begin building the result string
-    wstringstream resultStream{};
+    wstring result{};
 
     // Make sure negative zeros aren't allowed.
     if ((pnum->sign == -1) && (length > 0))
     {
-        resultStream << L'-';
+        result += L'-';
     }
 
     if (exponent <= 0 && !useSciForm)
     {
-        resultStream << L'0';
-        resultStream << g_decimalSeparator;
+        result += L'0';
+        result += g_decimalSeparator;
         // Used up a digit unaccounted for.
     }
 
     while (exponent < 0)
     {
-        resultStream << L'0';
+        result += L'0';
         exponent++;
     }
 
     while (length > 0)
     {
         exponent--;
-        resultStream << DIGITS[*pmant--];
+        result += DIGITS[*pmant--];
         length--;
 
         // Be more regular in using a decimal point.
         if (exponent == 0)
         {
-            resultStream << g_decimalSeparator;
+            result += g_decimalSeparator;
         }
     }
 
     while (exponent > 0)
     {
-        resultStream << L'0';
+        result += L'0';
         exponent--;
         // Be more regular in using a decimal point.
         if (exponent == 0)
         {
-            resultStream << g_decimalSeparator;
+            result += g_decimalSeparator;
         }
     }
 
     if (useSciForm)
     {
-        resultStream << (radix == 10 ? L'e' : L'^');
-        resultStream << (eout < 0 ? L'-' : L'+');
+        result += (radix == 10 ? L'e' : L'^');
+        result += (eout < 0 ? L'-' : L'+');
         eout = abs(eout);
-        wstringstream exponentStream{};
+        wstring expString{};
         do
         {
-            exponentStream << DIGITS[eout % radix];
+            expString += DIGITS[eout % radix];
             eout /= radix;
         } while (eout > 0);
 
-        auto expString = exponentStream.str();
-        for (auto ritr = expString.rbegin(); ritr != expString.rend(); ritr++)
-        {
-            resultStream << *ritr;
-        }
+        result.insert(result.end(), expString.crbegin(), expString.crend());
     }
 
     // Remove trailing decimal
-    auto resultString = resultStream.str();
-    if (!resultString.empty() && resultString.back() == g_decimalSeparator)
+    if (!result.empty() && result.back() == g_decimalSeparator)
     {
-        resultString.pop_back();
+        result.pop_back();
     }
 
-    return resultString;
+    return result;
 }
 
 //-----------------------------------------------------------------------------

--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -1204,12 +1204,12 @@ wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_
     }
 
     // Begin building the result string
-    wstring result{};
+    wstring result;
 
     // Make sure negative zeros aren't allowed.
     if ((pnum->sign == -1) && (length > 0))
     {
-        result += L'-';
+        result = L'-';
     }
 
     if (exponent <= 0 && !useSciForm)

--- a/src/CalcViewModel/Common/LocalizationService.cpp
+++ b/src/CalcViewModel/Common/LocalizationService.cpp
@@ -599,16 +599,15 @@ String ^ LocalizationService::GetNarratorReadableToken(String ^ rawToken)
 
 String ^ LocalizationService::GetNarratorReadableString(String ^ rawString)
 {
-    wstringstream readableString{};
-    readableString << L"";
+    wstring readableString{};
 
     wstring asWstring = rawString->Data();
     for (const auto& c : asWstring)
     {
-        readableString << LocalizationService::GetNarratorReadableToken(L"" + c)->Data();
+        readableString += LocalizationService::GetNarratorReadableToken(ref new String(&c, 1))->Data();
     }
 
-    return ref new String(readableString.str().c_str());
+    return ref new String(readableString.c_str());
 }
 
 void LocalizationService::Sort(std::vector<Platform::String ^>& source)

--- a/src/CalcViewModel/HistoryItemViewModel.cpp
+++ b/src/CalcViewModel/HistoryItemViewModel.cpp
@@ -31,13 +31,12 @@ String
         _In_ String ^ fallbackExpression)
 {
     // updating accessibility names for expression and result
-    wstringstream accExpression{};
-    accExpression << L"";
+    wstring accExpression{};
 
     for (const auto& tokenItem : *spTokens)
     {
-        accExpression << LocalizationService::GetNarratorReadableToken(StringReference(tokenItem.first.c_str()))->Data();
+        accExpression += LocalizationService::GetNarratorReadableToken(StringReference(tokenItem.first.c_str()))->Data();
     }
 
-    return ref new String(accExpression.str().c_str());
+    return ref new String(accExpression.c_str());
 }

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -177,21 +177,20 @@ String ^ StandardCalculatorViewModel::CalculateNarratorDisplayValue(_In_ wstring
 
 String ^ StandardCalculatorViewModel::GetNarratorStringReadRawNumbers(_In_ String ^ localizedDisplayValue)
 {
-    wstringstream wss;
-    auto& locSettings = LocalizationSettings::GetInstance();
+    wstring ws;
+    const auto& locSettings = LocalizationSettings::GetInstance();
 
     // Insert a space after each digit in the string, to force Narrator to read them as separate numbers.
-    wstring wstrValue(localizedDisplayValue->Data());
-    for (wchar_t& c : wstrValue)
+    for (const wchar_t& c : localizedDisplayValue)
     {
-        wss << c;
+        ws += c;
         if (locSettings.IsLocalizedHexDigit(c))
         {
-            wss << L' ';
+            ws += L' ';
         }
     }
 
-    return ref new String(wss.str().c_str());
+    return ref new String(ws.c_str());
 }
 
 void StandardCalculatorViewModel::SetPrimaryDisplay(_In_ String ^ displayStringValue, _In_ bool isError)


### PR DESCRIPTION
## Fixes #880.

### Description of the changes:
- Replaced most wstringstream usage with wstring.
- In a couple of places, used if...else instead of ternary operator since the later requires the true and false parts to be of the same type.  This resulted in extra wstring instances to be created which isn't necessary.
- In one pace, used Platform:String's constructor taking a character and a count.  This seems more clear and (should be more efficient) than the prior code of `L"" + c`.  That code seems confusing to a C++ developer since it is normally something a compiler would warn about.  I'm assuming it's a special C++/CX feature.

### How changes were validated:
- Ran existing unit tests.
- Manual testing.

