### PR TITLE
Feat/programmer signedness

### DIFF
--- a/src/CalcManager/CEngine/CalcUtils.cpp
+++ b/src/CalcManager/CEngine/CalcUtils.cpp
@@ -33,7 +33,7 @@ bool IsDigitOpCode(OpCode opCode)
 // was never inout, we need to revert the state changes made as a result of this test
 bool IsGuiSettingOpCode(OpCode opCode)
 {
-    if (IsOpInRange(opCode, IDM_HEX, IDM_BIN) || IsOpInRange(opCode, IDM_QWORD, IDM_BYTE) || IsOpInRange(opCode, IDM_DEG, IDM_GRAD))
+    if (IsOpInRange(opCode, IDM_HEX, IDM_BIN) || IsOpInRange(opCode, IDM_QWORD, IDM_BYTE) || IsOpInRange(opCode, IDM_DEG, IDM_GRAD) || IsOpInRange(opCode, IDM_SIGNED, IDM_UNSIGNED))
     {
         return true;
     }

--- a/src/CalcManager/CEngine/calc.cpp
+++ b/src/CalcManager/CEngine/calc.cpp
@@ -65,6 +65,7 @@ CCalcEngine::CCalcEngine(
     __in_opt shared_ptr<IHistoryDisplay> pHistoryDisplay)
     : m_fPrecedence(fPrecedence)
     , m_fIntegerMode(fIntegerMode)
+    , m_fUnsignedMode(false)
     , m_pCalcDisplay(pCalcDisplay)
     , m_resourceProvider(pResourceProvider)
     , m_nOpCode(0)
@@ -125,10 +126,12 @@ void CCalcEngine::InitChopNumbers()
     assert(m_chopNumbers.size() == m_maxDecimalValueStrings.size());
     for (size_t i = 0; i < m_chopNumbers.size(); i++)
     {
-        auto maxVal = m_chopNumbers[i] / 2;
-        maxVal = RationalMath::Integer(maxVal);
+        auto maxVal = m_chopNumbers[i];
+        auto maxUnsignedVal = RationalMath::Integer(maxVal);
+        m_maxUnsignedValueStrings[i] = maxUnsignedVal.ToString(10, FMT_FLOAT, m_precision);
 
-        m_maxDecimalValueStrings[i] = maxVal.ToString(10, FMT_FLOAT, m_precision);
+        auto maxSignedVal = RationalMath::Integer(maxVal / 2);
+        m_maxDecimalValueStrings[i] = maxSignedVal.ToString(10, FMT_FLOAT, m_precision);
     }
 }
 

--- a/src/CalcManager/CEngine/scidisp.cpp
+++ b/src/CalcManager/CEngine/scidisp.cpp
@@ -46,9 +46,10 @@ typedef struct
     bool fIntMath;
     bool bRecord;
     bool bUseSep;
+    bool bUnsigned;
 } LASTDISP;
 
-static LASTDISP gldPrevious = { 0, -1, 0, -1, (NUM_WIDTH)-1, false, false, false };
+static LASTDISP gldPrevious = { 0, -1, 0, -1, (NUM_WIDTH)-1, false, false, false, false };
 
 // Truncates if too big, makes it a non negative - the number in rat. Doesn't do anything if not in INT mode
 CalcEngine::Rational CCalcEngine::TruncateNumForIntMath(CalcEngine::Rational const& rat)
