### PR TITLE
Use path instead of glyph for active tracing

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -516,8 +516,8 @@
                 <Path x:Name="CursorPath"
                       Width="18"
                       Height="18"
-                      Fill="White"
-                      Stroke="Black"
+                      Fill="{ThemeResource SystemColorHighlightTextColor}"
+                      Stroke="{ThemeResource SystemColorWindowTextColor}"
                       StrokeThickness="1"
                       Data="M0 0 l1371 1371 H538 l-538 538 Z"
                       Stretch="Uniform"/>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -339,6 +339,7 @@
         <Grid x:Name="LeftGrid"
               Grid.Row="1"
               Padding="0,4,0,0"
+              SizeChanged="LeftGrid_SizeChanged"
               Visibility="{x:Bind ShouldDisplayPanel(IsSmallState, SwitchModeToggleButton.IsChecked.Value, x:True), Mode=OneWay}">
             <Grid.Resources>
                 <ResourceDictionary>
@@ -434,16 +435,18 @@
                 </StackPanel>
             </Border>
             <Border x:Name="TracePointer"
-                    Width="16"
+                    Width="18"
                     Height="18"
-                    Margin="48,50,0,0"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Top"
                     Visibility="Collapsed">
-                <FontIcon Foreground="Red"
-                          FontFamily="{StaticResource CalculatorFontFamily}"
-                          FontSize="18"
-                          Glyph="&#xE3B3;"/>
+                <Path Width="18"
+                      Height="18"
+                      Fill="White"
+                      Stroke="Black"
+                      StrokeThickness="1"
+                      Data="M0 0 l1371 1371 H538 l-538 538 Z"
+                      Stretch="Uniform"/>
             </Border>
             <Border MinWidth="36"
                     Margin="0,0,12,12"

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -508,20 +508,19 @@
                     </Button>
                 </StackPanel>
             </Border>
-            <Grid x:Name="TracePointer"
-                  HorizontalAlignment="Left"
-                  VerticalAlignment="Top"
-                  Visibility="Collapsed">
-                <Border x:Name="CursorShadow"/>
-                <Path x:Name="CursorPath"
-                      Width="18"
-                      Height="18"
-                      Fill="{ThemeResource SystemColorHighlightTextColor}"
-                      Stroke="{ThemeResource SystemColorWindowTextColor}"
-                      StrokeThickness="1"
-                      Data="M0 0 l1371 1371 H538 l-538 538 Z"
-                      Stretch="Uniform"/>
-            </Grid>
+            <Canvas>
+                <Grid x:Name="TracePointer" Visibility="Collapsed">
+                    <Border x:Name="CursorShadow"/>
+                    <Path x:Name="CursorPath"
+                          Width="18"
+                          Height="18"
+                          Fill="{ThemeResource SystemColorHighlightTextColor}"
+                          Stroke="{ThemeResource SystemColorWindowTextColor}"
+                          StrokeThickness="1"
+                          Data="M0 0 l1371 1371 H538 l-538 538 Z"
+                          Stretch="Uniform"/>
+                </Grid>
+            </Canvas>
             <Border MinWidth="36"
                     Margin="0,0,12,12"
                     HorizontalAlignment="Right"

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -434,20 +434,20 @@
                     </Button>
                 </StackPanel>
             </Border>
-            <Border x:Name="TracePointer"
-                    Width="18"
-                    Height="18"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Top"
-                    Visibility="Collapsed">
-                <Path Width="18"
+            <Grid x:Name="TracePointer"
+                  HorizontalAlignment="Left"
+                  VerticalAlignment="Top"
+                  Visibility="Collapsed">
+                <Border x:Name="CursorShadow"/>
+                <Path x:Name="CursorPath"
+                      Width="18"
                       Height="18"
                       Fill="White"
                       Stroke="Black"
                       StrokeThickness="1"
                       Data="M0 0 l1371 1371 H538 l-538 538 Z"
                       Stretch="Uniform"/>
