### PR TITLE
Fix release pipeline by setting provData to false

### DIFF
--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -81,6 +81,8 @@ jobs:
       pushPkgName: calculator.app
       version: $(versionMajor).$(versionMinor).$(versionBuild)
       owner: paxeeapps
+      provData: false
+
 
   - task: PublishBuildArtifacts@1
     displayName: Publish vpack\app artifact with vpack manifest


### PR DESCRIPTION
### Description of the changes:
- Set provData to false in PkgESVPack@10 step to work around the VPack failure in the release pipeline.