@@ -85,7 +86,7 @@ void CCalcEngine::DisplayNum(void)
     //  called.
     //
     if (m_bRecord || gldPrevious.value != m_currentVal || gldPrevious.precision != m_precision || gldPrevious.radix != m_radix || gldPrevious.nFE != (int)m_nFE
-        || gldPrevious.bUseSep != true || gldPrevious.numwidth != m_numwidth || gldPrevious.fIntMath != m_fIntegerMode || gldPrevious.bRecord != m_bRecord)
+        || gldPrevious.bUseSep != true || gldPrevious.numwidth != m_numwidth || gldPrevious.fIntMath != m_fIntegerMode || gldPrevious.bRecord != m_bRecord || gldPrevious.bUnsigned != m_fUnsignedMode)
     {
         gldPrevious.precision = m_precision;
         gldPrevious.radix = m_radix;
@@ -95,6 +96,7 @@ void CCalcEngine::DisplayNum(void)
         gldPrevious.fIntMath = m_fIntegerMode;
         gldPrevious.bRecord = m_bRecord;
         gldPrevious.bUseSep = true;
+        gldPrevious.bUnsigned = m_fUnsignedMode;
 
         if (m_bRecord)
         {

--- a/src/CalcManager/CEngine/sciset.cpp
+++ b/src/CalcManager/CEngine/sciset.cpp
@@ -21,7 +21,7 @@ void CCalcEngine::SetRadixTypeAndNumWidth(RADIX_TYPE radixtype, NUM_WIDTH numwid
         uint64_t w64Bits = m_currentVal.ToUInt64_t();
         bool fMsb = (w64Bits >> (m_dwWordBitWidth - 1)) & 1; // make sure you use the old width
 
-        if (fMsb)
+        if (fMsb && !m_fUnsignedMode)
         {
             // If high bit is set, then get the decimal number in -ve 2'scompl form.
             auto tempResult = m_currentVal ^ m_chopNumbers[m_numwidth];

--- a/src/CalcManager/CEngine/sciset.cpp
+++ b/src/CalcManager/CEngine/sciset.cpp
@@ -141,7 +141,10 @@ void CCalcEngine::UpdateMaxIntDigits()
         // if in integer mode you still have to honor the max digits you can enter based on bit width
         if (m_fIntegerMode)
         {
-            m_cIntDigitsSav = static_cast<int>(m_maxDecimalValueStrings[m_numwidth].length()) - 1;
+            if (m_fUnsignedMode)
+                m_cIntDigitsSav = static_cast<int>(m_maxUnsignedValueStrings[m_numwidth].length()) - 1;
+            else
+                m_cIntDigitsSav = static_cast<int>(m_maxDecimalValueStrings[m_numwidth].length()) - 1;
             // This is the max digits you can enter a decimal in fixed width mode aka integer mode -1. The last digit
             // has to be checked separately
         }

--- a/src/CalcManager/Command.h
+++ b/src/CalcManager/Command.h
@@ -205,6 +205,9 @@ namespace CalculationManager
         CommandWord = 319,
         CommandByte = 320,
 
+        CommandSigned = 325,
+        CommandUnsigned = 326,
+
         CommandBINEDITSTART = 700,
         CommandBINPOS0 = 700,
         CommandBINPOS1 = 701,

--- a/src/CalcManager/Header Files/CCommand.h
+++ b/src/CalcManager/Header Files/CCommand.h
@@ -29,6 +29,8 @@
 #define IDM_RAD 322
 #define IDM_GRAD 323
 #define IDM_DEGREES 324
+#define IDM_SIGNED 325
+#define IDM_UNSIGNED 326
 
 #define IDC_HEX IDM_HEX
 #define IDC_DEC IDM_DEC
@@ -44,6 +46,9 @@
 #define IDC_DWORD IDM_DWORD
 #define IDC_WORD IDM_WORD
 #define IDC_BYTE IDM_BYTE
+
+#define IDC_SIGNED IDM_SIGNED
+#define IDC_UNSIGNED IDM_UNSIGNED
 
 // Key IDs:
 // These id's must be consecutive from IDC_FIRSTCONTROL to IDC_LASTCONTROL.

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -112,6 +112,7 @@ public:
 private:
     bool m_fPrecedence;
     bool m_fIntegerMode; /* This is true if engine is explicitly called to be in integer mode. All bases are restricted to be in integers only */
+    bool m_fUnsignedMode;
     ICalcDisplay* m_pCalcDisplay;
     CalculationManager::IResourceProvider* const m_resourceProvider;
     int m_nOpCode;     /* ID value of operation.                       */
@@ -161,6 +162,7 @@ private:
 
     std::array<CalcEngine::Rational, NUM_WIDTH_LENGTH> m_chopNumbers;      // word size enforcement
     std::array<std::wstring, NUM_WIDTH_LENGTH> m_maxDecimalValueStrings;   // maximum values represented by a given word width based off m_chopNumbers
+    std::array<std::wstring, NUM_WIDTH_LENGTH> m_maxUnsignedValueStrings;   // maximum values represented by a given word width based off m_chopNumbers
     static std::unordered_map<std::wstring_view, std::wstring> s_engineStrings; // the string table shared across all instances
     wchar_t m_decimalSeparator;
     wchar_t m_groupSeparator;

--- a/src/CalcViewModel/Common/CalculatorButtonUser.h
+++ b/src/CalcViewModel/Common/CalculatorButtonUser.h
@@ -92,6 +92,8 @@ public
         Dword = (int)CM::Command::CommandDword,
         Word = (int)CM::Command::CommandWord,
         Byte = (int)CM::Command::CommandByte,
+        Signed = (int)CM::Command::CommandSigned,
+        Unsigned = (int)CM::Command::CommandUnsigned,
         Cube = (int)CM::Command::CommandCUB,
         DMS = (int)CM::Command::CommandDMS,
         Hyp = (int) CM::Command::CommandHYP,

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -143,6 +143,7 @@ public
             CalculatorApp::Common::NumberBase programmerNumberBase,
             CalculatorApp::Common::BitLength bitLengthType,
             bool unsignedMode);
+        static bool IsOperandNegative(Platform::String ^ operand);
         static Platform::String ^ SanitizeOperand(Platform::String ^ operand);
         static Platform::String ^ RemoveUnwantedCharsFromString(Platform::String ^ input);
         static Platform::IBox<unsigned long long int> ^ TryOperandToULL(Platform::String ^ operand, CalculatorApp::Common::NumberBase numberBase);

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -28,7 +28,19 @@ public
         static void CopyToClipboard(Platform::String ^ stringToCopy);
         static Windows::Foundation::IAsyncOperation<
             Platform::String
-            ^> ^ GetStringToPaste(CalculatorApp::Common::ViewMode mode, CalculatorApp::Common::CategoryGroupType modeType, CalculatorApp::Common::NumberBase programmerNumberBase, CalculatorApp::Common::BitLength bitLengthType);
+            ^> ^ GetStringToPaste(
+                CalculatorApp::Common::ViewMode mode,
+                CalculatorApp::Common::CategoryGroupType modeType,
+                CalculatorApp::Common::NumberBase programmerNumberBase,
+                CalculatorApp::Common::BitLength bitLengthType);
+        static Windows::Foundation::IAsyncOperation<
+            Platform::String
+            ^> ^ GetStringToPaste(
+                CalculatorApp::Common::ViewMode mode,
+                CalculatorApp::Common::CategoryGroupType modeType,
+                CalculatorApp::Common::NumberBase programmerNumberBase,
+                CalculatorApp::Common::BitLength bitLengthType,
+                bool unsignedMode);
         static bool HasStringToPaste();
         static bool IsErrorMessage(Platform::String ^ message);
         static property unsigned int MaxPasteableLength
@@ -97,11 +109,25 @@ public
                 CalculatorApp::Common::CategoryGroupType modeType,
                 CalculatorApp::Common::NumberBase programmerNumberBase,
                 CalculatorApp::Common::BitLength bitLengthType);
+        static Platform::String
+            ^ ValidatePasteExpression(
+                Platform::String ^ pastedText,
+                CalculatorApp::Common::ViewMode mode,
+                CalculatorApp::Common::CategoryGroupType modeType,
+                CalculatorApp::Common::NumberBase programmerNumberBase,
+                CalculatorApp::Common::BitLength bitLengthType,
+                bool unsignedMode);
         static CopyPasteMaxOperandLengthAndValue GetMaxOperandLengthAndValue(
             CalculatorApp::Common::ViewMode mode,
             CalculatorApp::Common::CategoryGroupType modeType,
             CalculatorApp::Common::NumberBase programmerNumberBase,
             CalculatorApp::Common::BitLength bitLengthType);
+        static CopyPasteMaxOperandLengthAndValue GetMaxOperandLengthAndValue(
+            CalculatorApp::Common::ViewMode mode,
+            CalculatorApp::Common::CategoryGroupType modeType,
+            CalculatorApp::Common::NumberBase programmerNumberBase,
+            CalculatorApp::Common::BitLength bitLengthType,
+            bool unsignedMode);
         static Windows::Foundation::Collections::IVector<
             Platform::String ^> ^ ExtractOperands(Platform::String ^ pasteExpression, CalculatorApp::Common::ViewMode mode);
         static bool ExpressionRegExMatch(
@@ -110,6 +136,13 @@ public
             CalculatorApp::Common::CategoryGroupType modeType,
             CalculatorApp::Common::NumberBase programmerNumberBase,
             CalculatorApp::Common::BitLength bitLengthType);
+        static bool ExpressionRegExMatch(
+            Windows::Foundation::Collections::IVector<Platform::String ^> ^ operands,
+            CalculatorApp::Common::ViewMode mode,
+            CalculatorApp::Common::CategoryGroupType modeType,
+            CalculatorApp::Common::NumberBase programmerNumberBase,
+            CalculatorApp::Common::BitLength bitLengthType,
+            bool unsignedMode);
         static Platform::String ^ SanitizeOperand(Platform::String ^ operand);
         static Platform::String ^ RemoveUnwantedCharsFromString(Platform::String ^ input);
         static Platform::IBox<unsigned long long int> ^ TryOperandToULL(Platform::String ^ operand, CalculatorApp::Common::NumberBase numberBase);
@@ -118,7 +151,7 @@ public
             Platform::String ^ operand,
             CalculatorApp::Common::ViewMode mode,
             CalculatorApp::Common::CategoryGroupType modeType,
-        CalculatorApp::Common::NumberBase programmerNumberBase);
+            CalculatorApp::Common::NumberBase programmerNumberBase);
         static ULONG32 ProgrammerOperandLength(Platform::String ^ operand, CalculatorApp::Common::NumberBase numberBase);
 
     private:

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1464,7 +1464,7 @@ void StandardCalculatorViewModel::Recalculate(bool fromHistory)
 bool StandardCalculatorViewModel::IsOpnd(Command command)
 {
     static constexpr Command opnd[] = { Command::Command0, Command::Command1, Command::Command2, Command::Command3, Command::Command4,  Command::Command5,
-                              Command::Command6, Command::Command7, Command::Command8, Command::Command9, Command::CommandPNT };
+                                        Command::Command6, Command::Command7, Command::Command8, Command::Command9, Command::CommandPNT };
 
     return find(begin(opnd), end(opnd), command) != end(opnd);
 }
