### PR TITLE
Graphing Calculator - Add Shortcuts to zoom in/out 

### DIFF
--- a/src/CalcViewModel/Common/KeyboardShortcutManager.cpp
+++ b/src/CalcViewModel/Common/KeyboardShortcutManager.cpp
@@ -44,10 +44,15 @@ static multimap<int, multimap<MyVirtualKey, WeakReference>> s_VirtualKeyControlS
 static multimap<int, multimap<MyVirtualKey, WeakReference>> s_VirtualKeyInverseChordsForButtons;
 static multimap<int, multimap<MyVirtualKey, WeakReference>> s_VirtualKeyControlInverseChordsForButtons;
 
-static multimap<int, bool> s_ShiftKeyPressed;
-static multimap<int, bool> s_ControlKeyPressed;
-static multimap<int, bool> s_ShiftButtonChecked;
-static multimap<int, bool> s_IsDropDownOpen;
+static map<int, bool> s_ShiftKeyPressed;
+static map<int, bool> s_ControlKeyPressed;
+static map<int, bool> s_ShiftButtonChecked;
+static map<int, bool> s_IsDropDownOpen;
+
+static map<int, bool> s_ignoreNextEscape;
+static map<int, bool> s_keepIgnoringEscape;
+static map<int, bool> s_fHonorShortcuts;
+static map<int, Flyout ^> s_AboutFlyout;
 
 static reader_writer_lock s_keyboardShortcutMapLock;
 
@@ -158,12 +163,6 @@ namespace CalculatorApp
     }
 }
 
-static multimap<int, bool> s_ignoreNextEscape;
-static multimap<int, bool> s_keepIgnoringEscape;
-static multimap<int, bool> s_fHonorShortcuts;
-static multimap<int, bool> s_fHandledEnter;
-static multimap<int, Flyout ^> s_AboutFlyout;
-
 void KeyboardShortcutManager::IgnoreEscape(bool onlyOnce)
 {
     // Writer lock for the static maps
@@ -173,14 +172,12 @@ void KeyboardShortcutManager::IgnoreEscape(bool onlyOnce)
 
     if (s_ignoreNextEscape.find(viewId) != s_ignoreNextEscape.end())
     {
-        s_ignoreNextEscape.erase(viewId);
-        s_ignoreNextEscape.insert(std::make_pair(viewId, true));
+        s_ignoreNextEscape[viewId] = true;
     }
 
     if (s_keepIgnoringEscape.find(viewId) != s_keepIgnoringEscape.end())
     {
-        s_keepIgnoringEscape.erase(viewId);
-        s_keepIgnoringEscape.insert(std::make_pair(viewId, !onlyOnce));
+        s_keepIgnoringEscape[viewId] = !onlyOnce;
     }
 }
 
@@ -193,14 +190,12 @@ void KeyboardShortcutManager::HonorEscape()
 
     if (s_ignoreNextEscape.find(viewId) != s_ignoreNextEscape.end())
     {
-        s_ignoreNextEscape.erase(viewId);
-        s_ignoreNextEscape.insert(std::make_pair(viewId, false));
+        s_ignoreNextEscape[viewId] = false;
     }
 
     if (s_keepIgnoringEscape.find(viewId) != s_keepIgnoringEscape.end())
     {
-        s_keepIgnoringEscape.erase(viewId);
-        s_keepIgnoringEscape.insert(std::make_pair(viewId, false));
+        s_keepIgnoringEscape[viewId] = false;
     }
 }
 
