### PR TITLE
Update group policy check to look in HKCU instead of HKLM for allowing graphing mode

### DIFF
--- a/src/CalcViewModel/Common/NavCategory.cpp
+++ b/src/CalcViewModel/Common/NavCategory.cpp
@@ -89,7 +89,7 @@ bool IsGraphingModeEnabled()
     DWORD bufferSize{ sizeof(allowGraphingCalculator) };
     // Make sure to call RegGetValueW only on Windows 10 1903+
     if (RegGetValueW(
-            HKEY_LOCAL_MACHINE,
+            HKEY_CURRENT_USER,
             L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Calculator",
             L"AllowGraphingCalculator",
             RRF_RT_REG_DWORD | RRF_RT_REG_BINARY,

--- a/src/CalcViewModel/Common/NavCategory.cpp
+++ b/src/CalcViewModel/Common/NavCategory.cpp
@@ -92,7 +92,7 @@ bool IsGraphingModeEnabled()
             HKEY_CURRENT_USER,
             L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Policies\\Calculator",
             L"AllowGraphingCalculator",
-            RRF_RT_REG_DWORD | RRF_RT_REG_BINARY,
+            RRF_RT_DWORD, // RRF_RT_DWORD == RRF_RT_REG_DWORD | RRF_RT_REG_BINARY
             nullptr,
             reinterpret_cast<LPBYTE>(&allowGraphingCalculator),
             &bufferSize)


### PR DESCRIPTION
## Fixes #919.


### Description of the changes:
- Update the registry path to HKCU instead of HKLM when it checks the group policy for allowing graphing mode

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually tested using the Group Policy editor to set the AllowGraphingMode policy.

