### PR TITLE
Fix graphing crash when plotting equations with errors

### DIFF
--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -162,14 +162,11 @@ namespace GraphControl
 
     void Grapher::OnEquationChanged(Equation ^ equation)
     {
-        // If the equation was previously valid, we should try to graph again in the event of the failure
-        bool shouldRetry = equation->IsValidated;
-
         // Reset these properties if the equation is requesting to be graphed again
         equation->HasGraphError = false;
         equation->IsValidated = false;
 
-        TryPlotGraph(false, shouldRetry);
+        TryPlotGraph(false, true);
     }
 
     void Grapher::OnEquationStyleChanged(Equation ^)
@@ -313,10 +310,6 @@ namespace GraphControl
                         shouldKeepPreviousGraph = false;
                         initResult = nullopt;
                     }
-                }
-                else
-                {
-                    shouldKeepPreviousGraph = false;
                 }
             }
 

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -321,7 +321,7 @@ namespace GraphControl
                 // Do not re-initialize the graph to empty if there are still valid equations graphed
                 if (!shouldKeepPreviousGraph)
                 {
-                    initResult = TryInitializeGraph(keepCurrentView, graphExpression.get());
+                    initResult = m_graph->TryInitialize();
                     if (initResult != nullopt)
                     {
                         UpdateGraphOptions(m_graph->GetOptions(), validEqs);

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -314,6 +314,10 @@ namespace GraphControl
                         initResult = nullopt;
                     }
                 }
+                else
+                {
+                    shouldKeepPreviousGraph = false;
+                }
             }
 
             if (initResult == nullopt)


### PR DESCRIPTION
## Fixes #957


### Description of the changes:
- The call to initialize an empty graph was replaced with a call that tries to graph the error equation

### How changes were validated:
- Type sqrt(y) and hover mouse over graph