@@ -474,8 +469,8 @@ const std::multimap<MyVirtualKey, WeakReference>& GetCurrentKeyDictionary(MyVirt
         }
         else
         {
-            auto iterViewMap = s_VirtualKeyControlInverseChordsForButtons.find(viewId);
-            if (iterViewMap != s_VirtualKeyControlInverseChordsForButtons.end())
+            auto iterViewMap = s_VirtualKeyInverseChordsForButtons.find(viewId);
+            if (iterViewMap != s_VirtualKeyInverseChordsForButtons.end())
             {
                 for (auto iterator = iterViewMap->second.begin(); iterator != iterViewMap->second.end(); ++iterator)
                 {
@@ -558,8 +553,7 @@ void KeyboardShortcutManager::OnKeyDownHandler(CoreWindow ^ sender, KeyEventArgs
 
             if (currControlKeyPressed != s_ControlKeyPressed.end())
             {
-                s_ControlKeyPressed.erase(viewId);
-                s_ControlKeyPressed.insert(std::make_pair(viewId, true));
+                s_ControlKeyPressed[viewId] = true;
             }
             return;
         }
@@ -572,26 +566,24 @@ void KeyboardShortcutManager::OnKeyDownHandler(CoreWindow ^ sender, KeyEventArgs
 
             if (currShiftKeyPressed != s_ShiftKeyPressed.end())
             {
-                s_ShiftKeyPressed.erase(viewId);
-                s_ShiftKeyPressed.insert(std::make_pair(viewId, true));
+                s_ShiftKeyPressed[viewId] = true;
             }
             return;
         }
-
-        const auto& lookupMap = GetCurrentKeyDictionary(static_cast<MyVirtualKey>(key));
-        auto buttons = lookupMap.equal_range(static_cast<MyVirtualKey>(key));
-
-        auto currentIsDropDownOpen = s_IsDropDownOpen.find(viewId);
 
         if (currentHonorShortcuts != s_fHonorShortcuts.end())
         {
             if (currentHonorShortcuts->second)
             {
+                const auto myVirtualKey = static_cast<MyVirtualKey>(key);
+                const auto& lookupMap = GetCurrentKeyDictionary(myVirtualKey);
+                auto buttons = lookupMap.equal_range(myVirtualKey);
                 RunFirstEnabledButtonCommand(buttons);
 
                 // Ctrl+C and Ctrl+V shifts focus to some button because of which enter doesn't work after copy/paste. So don't shift focus if Ctrl+C or Ctrl+V
                 // is pressed. When drop down is open, pressing escape shifts focus to clear button. So dont's shift focus if drop down is open. Ctrl+Insert is
                 // equivalent to Ctrl+C and Shift+Insert is equivalent to Ctrl+V
+                auto currentIsDropDownOpen = s_IsDropDownOpen.find(viewId);
                 if (currentIsDropDownOpen != s_IsDropDownOpen.end() && !currentIsDropDownOpen->second)
                 {
                     // Do not Light Up Buttons when Ctrl+C, Ctrl+V, Ctrl+Insert or Shift+Insert is pressed
@@ -620,8 +612,7 @@ void KeyboardShortcutManager::OnKeyUpHandler(CoreWindow ^ sender, KeyEventArgs ^
 
         if (currentShiftKeyPressed != s_ShiftKeyPressed.end())
         {
-            s_ShiftKeyPressed.erase(viewId);
-            s_ShiftKeyPressed.insert(std::make_pair(viewId, false));
+            s_ShiftKeyPressed[viewId] = false;
         }
     }
     else if (key == VirtualKey::Control)
@@ -633,8 +624,7 @@ void KeyboardShortcutManager::OnKeyUpHandler(CoreWindow ^ sender, KeyEventArgs ^
 
         if (currControlKeyPressed != s_ControlKeyPressed.end())
         {
-            s_ControlKeyPressed.erase(viewId);
-            s_ControlKeyPressed.insert(std::make_pair(viewId, false));
+            s_ControlKeyPressed[viewId] = false;
         }
     }
 }
@@ -712,8 +702,7 @@ void KeyboardShortcutManager::ShiftButtonChecked(bool checked)
 
     if (s_ShiftButtonChecked.find(viewId) != s_ShiftButtonChecked.end())
     {
-        s_ShiftButtonChecked.erase(viewId);
-        s_ShiftButtonChecked.insert(std::make_pair(viewId, checked));
+        s_ShiftButtonChecked[viewId] = checked;
     }
 }
 
@@ -723,8 +712,7 @@ void KeyboardShortcutManager::UpdateDropDownState(bool isOpen)
 
     if (s_IsDropDownOpen.find(viewId) != s_IsDropDownOpen.end())
     {
-        s_IsDropDownOpen.erase(viewId);
-        s_IsDropDownOpen.insert(std::make_pair(viewId, isOpen));
+        s_IsDropDownOpen[viewId] = isOpen;
     }
 }
 
@@ -734,8 +722,7 @@ void KeyboardShortcutManager::UpdateDropDownState(Flyout ^ aboutPageFlyout)
 
     if (s_AboutFlyout.find(viewId) != s_AboutFlyout.end())
     {
-        s_AboutFlyout.erase(viewId);
-        s_AboutFlyout.insert(std::make_pair(viewId, aboutPageFlyout));
+        s_AboutFlyout[viewId] = aboutPageFlyout;
     }
 }
 
@@ -748,19 +735,7 @@ void KeyboardShortcutManager::HonorShortcuts(bool allow)
 
     if (s_fHonorShortcuts.find(viewId) != s_fHonorShortcuts.end())
     {
-        s_fHonorShortcuts.erase(viewId);
-        s_fHonorShortcuts.insert(std::make_pair(viewId, allow));
-    }
-}
-
-void KeyboardShortcutManager::HandledEnter(bool ishandled)
-{
-    int viewId = Utils::GetWindowId();
-
-    if (s_fHandledEnter.find(viewId) != s_fHandledEnter.end())
-    {
-        s_fHandledEnter.erase(viewId);
-        s_fHandledEnter.insert(std::make_pair(viewId, ishandled));
+        s_fHonorShortcuts[viewId] = allow;
     }
 }
 
@@ -812,15 +787,14 @@ void KeyboardShortcutManager::RegisterNewAppViewId()
         s_VirtualKeyControlInverseChordsForButtons.insert(std::make_pair(appViewId, std::multimap<MyVirtualKey, WeakReference>()));
     }
 
