### PR TITLE
Fix inequalities not graphing, and other bugs

### DIFF
--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -273,18 +273,23 @@ void EquationTextBox::UpdateButtonsVisualState()
 void EquationTextBox::UpdateCommonVisualState()
 {
     String ^ state = nullptr;
+    bool richEditHasContent = RichEditHasContent();
 
     if (m_HasFocus && HasError)
     {
         state = "FocusedError";
     }
-    else if (IsAddEquationMode && ((m_HasFocus || m_isPointerOver) && !RichEditHasContent()))
+    else if (IsAddEquationMode && m_HasFocus && !richEditHasContent)
     {
-        state = "AddEquation";
+        state = "AddEquationFocused";
     }
     else if (m_HasFocus)
     {
         state = "Focused";
+    }
+    else if (IsAddEquationMode && m_isPointerOver && !richEditHasContent)
+    {
+        state = "AddEquation";
     }
     else if (HasError && (m_isPointerOver || m_isColorChooserFlyoutOpen))
     {

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -305,6 +305,16 @@
                                                 <Setter Target="EquationButton.IsEnabled" Value="false"/>
                                             </VisualState.Setters>
                                         </VisualState>
+                                        <VisualState x:Name="AddEquationFocused">
+                                            <VisualState.Setters>
+                                                <Setter Target="FunctionNumberLabelTextBlock.Visibility" Value="Collapsed"/>
+                                                <Setter Target="EquationButton.Background" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
+                                                <Setter Target="EquationButton.BorderBrush" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
+                                                <Setter Target="EquationButton.Foreground" Value="{ThemeResource EquationButtonHideLineForegroundBrush}"/>
+                                                <Setter Target="EquationButton.IsEnabled" Value="false"/>
+                                                <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource TextBoxBackgroundThemeBrush}"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
                                         <VisualState x:Name="Error">
                                             <VisualState.Setters>
                                                 <Setter Target="MathRichEditBox.PlaceholderText" Value=""/>

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -277,8 +277,15 @@ namespace GraphControl
                     {
                         request += L"<mo>,</mo>";
                     }
+                    auto equationRequest = eq->GetRequest()->Data();
 
-                    request += eq->GetRequest()->Data();
+                    // If the equation request failed, then fail graphing.
+                    if (equationRequest == nullptr)
+                    {
+                        return false;
+                    }
+
+                    request += equationRequest;
                 }
 
                 request += s_getGraphClosingTags;

--- a/src/GraphControl/Models/Equation.cpp
+++ b/src/GraphControl/Models/Equation.cpp
@@ -29,7 +29,9 @@ namespace GraphControl
 
         // Check for unicode characters of less than, less than or equal to, greater than and greater than or equal to.
         if (expr.find(L">&#x3E;<") != wstring_view::npos || expr.find(L">&#x3C;<") != wstring_view::npos || expr.find(L">&#x2265;<") != wstring_view::npos
-            || expr.find(L">&#x2264;<") != wstring_view::npos)
+            || expr.find(L">&#x2264;<") != wstring_view::npos || expr.find(8805) != wstring_view::npos || expr.find(8804) != wstring_view::npos
+            || expr.find(L">&lt;<") != wstring_view::npos
+            || expr.find(L">&gt;<") != wstring_view::npos)
         {
             request = L"<mrow><mi>plotIneq2D</mi><mfenced separators=\"\">";
         }
@@ -37,6 +39,12 @@ namespace GraphControl
         {
             request = L"<mrow><mi>plotEq2d</mi><mfenced separators=\"\">";
         }
+        // If the expression contains both x and y but no equal or inequality sign, then that cannot be graphed.
+        else if (expr.find(L">x<") != wstring_view::npos && (expr.find(L">y<") != wstring_view::npos))
+        {
+            return nullptr;
+        }
+        // Else default to plot2d
         else
         {
             request = L"<mrow><mi>plot2d</mi><mfenced separators=\"\">";


### PR DESCRIPTION
## Fixes part of #906 


### Description of the changes:
- In #926 we format the MathML before submitting the equation, this caused the unicode symbols for inequalities to be changed into a different format. This PR updates our parsing to detect the new format. Left in the previous code since those might still potentially appear.
- Fixed a bug when graphing x^2+y^2 (or any equation with x,y) without an equal sign would result in a crash
- Fixed formatting of focused ghost textbox to have the correct focused background

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual tests