@@ -1472,9 +1472,9 @@ bool StandardCalculatorViewModel::IsOpnd(Command command)
 bool StandardCalculatorViewModel::IsUnaryOp(Command command)
 {
     static constexpr Command unaryOp[] = { Command::CommandSQRT,  Command::CommandFAC,  Command::CommandSQR,   Command::CommandLOG,
-                                 Command::CommandPOW10, Command::CommandPOWE, Command::CommandLN,    Command::CommandREC,
-                                 Command::CommandSIGN,  Command::CommandSINH, Command::CommandASINH, Command::CommandCOSH,
-                                 Command::CommandACOSH, Command::CommandTANH, Command::CommandATANH, Command::CommandCUB };
+                                           Command::CommandPOW10, Command::CommandPOWE, Command::CommandLN,    Command::CommandREC,
+                                           Command::CommandSIGN,  Command::CommandSINH, Command::CommandASINH, Command::CommandCOSH,
+                                           Command::CommandACOSH, Command::CommandTANH, Command::CommandATANH, Command::CommandCUB };
 
     if (find(begin(unaryOp), end(unaryOp), command) != end(unaryOp))
     {
@@ -1501,7 +1501,7 @@ bool StandardCalculatorViewModel::IsTrigOp(Command command)
 bool StandardCalculatorViewModel::IsBinOp(Command command)
 {
     static constexpr Command binOp[] = { Command::CommandADD, Command::CommandSUB,  Command::CommandMUL, Command::CommandDIV,
-                               Command::CommandEXP, Command::CommandROOT, Command::CommandMOD, Command::CommandPWR };
+                                         Command::CommandEXP, Command::CommandROOT, Command::CommandMOD, Command::CommandPWR };
 
     return find(begin(binOp), end(binOp), command) != end(binOp);
 }
