### PR TITLE
Removing wstringstream usage since it adds unnecessary overhead

### DIFF
--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -253,7 +253,6 @@ namespace GraphControl
 
         if (m_renderMain && m_graph != nullptr)
         {
-            unique_ptr<IExpression> graphExpression;
             wstring request;
 
             auto validEqs = GetGraphableEquations();
@@ -263,8 +262,7 @@ namespace GraphControl
 
             if (!validEqs.empty())
             {
-                wstringstream ss{};
-                ss << s_getGraphOpeningTags;
+                request = s_getGraphOpeningTags;
 
                 int numValidEquations = 0;
                 for (Equation ^ eq : validEqs)
@@ -276,18 +274,16 @@ namespace GraphControl
 
                     if (numValidEquations++ > 0)
                     {
-                        ss << L"<mo>,</mo>";
+                        request += L"<mo>,</mo>";
                     }
 
-                    ss << eq->GetRequest()->Data();
+                    request += eq->GetRequest()->Data();
                 }
 
-                ss << s_getGraphClosingTags;
-
-                request = ss.str();
+                request += s_getGraphClosingTags;
             }
 
-            if (graphExpression = m_solver->ParseInput(request))
+            if (unique_ptr<IExpression> graphExpression = m_solver->ParseInput(request))
             {
                 initResult = m_graph->TryInitialize(graphExpression.get());
 
@@ -375,14 +371,11 @@ namespace GraphControl
     {
         std::shared_ptr<Graphing::IGraph> graph = m_solver->CreateGrapher();
 
-        wstringstream ss{};
-        ss << s_getGraphOpeningTags;
-        ss << equation->GetRequest()->Data();
-        ss << s_getGraphClosingTags;
+        wstring request = s_getGraphOpeningTags;
+        request += equation->GetRequest()->Data();
+        request += s_getGraphClosingTags;
 
-        wstring request = ss.str();
-        unique_ptr<IExpression> graphExpression;
-        if (graphExpression = m_solver->ParseInput(request))
+        if (unique_ptr<IExpression> graphExpression = m_solver->ParseInput(request))
         {
             if (graph->TryInitialize(graphExpression.get()))
             {

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -253,6 +253,7 @@ namespace GraphControl
 
         if (m_renderMain && m_graph != nullptr)
         {
+            unique_ptr<IExpression> graphExpression;
             wstring request;
 
             auto validEqs = GetGraphableEquations();
@@ -283,7 +284,7 @@ namespace GraphControl
                 request += s_getGraphClosingTags;
             }
 
-            if (unique_ptr<IExpression> graphExpression = m_solver->ParseInput(request))
+            if (graphExpression = m_solver->ParseInput(request))
             {
                 initResult = m_graph->TryInitialize(graphExpression.get());
 

--- a/src/GraphControl/Models/Equation.cpp
+++ b/src/GraphControl/Models/Equation.cpp
@@ -24,26 +24,27 @@ namespace GraphControl
 
     String ^ Equation::GetRequest()
     {
-        wstringstream ss;
-        wstring expr{ Expression->Data() };
+        wstring request;
+        wstring_view expr{ Expression->Data() };
 
         // Check for unicode characters of less than, less than or equal to, greater than and greater than or equal to.
-        if (expr.find(L">&#x3E;<") != wstring::npos || expr.find(L">&#x3C;<") != wstring::npos || expr.find(L">&#x2265;<") != wstring::npos
-            || expr.find(L">&#x2264;<") != wstring::npos)
+        if (expr.find(L">&#x3E;<") != wstring_view::npos || expr.find(L">&#x3C;<") != wstring_view::npos || expr.find(L">&#x2265;<") != wstring_view::npos
+            || expr.find(L">&#x2264;<") != wstring_view::npos)
         {
-            ss << L"<mrow><mi>plotIneq2D</mi><mfenced separators=\"\">"s;
+            request = L"<mrow><mi>plotIneq2D</mi><mfenced separators=\"\">";
         }
-        else if (expr.find(L">=<") != wstring::npos)
+        else if (expr.find(L">=<") != wstring_view::npos)
         {
-            ss << L"<mrow><mi>plotEq2d</mi><mfenced separators=\"\">";
+            request = L"<mrow><mi>plotEq2d</mi><mfenced separators=\"\">";
         }
         else
         {
-            ss << L"<mrow><mi>plot2d</mi><mfenced separators=\"\">";
+            request = L"<mrow><mi>plot2d</mi><mfenced separators=\"\">";
         }
-        ss << GetExpression() << L"</mfenced></mrow>";
+        request += GetExpression();
+        request += L"</mfenced></mrow>";
 
-        return ref new String(ss.str().c_str());
+        return ref new String(request.c_str());
     }
 
     wstring Equation::GetExpression()
@@ -51,7 +52,7 @@ namespace GraphControl
         wstring mathML = Expression->Data();
 
         size_t mathPrefix = 0;
-        while ((mathPrefix = mathML.find(s_mathPrefix, mathPrefix)) != std::string::npos)
+        while ((mathPrefix = mathML.find(s_mathPrefix, mathPrefix)) != wstring::npos)
         {
             mathML.replace(mathPrefix, s_mathPrefix.length(), L"");
             mathPrefix += s_mathPrefix.length();


### PR DESCRIPTION
### Description of the changes:
- Removing wstringstream usage since it adds unnecessary overhead.
- Limited scope of `graphExpression` inside `Grapher::GetGraph`
- Used a `wstring_view` for performing `find` operations in `Equation::GetRequest`