-            </Border>
+            </Grid>
             <Border MinWidth="36"
                     Margin="0,0,12,12"
                     HorizontalAlignment="Right"

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -312,6 +312,11 @@
                         <Setter Property="Background" Value="{ThemeResource SystemControlAcrylicElementBrush}"/>
                     </Style>
                     <SolidColorBrush x:Key="SwitchToggleBackground" Color="#40000000"/>
+                    <Style x:Key="TracePointerPathStyle" TargetType="Path">
+                        <Setter Property="Fill" Value="White"/>
+                        <Setter Property="Stroke" Value="Black"/>
+                        <Setter Property="StrokeThickness" Value="1"/>
+                    </Style>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Light">
                     <Style x:Key="ThemedSwitchModeToggleButtonStyle"
@@ -338,6 +343,11 @@
                         <Setter Property="CornerRadius" Value="4"/>
                         <Setter Property="Background" Value="{ThemeResource SystemControlAcrylicElementBrush}"/>
                     </Style>
+                    <Style x:Key="TracePointerPathStyle" TargetType="Path">
+                        <Setter Property="Fill" Value="White"/>
+                        <Setter Property="Stroke" Value="Black"/>
+                        <Setter Property="StrokeThickness" Value="1"/>
+                    </Style>
                     <SolidColorBrush x:Key="SwitchToggleBackground" Color="#60ffffff"/>
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="HighContrast">
@@ -358,6 +368,11 @@
                         <Setter Property="Background" Value="{ThemeResource ToolTipBackground}"/>
                     </Style>
                     <SolidColorBrush x:Key="SwitchToggleBackground" Color="{ThemeResource SystemColorWindowColor}"/>
+                    <Style x:Key="TracePointerPathStyle" TargetType="Path">
+                        <Setter Property="Fill" Value="{ThemeResource SystemColorHighlightTextColor}"/>
+                        <Setter Property="Stroke" Value="{ThemeResource SystemColorWindowTextColor}"/>
+                        <Setter Property="StrokeThickness" Value="2"/>
+                    </Style>
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>
@@ -514,9 +529,7 @@
                     <Path x:Name="CursorPath"
                           Width="18"
                           Height="18"
-                          Fill="{ThemeResource SystemColorHighlightTextColor}"
-                          Stroke="{ThemeResource SystemColorWindowTextColor}"
-                          StrokeThickness="1"
+                          Style="{ThemeResource TracePointerPathStyle}"
                           Data="M0 0 l1371 1371 H538 l-538 538 Z"
                           Stretch="Uniform"/>
                 </Grid>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -185,8 +185,7 @@ void GraphingCalculator::OnTracePointChanged(Point newPoint)
 void CalculatorApp::GraphingCalculator::OnPointerPointChanged(Windows::Foundation::Point newPoint)
 {
     // Move the pointer glyph to where it is supposed to be.
-    // because the glyph is centered and has some spacing, to get the point to properly line up with the glyph, move the x point over 2 px
-    TracePointer->Margin = Thickness(newPoint.X - 2, newPoint.Y, 0, 0);
+    TracePointer->Margin = Thickness(newPoint.X, newPoint.Y, 0, 0);
 }
 
 GraphingCalculatorViewModel ^ GraphingCalculator::ViewModel::get()
@@ -542,4 +541,10 @@ void GraphingCalculator::OnSettingsFlyout_Closing(FlyoutBase ^ sender, FlyoutBas
     auto flyout = static_cast<Flyout ^>(sender);
     auto graphingSetting = static_cast<GraphingSettings ^>(flyout->Content);
     args->Cancel = graphingSetting->CanBeClose();
+}
+
+void GraphingCalculator::LeftGrid_SizeChanged(Object ^ /*sender*/, SizeChangedEventArgs ^ e)
+{
+    // Initialize the pointer to the correct location to match initial value in GraphControl\DirectX\RenderMain.cpp
+    TracePointer->Margin = Thickness(e->NewSize.Width/2 + 40, e->NewSize.Height/2 - 40, 0, 0);
 }

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -82,6 +82,13 @@ GraphingCalculator::GraphingCalculator()
     virtualKey->Key = (VirtualKey)187; // OemAdd key
     virtualKey->Modifiers = VirtualKeyModifiers::Control;
     ZoomInButton->KeyboardAccelerators->Append(virtualKey);