@@ -1775,6 +1775,20 @@ ViewMode StandardCalculatorViewModel::GetCalculatorMode()
         return ViewMode::Scientific;
     }
     return ViewMode::Programmer;
+}
+
+void StandardCalculatorViewModel::IsUnsigned::set(bool isUnsigned)
+{
+    if (m_isUnsigned != isUnsigned)
+    {
+        m_isUnsigned = isUnsigned;
+        RaisePropertyChanged(L"IsUnsigned");
+
+        if (isUnsigned)
+            ButtonPressed->Execute(NumbersAndOperatorsEnum::Unsigned);
+        else
+            ButtonPressed->Execute(NumbersAndOperatorsEnum::Signed);
+    }
 }
 
 void StandardCalculatorViewModel::ValueBitLength::set(CalculatorApp::Common::BitLength value)

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -708,6 +708,7 @@ void StandardCalculatorViewModel::OnPasteCommand(Object ^ parameter)
     ViewMode mode;
     BitLength bitLengthType = BitLength::BitLengthUnknown;
     NumberBase numberBase = NumberBase::Unknown;
+    bool isUnsigned = false;
     if (IsScientific)
     {
         mode = ViewMode::Scientific;
@@ -717,6 +718,7 @@ void StandardCalculatorViewModel::OnPasteCommand(Object ^ parameter)
         mode = ViewMode::Programmer;
         bitLengthType = m_valueBitLength;
         numberBase = CurrentRadixType;
+        isUnsigned = m_isUnsigned;
     }
     else
     {
@@ -729,7 +731,7 @@ void StandardCalculatorViewModel::OnPasteCommand(Object ^ parameter)
     }
 
     // Ensure that the paste happens on the UI thread
