### PR TITLE
Wstring view overrun

### DIFF
--- a/src/CalcManager/CEngine/scidisp.cpp
+++ b/src/CalcManager/CEngine/scidisp.cpp
@@ -218,8 +218,9 @@ vector<uint32_t> CCalcEngine::DigitGroupingStringToGroupingVector(wstring_view g
     vector<uint32_t> grouping;
     uint32_t currentGroup = 0;
     wchar_t* next = nullptr;
-    const wchar_t* end = groupingString.data() + groupingString.size();
-    for (auto itr = groupingString.data(); itr != end; ++itr)
+    const wchar_t* begin = groupingString.data();
+    const wchar_t* end = begin + groupingString.length();
+    for (auto itr = begin; itr != end; ++itr)
     {
         // Try to parse a grouping number from the string
         currentGroup = wcstoul(itr, &next, 10);
@@ -233,7 +234,7 @@ vector<uint32_t> CCalcEngine::DigitGroupingStringToGroupingVector(wstring_view g
         // If we found a grouping and aren't at the end of the string yet,
         // jump to the next position in the string (the ';').
         // The loop will then increment us to the next character, which should be a number.
-        if (next && (static_cast<size_t>(next - groupingString.data()) < groupingString.length()))
+        if (next && (static_cast<size_t>(next - begin) < groupingString.length()))
         {
             itr = next;
         }

--- a/src/CalcManager/CEngine/scidisp.cpp
+++ b/src/CalcManager/CEngine/scidisp.cpp
@@ -215,10 +215,11 @@ int CCalcEngine::IsNumberInvalid(const wstring& numberString, int iMaxExp, int i
 \****************************************************************************/
 vector<uint32_t> CCalcEngine::DigitGroupingStringToGroupingVector(wstring_view groupingString)
 {
-    vector<uint32_t> grouping{};
+    vector<uint32_t> grouping;
     uint32_t currentGroup = 0;
     wchar_t* next = nullptr;
-    for (const wchar_t* itr = groupingString.data(); *itr != L'\0'; ++itr)
+    const wchar_t* end = groupingString.data() + groupingString.size();
+    for (auto itr = groupingString.data(); itr != end; ++itr)
     {
         // Try to parse a grouping number from the string
         currentGroup = wcstoul(itr, &next, 10);

--- a/src/CalculatorUnitTests/CalcEngineTests.cpp
+++ b/src/CalculatorUnitTests/CalcEngineTests.cpp
@@ -177,6 +177,11 @@ namespace CalculatorEngineTests
 
             groupingVector = { 4, 7, 0 };
             VERIFY_ARE_EQUAL(groupingVector, CCalcEngine::DigitGroupingStringToGroupingVector(L"4;16;7;25;0"), L"Verify we ignore oversize grouping");
+
+            groupingVector = { 3, 0 };
+            constexpr wstring_view nonRepeatingGrouping = L"3;0;0";
+            constexpr wstring_view repeatingGrouping = nonRepeatingGrouping.substr(0, 3);
+            VERIFY_ARE_EQUAL(groupingVector, CCalcEngine::DigitGroupingStringToGroupingVector(repeatingGrouping), L"Verify we don't go past the end of wstring_view range");
         }
 
         TEST_METHOD(TestGroupDigits)


### PR DESCRIPTION
## Fixes #883.

### Description of the changes:
- Updated loop inside CCalcEngine::DigitGroupingStringToGroupingVector to compare against an end point set to the beginning plus size of the wstring_view.

### How changes were validated:
- Manual testing.
- Added a unit test to confirm that the grouping is based on the wstring_view passed in.