### PR TITLE
Prevent the graph to pan/zoom in some cases

### DIFF
--- a/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
+++ b/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
@@ -71,21 +71,6 @@ void GraphingSettingsViewModel::InitRanges()
     m_dontUpdateDisplayRange = false;
 }
 
-void GraphingSettingsViewModel::RefreshPosition()
-{
-    if (HasError())
-    {
-        InitRanges();
-    }
-    else
-    {
-        if (m_Graph != nullptr)
-        {
-            m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue);
-        }
-    }
-}
-
 void GraphingSettingsViewModel::UpdateDisplayRange(bool XValuesModified)
 {
     if (m_Graph == nullptr || m_dontUpdateDisplayRange || HasError())

--- a/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.h
+++ b/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.h
@@ -229,7 +229,6 @@ namespace CalculatorApp::ViewModel
                     RaisePropertyChanged(L"TrigModeRadians");
                     RaisePropertyChanged(L"TrigModeDegrees");
                     RaisePropertyChanged(L"TrigModeGradians");
-                    RefreshPosition();
                 }
             }
         }
@@ -248,7 +247,6 @@ namespace CalculatorApp::ViewModel
                     RaisePropertyChanged(L"TrigModeDegrees");
                     RaisePropertyChanged(L"TrigModeRadians");
                     RaisePropertyChanged(L"TrigModeGradians");
-                    RefreshPosition();
                 }
             }
         }
@@ -267,14 +265,12 @@ namespace CalculatorApp::ViewModel
                     RaisePropertyChanged(L"TrigModeGradians");
                     RaisePropertyChanged(L"TrigModeDegrees");
                     RaisePropertyChanged(L"TrigModeRadians");
-                    RefreshPosition();
                 }
             }
         }
 
     public:
         void UpdateDisplayRange(bool XValuesModified);
-        void RefreshPosition();
 
     public:
         void SetGrapher(GraphControl::Grapher ^ grapher);

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -160,7 +160,7 @@ void GraphingCalculator::OnEquationsVectorChanged(IObservableVector<EquationView
         GraphingControl->Equations->Append(equationViewModel->GraphEquation);
     }
 
-    GraphingControl->PlotGraph();
+    GraphingControl->PlotGraph(false);
 }
 
 void GraphingCalculator::OnTracePointChanged(Point newPoint)

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -104,7 +104,13 @@ public
         event Windows::Foundation::EventHandler<Windows::Foundation::Collections::IMap<Platform::String ^, double> ^> ^ VariablesUpdated;
         void SetVariable(Platform::String ^ variableName, double newValue);
         Platform::String ^ ConvertToLinear(Platform::String ^ mmlString);
-        void PlotGraph(bool keepRanges);
+
+        /// <summary>
+        /// Draw the graph. Call this method if you add or modify an equation.
+        /// </summary>
+        /// <param name="keepCurrentView">Force the graph control to not pan or zoom to adapt the view.</param>
+        void PlotGraph(bool keepCurrentView);
+
         GraphControl::KeyGraphFeaturesInfo ^ AnalyzeEquation(GraphControl::Equation ^ equation);
 
         // We can't use the EvalTrigUnitMode enum directly in as the property type because it comes from another module which doesn't expose
@@ -265,8 +271,8 @@ public
         void OnEquationChanged(Equation ^ equation);
         void OnEquationStyleChanged(Equation ^ equation);
         void OnEquationLineEnabledChanged(Equation ^ equation);
-        bool TryUpdateGraph(bool keepRanges);
-        void TryPlotGraph(bool keepRanges, bool shouldRetry);
+        bool TryUpdateGraph(bool keepCurrentView);
+        void TryPlotGraph(bool keepCurrentView, bool shouldRetry);
         void UpdateGraphOptions(Graphing::IGraphingOptions& options, const std::vector<Equation ^>& validEqs);
         std::vector<Equation ^> GetGraphableEquations();
         void SetGraphArgs();
@@ -284,7 +290,7 @@ public
 
         void SetEquationsAsValid();
         void SetEquationErrors();
-
+        std::optional<std::vector<std::shared_ptr<Graphing::IEquation>>> TryInitializeGraph(bool keepCurrentView, _In_ const Graphing::IExpression* graphingExp = nullptr);
     private:
         DX::RenderMain ^ m_renderMain = nullptr;
 

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -104,7 +104,7 @@ public
         event Windows::Foundation::EventHandler<Windows::Foundation::Collections::IMap<Platform::String ^, double> ^> ^ VariablesUpdated;
         void SetVariable(Platform::String ^ variableName, double newValue);
         Platform::String ^ ConvertToLinear(Platform::String ^ mmlString);
-        void PlotGraph();
+        void PlotGraph(bool keepRanges);
         GraphControl::KeyGraphFeaturesInfo ^ AnalyzeEquation(GraphControl::Equation ^ equation);
 
         // We can't use the EvalTrigUnitMode enum directly in as the property type because it comes from another module which doesn't expose
@@ -116,7 +116,7 @@ public
                 if (value != (int)m_solver->EvalOptions().GetTrigUnitMode())
                 {
                     m_solver->EvalOptions().SetTrigUnitMode((Graphing::EvalTrigUnitMode)value);
-                    PlotGraph();
+                    PlotGraph(true);
                 }
             }
 
@@ -265,8 +265,8 @@ public
         void OnEquationChanged(Equation ^ equation);
         void OnEquationStyleChanged(Equation ^ equation);
         void OnEquationLineEnabledChanged(Equation ^ equation);
-        bool TryUpdateGraph();
-        void TryPlotGraph(bool shouldRetry);
+        bool TryUpdateGraph(bool keepRanges);
+        void TryPlotGraph(bool keepRanges, bool shouldRetry);
         void UpdateGraphOptions(Graphing::IGraphingOptions& options, const std::vector<Equation ^>& validEqs);
         std::vector<Equation ^> GetGraphableEquations();
         void SetGraphArgs();


### PR DESCRIPTION
### Description of the changes:
Prevent the graph to pan/zoom when we
  - hide/show an equation
  - select a different trigonometric unit

### How changes were validated:
- manually