-    s_ShiftKeyPressed.insert(std::make_pair(appViewId, false));
-    s_ControlKeyPressed.insert(std::make_pair(appViewId, false));
-    s_ShiftButtonChecked.insert(std::make_pair(appViewId, false));
-    s_IsDropDownOpen.insert(std::make_pair(appViewId, false));
-    s_ignoreNextEscape.insert(std::make_pair(appViewId, false));
-    s_keepIgnoringEscape.insert(std::make_pair(appViewId, false));
-    s_fHonorShortcuts.insert(std::make_pair(appViewId, true));
-    s_fHandledEnter.insert(std::make_pair(appViewId, true));
-    s_AboutFlyout.insert(std::make_pair(appViewId, nullptr));
+    s_ShiftKeyPressed[appViewId] = false;
+    s_ControlKeyPressed[appViewId] = false;
+    s_ShiftButtonChecked[appViewId] = false;
+    s_IsDropDownOpen[appViewId] = false;
+    s_ignoreNextEscape[appViewId] = false;
+    s_keepIgnoringEscape[appViewId] = false;
+    s_fHonorShortcuts[appViewId] = true;
+    s_AboutFlyout[appViewId] = nullptr;
 }
 
 void KeyboardShortcutManager::OnWindowClosed(int viewId)
@@ -845,6 +819,5 @@ void KeyboardShortcutManager::OnWindowClosed(int viewId)
     s_ignoreNextEscape.erase(viewId);
     s_keepIgnoringEscape.erase(viewId);
     s_fHonorShortcuts.erase(viewId);
-    s_fHandledEnter.erase(viewId);
     s_AboutFlyout.erase(viewId);
 }

--- a/src/CalcViewModel/Common/KeyboardShortcutManager.h
+++ b/src/CalcViewModel/Common/KeyboardShortcutManager.h
@@ -43,7 +43,6 @@ namespace CalculatorApp
             static void IgnoreEscape(bool onlyOnce);
             static void HonorEscape();
             static void HonorShortcuts(bool allow);
-            static void HandledEnter(bool ishandled);
             static void UpdateDropDownState(bool);
             static void ShiftButtonChecked(bool checked);
             static void UpdateDropDownState(Windows::UI::Xaml::Controls::Flyout ^ aboutPageFlyout);

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3883,10 +3883,6 @@
     <value>Reset View</value>
     <comment>Screen reader prompt for the reset zoom button.</comment>
   </data>
-  <data name="zoomInButton.[using:CalculatorApp.Common]KeyboardShortcutManager.VirtualKeyControlChord" xml:space="preserve">
-    <value>Add</value>
-    <comment>{Locked}This is the shortcut for the zoom in button.</comment>
-  </data>
   <data name="zoomInButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Zoom In</value>
     <comment>This is the tool tip automation name for the Calculator zoom in button.</comment>
@@ -3894,10 +3890,6 @@
   <data name="zoomInButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Zoom In</value>
     <comment>Screen reader prompt for the zoom in button.</comment>
-  </data>
-  <data name="zoomOutButton.[using:CalculatorApp.Common]KeyboardShortcutManager.VirtualKeyControlChord" xml:space="preserve">
-    <value>Subtract</value>
-    <comment>{Locked}This is the shortcut for the zoom out button.</comment>
   </data>
   <data name="zoomOutButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Zoom Out</value>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -368,8 +368,8 @@
                     VerticalAlignment="Top"
                     Style="{ThemeResource GraphControlCommandPanel}"
                     RequestedTheme="Light">
