### PR TITLE
Change Calculator app name back to Calculator and add spacing to Preview tag

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -118,7 +118,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="AppName" xml:space="preserve">
-    <value>Graphing Calculator</value>
+    <value>Calculator</value>
     <comment>{@Appx_ShortDisplayName@}{StringCategory="Feature Title"} This is the title of the official application when published through Windows Store.</comment>
   </data>
   <data name="DevAppName" xml:space="preserve">

--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -36,7 +36,7 @@
         <DataTemplate x:Key="NavMenuItemPreviewDataTemplate" x:DataType="x:String">
             <StackPanel Orientation="Horizontal">
                 <TextBlock VerticalAlignment="Center" Text="{x:Bind}"/>
-                <controls:PreviewTagControl Margin="6,0,0,0" VerticalAlignment="Center"/>
+                <controls:PreviewTagControl Margin="10,0,0,0" VerticalAlignment="Center"/>
             </StackPanel>
         </DataTemplate>
 
@@ -177,7 +177,7 @@
                                Style="{StaticResource SubtitleTextBlockStyle}"
                                Text="{x:Bind Model.CategoryName, Mode=OneWay}"
                                Visibility="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
-                    <controls:PreviewTagControl Margin="6,0,0,0"
+                    <controls:PreviewTagControl Margin="10,0,0,0"
                                                 VerticalAlignment="Center"
                                                 Visibility="{x:Bind Model.IsModePreview, Mode=OneWay}"/>
                 </StackPanel>


### PR DESCRIPTION
## Fixes part of #906.


### Description of the changes:
- Change the calculator app name back to Calculator (from Graphing Calculator)
- Add 10px spacing between Graphing and the Preview tag instead of 6px
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually
-
-