+
+    // add shadow to the trace pointer when not in high contrast mode
+    auto accessibilitySettings = ref new Windows::UI::ViewManagement::AccessibilitySettings();
+    if (!accessibilitySettings->HighContrast)
+    {
+        AddShadow();
+    }
 }
 
 void GraphingCalculator::OnShowTracePopupChanged(bool newValue)
@@ -534,6 +541,21 @@ void GraphingCalculator::DisplayGraphSettings()
     flyoutGraphSettings->Content = graphSettings;
     flyoutGraphSettings->Closing += ref new TypedEventHandler<FlyoutBase ^, FlyoutBaseClosingEventArgs ^>(this, &GraphingCalculator::OnSettingsFlyout_Closing);
     flyoutGraphSettings->ShowAt(GraphSettingsButton);
+}
+
+void CalculatorApp::GraphingCalculator::AddShadow()
+{
+    auto compositor = ::Hosting::ElementCompositionPreview::GetElementVisual(CursorPath)->Compositor;
+    auto dropShadow = compositor->CreateDropShadow();
+    dropShadow->BlurRadius = 6;
+    dropShadow->Opacity = 0.33f;
+    dropShadow->Offset = ::Numerics::float3(2, 2, 0); 
+    dropShadow->Mask = CursorPath->GetAlphaMask();
+
+    auto shadowSpriteVisual = compositor->CreateSpriteVisual();
+    shadowSpriteVisual->Size = ::Numerics::float2(static_cast<float>(CursorPath->ActualWidth), static_cast<float>(CursorPath->ActualHeight));
+    shadowSpriteVisual->Shadow = dropShadow;
+    ::Hosting::ElementCompositionPreview::SetElementChildVisual(CursorShadow, shadowSpriteVisual);
 }
 
 void GraphingCalculator::OnSettingsFlyout_Closing(FlyoutBase ^ sender, FlyoutBaseClosingEventArgs ^ args)

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -194,7 +194,8 @@ void GraphingCalculator::OnTracePointChanged(Point newPoint)
 void CalculatorApp::GraphingCalculator::OnPointerPointChanged(Windows::Foundation::Point newPoint)
 {
     // Move the pointer glyph to where it is supposed to be.
-    TracePointer->Margin = Thickness(newPoint.X, newPoint.Y, 0, 0);
+    Canvas::SetLeft(TracePointer, newPoint.X);
+    Canvas::SetTop(TracePointer, newPoint.Y);
 }
 
 GraphingCalculatorViewModel ^ GraphingCalculator::ViewModel::get()
