### PR TITLE
Removing useless code from VisualTree::FindDescendantByName

### DIFF
--- a/src/Calculator/Utils/VisualTree.cpp
+++ b/src/Calculator/Utils/VisualTree.cpp
@@ -19,8 +19,6 @@ FrameworkElement ^ VisualTree::FindDescendantByName(DependencyObject ^ element, 
     }
 
     auto frameworkElement = dynamic_cast<FrameworkElement ^>(element);
-    auto nsame = frameworkElement->Name->Data();
-    nsame = nsame;
     if (frameworkElement != nullptr && name->Equals(frameworkElement->Name))
     {
         return frameworkElement;


### PR DESCRIPTION
### Description of the changes:
- Removing unusual code that accessed a String's Data property and then sets it to itself (maybe it was once added for debugging?)