-    create_task(CopyPasteManager::GetStringToPaste(mode, NavCategory::GetGroupType(mode), numberBase, bitLengthType))
+    create_task(CopyPasteManager::GetStringToPaste(mode, NavCategory::GetGroupType(mode), numberBase, bitLengthType, isUnsigned))
         .then([that, mode](String ^ pastedString) { that->OnPaste(pastedString); }, concurrency::task_continuation_context::use_current());
 }
 

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -118,6 +118,15 @@ namespace CalculatorApp
             static property Platform::String
                 ^ IsBitFlipCheckedPropertyName { Platform::String ^ get() { return Platform::StringReference(L"IsBitFlipChecked"); } }
 
+            property bool IsUnsigned
+            {
+                bool get()
+                {
+                    return m_isUnsigned;
+                }
+                void set(bool isUnsigned);
+            }
+
             property CalculatorApp::Common::BitLength ValueBitLength
             {
                 CalculatorApp::Common::BitLength get()
@@ -198,7 +207,7 @@ namespace CalculatorApp
             static property Platform::String
                 ^ IsProgrammerPropertyName { Platform::String ^ get() { return Platform::StringReference(L"IsProgrammer"); } }
 
-            property bool IsEditingEnabled
+                property bool IsEditingEnabled
             {
                 bool get()
                 {
@@ -283,7 +292,7 @@ namespace CalculatorApp
             void SetMemorizedNumbersString();
             void SwitchAngleType(NumbersAndOperatorsEnum num);
             void ResetDisplay();
-          
+
             void SetPrecision(int32_t precision);
             void UpdateMaxIntDigits()
             {
@@ -338,6 +347,7 @@ namespace CalculatorApp
             bool m_isRtlLanguage;
             bool m_operandUpdated;
             bool m_isLastOperationHistoryLoad;
+            bool m_isUnsigned;
             CalculatorApp::Common::BitLength m_valueBitLength;
             Platform::String ^ m_selectedExpressionLastData;
             Common::DisplayExpressionToken ^ m_selectedExpressionToken;

--- a/src/Calculator/Views/CalculatorProgrammerDisplayPanel.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerDisplayPanel.xaml
@@ -20,8 +20,7 @@
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="2*" MaxWidth="160"/>
             <ColumnDefinition Width="0.01*"/>
-            <ColumnDefinition Width="1*" MaxWidth="80"/>
-            <ColumnDefinition Width="1*" MaxWidth="80"/>
+            <ColumnDefinition Width="2*" MaxWidth="160"/>
             <ColumnDefinition Width="1*" MaxWidth="80"/>
             <ColumnDefinition Width="1*" MaxWidth="80"/>
         </Grid.ColumnDefinitions>
@@ -74,44 +73,65 @@
                          IsChecked="{x:Bind Model.IsBitFlipChecked, Mode=TwoWay}"/>
         </Grid>
 
-        <Button x:Name="QwordButton"
+        <Grid x:Uid="DataTypeGroup"
+              Grid.Column="2"
+              AutomationProperties.HeadingLevel="Level1">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="1*" MaxWidth="80"/>
+                <ColumnDefinition Width="1*" MaxWidth="80"/>
+            </Grid.ColumnDefinitions>
+            <Button x:Name="QwordButton"
                 x:Uid="qwordButton"
                 Grid.Column="0"
-                Grid.ColumnSpan="7"
                 Style="{StaticResource ProgWordSizeButtonStyle}"
                 AutomationProperties.AutomationId="qwordButton"
                 Command="{x:Bind BitLengthButtonPressed, Mode=OneTime}"
                 CommandParameter="0"
                 Content="QWORD"/>
-        <Button x:Name="DwordButton"
+            <Button x:Name="DwordButton"
                 x:Uid="dwordButton"
                 Grid.Column="0"
-                Grid.ColumnSpan="7"
                 Style="{StaticResource ProgWordSizeButtonStyle}"
                 AutomationProperties.AutomationId="dwordButton"
                 Command="{x:Bind BitLengthButtonPressed, Mode=OneTime}"
                 CommandParameter="1"
                 Content="DWORD"
                 Visibility="Collapsed"/>
-        <Button x:Name="WordButton"
+            <Button x:Name="WordButton"
                 x:Uid="wordButton"
                 Grid.Column="0"
-                Grid.ColumnSpan="7"
                 Style="{StaticResource ProgWordSizeButtonStyle}"
                 AutomationProperties.AutomationId="wordButton"
                 Command="{x:Bind BitLengthButtonPressed, Mode=OneTime}"
                 CommandParameter="2"
                 Content="WORD"
                 Visibility="Collapsed"/>
-        <Button x:Name="ByteButton"
+            <Button x:Name="ByteButton"
                 x:Uid="byteButton"
                 Grid.Column="0"
-                Grid.ColumnSpan="7"
                 Style="{StaticResource ProgWordSizeButtonStyle}"
                 AutomationProperties.AutomationId="byteButton"
                 Command="{x:Bind BitLengthButtonPressed, Mode=OneTime}"
                 CommandParameter="3"
                 Content="BYTE"
                 Visibility="Collapsed"/>
+            <Button x:Name="SignedButton"
+                x:Uid="signedButton"
+                Grid.Column="1"
+                Style="{StaticResource ProgWordSizeButtonStyle}"
+                AutomationProperties.AutomationId="byteButton"
+                Command="{x:Bind SignednessButtonPressed, Mode=OneTime}"
+                CommandParameter="0"
+                Content="Signed"/>
+            <Button x:Name="UnsignedButton"
+                x:Uid="unsignedButton"
+                Grid.Column="1"
+                Style="{StaticResource ProgWordSizeButtonStyle}"
+                AutomationProperties.AutomationId="byteButton"
+                Command="{x:Bind SignednessButtonPressed, Mode=OneTime}"
+                CommandParameter="1"
+                Content="Unsigned"
+                Visibility="Collapsed"/>
+        </Grid>
     </Grid>
 </UserControl>

--- a/src/Calculator/Views/CalculatorProgrammerDisplayPanel.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerDisplayPanel.xaml
@@ -46,6 +46,8 @@
                         <Setter Target="DwordButton.IsEnabled" Value="False"/>
                         <Setter Target="WordButton.IsEnabled" Value="False"/>
                         <Setter Target="ByteButton.IsEnabled" Value="False"/>
+                        <Setter Target="SignedButton.IsEnabled" Value="False"/>
+                        <Setter Target="UnsignedButton.IsEnabled" Value="False"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>

--- a/src/Calculator/Views/CalculatorProgrammerDisplayPanel.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerDisplayPanel.xaml.cpp
@@ -59,7 +59,27 @@ void CalculatorProgrammerDisplayPanel::OnBitLengthButtonPressed(Object ^ paramet
         QwordButton->Visibility = ::Visibility::Visible;
         QwordButton->Focus(::FocusState::Programmatic);
     }
+}
 
+void CalculatorProgrammerDisplayPanel::OnSignednessButtonPressed(Object ^ parameter)
+{
+    String ^ buttonId = parameter->ToString();
+
+    SignedButton->Visibility = ::Visibility::Collapsed;
+    UnsignedButton->Visibility = ::Visibility::Collapsed;
+
+    if (buttonId == "0")
+    {
+        Model->IsUnsigned = true;
+        UnsignedButton->Visibility = ::Visibility::Visible;
+        UnsignedButton->Focus(::FocusState::Programmatic);
+    }
+    else if (buttonId == "1")
+    {
+        Model->IsUnsigned = false;
+        SignedButton->Visibility = ::Visibility::Visible;
+        SignedButton->Focus(::FocusState::Programmatic);
+    }
 }
 
 bool CalculatorProgrammerDisplayPanel::IsErrorVisualState::get()

--- a/src/Calculator/Views/CalculatorProgrammerDisplayPanel.xaml.h
+++ b/src/Calculator/Views/CalculatorProgrammerDisplayPanel.xaml.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -14,6 +14,7 @@ namespace CalculatorApp
         CalculatorProgrammerDisplayPanel();
 
         COMMAND_FOR_METHOD(BitLengthButtonPressed, CalculatorProgrammerDisplayPanel::OnBitLengthButtonPressed);
+        COMMAND_FOR_METHOD(SignednessButtonPressed, CalculatorProgrammerDisplayPanel::OnSignednessButtonPressed);
 
         property CalculatorApp::ViewModel::StandardCalculatorViewModel^ Model
         {
@@ -31,6 +32,7 @@ namespace CalculatorApp
     private:
         void ShowBitFlip(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void OnBitLengthButtonPressed(Platform::Object ^ parameter);
+        void OnSignednessButtonPressed(Platform::Object ^ parameter);
 
         bool m_isErrorVisualState;
     };

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
@@ -17,6 +17,7 @@
              mc:Ignorable="d">
     <UserControl.Resources>
         <converters:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+        <converters:BooleanNegationConverter x:Key="BooleanNegationConverter"/>
         <converters:BooleanToVisibilityNegationConverter x:Key="BooleanToVisibilityNegationConverter"/>
     </UserControl.Resources>
 
@@ -686,6 +687,7 @@
                                    FontWeight="Normal"
                                    AutomationProperties.AutomationId="negateButton"
                                    ButtonId="Negate"
+                                   IsEnabled="{x:Bind Model.IsUnsigned, Mode=OneWay, Converter={StaticResource BooleanNegationConverter}}"
                                    Content="&#xF898;"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Fixes #66 


### Description of the changes:
- Added signedness toggle to UI
- Updated max values in CalcEngine when in unsigned mode
- Updated max values in CopyPasteManager when in unsigned mode
- Disabled ability to paste negative numbers when in unsigned mode
- Disabled negate button when in unsigned mode

### How changes were validated:
- Manually tested
- Entered values outside of signed int range while in signed and unsigned modes for all bit lengths
- Pasted values outside of signed int range while in signed and unsigned modes for all bit lengths
- Pasted negative numbers while in signed and unsigned modes

Attempted to run automated testing to ensure no functionality was broken but it appears some element IDs have changed and the tests do not work at the moment.