@@ -570,7 +571,8 @@ void GraphingCalculator::OnSettingsFlyout_Closing(FlyoutBase ^ sender, FlyoutBas
 void GraphingCalculator::LeftGrid_SizeChanged(Object ^ /*sender*/, SizeChangedEventArgs ^ e)
 {
     // Initialize the pointer to the correct location to match initial value in GraphControl\DirectX\RenderMain.cpp
-    TracePointer->Margin = Thickness(e->NewSize.Width/2 + 40, e->NewSize.Height/2 - 40, 0, 0);
+    Canvas::SetLeft(TracePointer, e->NewSize.Width / 2 + 40);
+    Canvas::SetTop(TracePointer, e->NewSize.Height / 2 - 40);
 }
 
 void GraphingCalculator::OnHighContrastChanged(AccessibilitySettings ^ sender, Object ^ /*args*/)

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -78,6 +78,7 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
         void GraphSettingsButton_Click(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 
         void DisplayGraphSettings();
+        void AddShadow();
 
     private:
         Windows::Foundation::EventRegistrationToken m_dataRequestedToken;

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -74,7 +74,7 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
         void GraphSettingsButton_Click(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void SwitchModeToggleButton_Toggled(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void DisplayGraphSettings();
-        void AddShadow();
+        void AddTracePointerShadow();
 
     private:
         Windows::Foundation::EventRegistrationToken m_dataRequestedToken;
@@ -83,9 +83,11 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
         Windows::Foundation::EventRegistrationToken m_activeTracingKeyUpToken;
         Windows::Foundation::EventRegistrationToken m_ActiveTracingPointerCaptureLost;
         CalculatorApp::ViewModel::GraphingCalculatorViewModel ^ m_viewModel;
+        Windows::UI::ViewManagement::AccessibilitySettings ^ m_accessibilitySettings;
         void
             OnSettingsFlyout_Closing(Windows::UI::Xaml::Controls::Primitives::FlyoutBase ^ sender, Windows::UI::Xaml::Controls::Primitives::FlyoutBaseClosingEventArgs ^ args);
         void LeftGrid_SizeChanged(Platform::Object ^ sender, Windows::UI::Xaml::SizeChangedEventArgs ^ e);
+        void OnHighContrastChanged(Windows::UI::ViewManagement::AccessibilitySettings ^ sender, Platform::Object ^ args);
     };
 
 }

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -88,6 +88,7 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
         CalculatorApp::ViewModel::GraphingCalculatorViewModel ^ m_viewModel;
         void
             OnSettingsFlyout_Closing(Windows::UI::Xaml::Controls::Primitives::FlyoutBase ^ sender, Windows::UI::Xaml::Controls::Primitives::FlyoutBaseClosingEventArgs ^ args);
+        void LeftGrid_SizeChanged(Platform::Object ^ sender, Windows::UI::Xaml::SizeChangedEventArgs ^ e);
     };
 
 }

--- a/src/Calculator/pch.h
+++ b/src/Calculator/pch.h
@@ -29,6 +29,7 @@
 #include <string>
 #include <tuple>
 #include <iomanip>
+#include <WindowsNumerics.h>
 
 // C++\WinRT Headers
 #include "winrt/base.h"

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -290,7 +290,7 @@ namespace GraphControl
             if (graphExpression = m_solver->ParseInput(request))
             {
                 initResult = TryInitializeGraph(keepCurrentView, graphExpression.get());
-                
+
                 if (initResult != nullopt)
                 {
                     UpdateGraphOptions(m_graph->GetOptions(), validEqs);

--- a/src/GraphControl/DirectX/RenderMain.cpp
+++ b/src/GraphControl/DirectX/RenderMain.cpp
@@ -44,8 +44,6 @@ namespace GraphControl::DX
         RegisterEventHandlers();
 
         m_drawActiveTracing = false;
-        m_activeTracingPointerLocation.X = 50;
-        m_activeTracingPointerLocation.Y = 50;
     }
 
     RenderMain::~RenderMain()
@@ -65,6 +63,7 @@ namespace GraphControl::DX
                 renderer->SetDpi(dpi, dpi);
 
                 renderer->SetGraphSize(static_cast<unsigned int>(m_swapChainPanel->ActualWidth), static_cast<unsigned int>(m_swapChainPanel->ActualHeight));
+              
             }
         }
     }
@@ -120,6 +119,13 @@ namespace GraphControl::DX
     {
         // TODO: Replace this with the sizedependent initialization of your app's content.
         RunRenderPass();
+
+        if (m_swapChainPanel != nullptr)
+        {
+            // Initialize the active tracing location to just above and to the right of the center of the graph area
+            m_activeTracingPointerLocation.X = m_swapChainPanel->ActualWidth / 2 + 40;
+            m_activeTracingPointerLocation.Y = m_swapChainPanel->ActualHeight / 2 - 40;
+        }
     }
 
     bool RenderMain::RunRenderPass()


### PR DESCRIPTION
## Fixes part of #906.

### Description of the changes:
- Updates the glyph in active tracing to use a path instead.
- Moves the initial position closer to the center of the graph surface
- Resets the position of the pointer when the calculator is resized

### How changes were validated:
Manually
