### PR TITLE
Focus ClearEntry button after Clear button is used and vice versa

### DIFF
--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
@@ -490,6 +490,7 @@
                                        AutomationProperties.AutomationId="clearButton"
                                        ButtonId="Clear"
                                        Content="C"
+                                       LostFocus="ClearButton_LostFocus"
                                        Visibility="{x:Bind Model.IsInputEmpty, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
             <controls:CalculatorButton x:Name="ClearEntryButton"
@@ -499,6 +500,7 @@
                                        AutomationProperties.AutomationId="clearEntryButton"
                                        ButtonId="ClearEntry"
                                        Content="CE"
+                                       LostFocus="ClearEntryButton_LostFocus"
                                        Visibility="{x:Bind Model.IsInputEmpty, Mode=OneWay, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
 
             <controls:CalculatorButton x:Name="BackSpaceButton"

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
@@ -52,7 +52,8 @@ void CalculatorProgrammerRadixOperators::BitshiftFlyout_Checked(Platform::Object
         FindName("RshLogicalButton");
     }
 
-    // Since arithmeticShiftButton defaults to IsChecked = true, this event an fire before we can load the deferred loaded controls. If that is the case, just return and do nothing.
+    // Since arithmeticShiftButton defaults to IsChecked = true, this event an fire before we can load the deferred loaded controls. If that is the case, just
+    // return and do nothing.
     if (RolButton == nullptr || RorButton == nullptr || RolCarryButton == nullptr || RorCarryButton == nullptr || LshLogicalButton == nullptr
         || RshLogicalButton == nullptr)
     {
@@ -61,7 +62,7 @@ void CalculatorProgrammerRadixOperators::BitshiftFlyout_Checked(Platform::Object
 
     CollapseBitshiftButtons();
 
-    auto radioButton = static_cast<RadioButton^>(sender);
+    auto radioButton = static_cast<RadioButton ^>(sender);
 
     if (radioButton == ArithmeticShiftButton)
     {
@@ -141,4 +142,20 @@ String ^ CalculatorProgrammerRadixOperators::ParenthesisCountToString(unsigned i
 void CalculatorProgrammerRadixOperators::CalculatorProgrammerRadixOperators::OpenParenthesisButton_GotFocus(Object ^ sender, RoutedEventArgs ^ e)
 {
     Model->SetOpenParenthesisCountNarratorAnnouncement();
+}
+
+void CalculatorProgrammerRadixOperators::ClearEntryButton_LostFocus(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (ClearEntryButton->Visibility == ::Visibility::Collapsed && ClearButton->Visibility == ::Visibility::Visible)
+    {
+        ClearButton->Focus(::FocusState::Programmatic);
+    }
+}
+
+void CalculatorProgrammerRadixOperators::ClearButton_LostFocus(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (ClearEntryButton->Visibility == ::Visibility::Visible && ClearButton->Visibility == ::Visibility::Collapsed)
+    {
+        ClearEntryButton->Focus(::FocusState::Programmatic);
+    }
 }

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
@@ -39,5 +39,7 @@ namespace CalculatorApp
 
         bool m_isErrorVisualState;
         void OpenParenthesisButton_GotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void ClearEntryButton_LostFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void ClearButton_LostFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
     };
 }

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -914,7 +914,7 @@
                 <ColumnDefinition/>
                 <ColumnDefinition/>
             </Grid.ColumnDefinitions>
-            <controls:CalculatorButton Name="ClearEntryButton"
+            <controls:CalculatorButton x:Name="ClearEntryButton"
                                        x:Uid="clearEntryButton"
                                        Grid.Column="1"
                                        Style="{StaticResource OperatorButtonStyle}"
@@ -922,6 +922,7 @@
                                        AutomationProperties.AutomationId="clearEntryButton"
                                        ButtonId="ClearEntry"
                                        Content="CE"
+                                       LostFocus="ClearEntryButton_LostFocus"
                                        Visibility="{x:Bind Model.IsInputEmpty, Mode=OneWay, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
 
             <controls:CalculatorButton x:Name="ClearButton"
@@ -932,6 +933,7 @@
                                        AutomationProperties.AutomationId="clearButton"
                                        ButtonId="Clear"
                                        Content="C"
+                                       LostFocus="ClearButton_LostFocus"
                                        Visibility="{x:Bind Model.IsInputEmpty, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"/>
 
             <controls:CalculatorButton x:Name="BackSpaceButton"

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.cpp
@@ -140,3 +140,19 @@ String ^ CalculatorScientificOperators::ParenthesisCountToString(unsigned int co
 {
     return (count == 0) ? ref new String() : ref new String(to_wstring(count).data());
 }
+
+void CalculatorScientificOperators::ClearEntryButton_LostFocus(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (ClearEntryButton->Visibility == ::Visibility::Collapsed && ClearButton->Visibility == ::Visibility::Visible)
+    {
+        ClearButton->Focus(::FocusState::Programmatic);
+    }
+}
+
+void CalculatorScientificOperators::ClearButton_LostFocus(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (ClearEntryButton->Visibility == ::Visibility::Visible && ClearButton->Visibility == ::Visibility::Collapsed)
+    {
+        ClearEntryButton->Focus(::FocusState::Programmatic);
+    }
+}

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml.h
@@ -43,5 +43,7 @@ namespace CalculatorApp
         void ShiftButton_IsEnabledChanged(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::DependencyPropertyChangedEventArgs ^ e);
         void SetOperatorRowVisibility();
         void SetTrigRowVisibility();
+        void ClearEntryButton_LostFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+        void ClearButton_LostFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
     };
 }


### PR DESCRIPTION
## Fixes #860.


### Description of the changes:
- In scientific and programmer modes we hide/show either the Clear or ClearEntry button depending on if there is input to clear. When focus is lost, focus can go to the backspace button or as shown in #860 perhaps the navigation button. This PR fixes the focus issue, which will hopefully also fix the bug reported in #860.

### How changes were validated:
- Manual tests

