### PR TITLE
Remove ARM64 from Release builds

### DIFF
--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -30,11 +30,6 @@ jobs:
     platform: ARM
     condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
-- template: ./templates/build-app-internal.yaml
-  parameters:
-    platform: ARM64
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
-
 - template: ./templates/run-ui-tests.yaml
   parameters:
     platform: x64


### PR DESCRIPTION
### Description of the changes:
- Remove ARM64 from Release builds since Graphing mode does not support ARM64