-                    <StackPanel Orientation="Horizontal">
-                        <ToggleButton x:Name="ActiveTracing"
+                <StackPanel Orientation="Horizontal">
+                    <ToggleButton x:Name="ActiveTracing"
                                   MinWidth="40"
                                   Margin="0,-1"
                                   Style="{ThemeResource ThemedGraphToggleButtonStyle}"
@@ -405,8 +405,8 @@
                     Style="{ThemeResource GraphControlCommandPanel}"
                     RequestedTheme="Light">
                 <StackPanel Orientation="Vertical">
-
-                    <RepeatButton x:Uid="zoomInButton"
+                    <RepeatButton x:Name="ZoomInButton"
+                                  x:Uid="zoomInButton"
                                   MinHeight="40"
                                   HorizontalAlignment="Stretch"
                                   Style="{ThemeResource ThemedGraphRepeatButtonStyle}"
@@ -417,9 +417,13 @@
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
                                   FontSize="14"
                                   Glyph="&#xE710;"/>
+                        <RepeatButton.KeyboardAccelerators>
+                            <KeyboardAccelerator Key="Add" Modifiers="Control"/>
+                        </RepeatButton.KeyboardAccelerators>
                     </RepeatButton>
 
-                    <RepeatButton x:Uid="zoomOutButton"
+                    <RepeatButton x:Name="ZoomOutButton"
+                                  x:Uid="zoomOutButton"
                                   MinHeight="40"
                                   HorizontalAlignment="Stretch"
                                   Style="{ThemeResource ThemedGraphRepeatButtonStyle}"
@@ -429,6 +433,9 @@
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
                                   FontSize="14"
                                   Glyph="&#xE738;"/>
+                        <RepeatButton.KeyboardAccelerators>
+                            <KeyboardAccelerator Key="Subtract" Modifiers="Control"/>
+                        </RepeatButton.KeyboardAccelerators>
                     </RepeatButton>
 
                     <Button x:Uid="zoomResetButton"

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -51,7 +51,7 @@ constexpr auto sc_ViewModelPropertyName = L"ViewModel";
 
 DEPENDENCY_PROPERTY_INITIALIZATION(GraphingCalculator, IsSmallState);
 
-GraphingCalculator::GraphingCalculator()    
+GraphingCalculator::GraphingCalculator()
 {
     InitializeComponent();
 
@@ -66,6 +66,17 @@ GraphingCalculator::GraphingCalculator()
 
     // And when the actual trace value changes
     GraphingControl->TracingValueChangedEvent += ref new TracingValueChangedEventHandler(this, &GraphingCalculator::OnTracePointChanged);
+
+    // OemMinus and OemAdd aren't declared in the VirtualKey enum, we can't add this accelerator XAML-side
+    auto virtualKey = ref new KeyboardAccelerator();
+    virtualKey->Key = (VirtualKey)187; //OemMinus key
+    virtualKey->Modifiers = VirtualKeyModifiers::Control;
+    ZoomOutButton->KeyboardAccelerators->Append(virtualKey);
+
+    virtualKey = ref new KeyboardAccelerator();
+    virtualKey->Key = (VirtualKey)189; //OemAdd key
+    virtualKey->Modifiers = VirtualKeyModifiers::Control;
+    ZoomInButton->KeyboardAccelerators->Append(virtualKey);
 }
 
 void GraphingCalculator::OnShowTracePopupChanged(bool newValue)


### PR DESCRIPTION
### Description of the changes:
- Support <kbd>Ctrl</kbd> + <kbd>-/+</kbd> (in addition to the existing <kbd>Ctrl</kbd> + <kbd>Numpad -/+</kbd>)

⚠ Important change:
- We use the new RS3+ UWP api to manage shortcuts instead of our own implementation. The UWP being more powerful and supporting multi-shortcuts. We should plan to migrate all other shortcuts in the future
- The current shortcut was localized, not this implementation, but I don't think it's something we need.

Also: 
- simplify KeyboardShortcutManager
- fix a bug in KeyboardShortcutManager (s_VirtualKeyControlInverseChordsForButtons were used instead of s_VirtualKeyInverseChordsForButtons)

### How changes were validated:
- Manually, English and French keyboard layout.

