### PR TITLE
Fix focus bug in graphing mode and other small changes

### DIFF
--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -185,7 +185,7 @@ void MathRichEditBox::SubmitEquation(EquationSubmissionSource source)
         auto formatRequest = ref new MathRichEditBoxFormatRequest(newVal);
         FormatRequest(this, formatRequest);
 
-        if (!formatRequest->FormattedText->IsEmpty())
+        if (formatRequest->FormattedText != nullptr && !formatRequest->FormattedText->IsEmpty())
         {
             newVal = formatRequest->FormattedText;
         }

--- a/src/Calculator/Controls/MathRichEditBox.h
+++ b/src/Calculator/Controls/MathRichEditBox.h
@@ -39,8 +39,8 @@ namespace CalculatorApp
 
         public:
             MathRichEditBoxFormatRequest(Platform::String^ originalText)
+                : m_OriginalText(originalText)
             {
-                m_OriginalText = originalText;
             }
         };
 

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -330,6 +330,9 @@ void EquationInputArea::SubmitTextbox(TextBox ^ sender)
     {
         val = validateDouble(sender->Text, variableViewModel->Value);
         variableViewModel->Value = val;
+
+        // Assign back to val in case it gets changed due to min/max
+        val = variableViewModel->Value;
     }
     else if (sender->Name == "MinTextBox")
     {

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
@@ -61,12 +61,12 @@ namespace CalculatorApp
         void TextBoxLosingFocus(Windows::UI::Xaml::Controls::TextBox ^ textbox, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ args);
         void TextBoxKeyDown(Windows::UI::Xaml::Controls::TextBox ^ textbox, Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e);
         void SubmitTextbox(Windows::UI::Xaml::Controls::TextBox ^ textbox);
+        void VariableAreaTapped(Platform::Object ^ sender, Windows::UI::Xaml::Input::TappedRoutedEventArgs ^ e);
+        void EquationTextBox_EquationFormatRequested(Platform::Object ^ sender, CalculatorApp::Controls::MathRichEditBoxFormatRequest ^ e);
 
         Windows::UI::ViewManagement::AccessibilitySettings ^ m_accessibilitySettings;
         int m_lastLineColorIndex;
         int m_lastFunctionLabelIndex;
         ViewModel::EquationViewModel ^ m_equationToFocus;
-        void VariableAreaTapped(Platform::Object ^ sender, Windows::UI::Xaml::Input::TappedRoutedEventArgs ^ e);
-        void EquationTextBox_EquationFormatRequested(Platform::Object ^ sender, CalculatorApp::Controls::MathRichEditBoxFormatRequest ^ e);
     };
 }

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -552,7 +552,7 @@ void CalculatorApp::GraphingCalculator::AddTracePointerShadow()
     auto dropShadow = compositor->CreateDropShadow();
     dropShadow->BlurRadius = 6;
     dropShadow->Opacity = 0.33f;
-    dropShadow->Offset = ::Numerics::float3(2, 2, 0); 
+    dropShadow->Offset = ::Numerics::float3(2, 2, 0);
     dropShadow->Mask = CursorPath->GetAlphaMask();
 
     auto shadowSpriteVisual = compositor->CreateSpriteVisual();
@@ -585,5 +585,17 @@ void GraphingCalculator::OnEquationFormatRequested(Object ^ sender, MathRichEdit
     if (!e->OriginalText->IsEmpty())
     {
         e->FormattedText = GraphingControl->FormatMathML(e->OriginalText);
+    }
+}
+
+void GraphingCalculator::SetDefaultFocus()
+{
+    if (IsSmallState)
+    {
+        SwitchModeToggleButton->Focus(::FocusState::Programmatic);
+    }
+    else
+    {
+        EquationInputAreaControl->Focus(::FocusState::Programmatic);
     }
 }

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -38,6 +38,8 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
         static Platform::String ^ GetInfoForSwitchModeToggleButton(bool isChecked);
         static Windows::UI::Xaml::Visibility ManageEditVariablesButtonVisibility(unsigned int numberOfVariables);
         static Platform::String ^ GetTracingLegend(Platform::IBox<bool> ^ isTracing);
+
+        void SetDefaultFocus();
     private:
         void GraphingCalculator_DataContextChanged(Windows::UI::Xaml::FrameworkElement ^ sender, Windows::UI::Xaml::DataContextChangedEventArgs ^ args);
 

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -297,7 +297,7 @@ void MainPage::SetDefaultFocus()
     }
     if (m_graphingCalculator != nullptr && m_graphingCalculator->Visibility == ::Visibility::Visible)
     {
-        FocusManager::TryFocusAsync(m_graphingCalculator, ::FocusState::Programmatic);
+        m_graphingCalculator->SetDefaultFocus();
     }
     if (m_converter != nullptr && m_converter->Visibility == ::Visibility::Visible)
     {


### PR DESCRIPTION
## Fixes #906 


### Description of the changes:
- Focus now lands on the equation text box, or switch mode button when using ALT + 3 to switch modes
- Putting in a value smaller or larger than the min/max for a variable would accept the input but would not do anything. Now the value is reset to the min/max. I debated automatically decreasing/increasing the min/max if the user manually inputs a value smaller/larger but decided against it for now.
- Fixes some coding style comments from a prev PR

### How changes were validated:
- Manual tests

