### PR TITLE
Allow rendering the graph on a background thread

### DIFF
--- a/src/CalcViewModel/GraphingCalculator/VariableViewModel.h
+++ b/src/CalcViewModel/GraphingCalculator/VariableViewModel.h
@@ -47,11 +47,13 @@ public
             {
                 if (value < Min)
                 {
-                    value = Min;
+                    Min = value;
+                    RaisePropertyChanged(L"Min");
                 }
                 else if (value > Max)
                 {
-                    value = Max;
+                    Max = value;
+                    RaisePropertyChanged(L"Max");
                 }
 
                 if (Value != value)

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -319,26 +319,6 @@ void EquationTextBox::OnHasErrorPropertyChanged(bool, bool)
     UpdateCommonVisualState();
 }
 
-Platform::String ^ EquationTextBox::GetEquationText()
-{
-    String ^ text;
-    if (m_richEditBox != nullptr)
-    {
-        // Clear formatting since the graph control doesn't work with bold/underlines
-        ITextRange ^ range = m_richEditBox->TextDocument->GetRange(0, m_richEditBox->TextDocument->Selection->EndPosition);
-
-        if (range != nullptr)
-        {
-            range->CharacterFormat->Bold = FormatEffect::Off;
-            range->CharacterFormat->Underline = UnderlineType::None;
-        }
-
-        text = m_richEditBox->MathText;
-    }
-
-    return text;
-}
-
 void EquationTextBox::SetEquationText(Platform::String ^ equationText)
 {
     if (m_richEditBox != nullptr)

--- a/src/Calculator/Controls/EquationTextBox.h
+++ b/src/Calculator/Controls/EquationTextBox.h
@@ -33,7 +33,6 @@ namespace CalculatorApp
             event Windows::Foundation::EventHandler<MathRichEditBoxFormatRequest ^> ^ EquationFormatRequested;
             event Windows::UI::Xaml::RoutedEventHandler ^ EquationButtonClicked;
 
-            Platform::String ^ GetEquationText();
             void SetEquationText(Platform::String ^ equationText);
             void FocusTextBox();
 

--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -12,6 +12,7 @@ using namespace std;
 using namespace Windows::ApplicationModel;
 using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;
+using namespace Windows::UI::Text;
 using namespace Windows::Foundation::Collections;
 using namespace Windows::System;
 
@@ -178,6 +179,15 @@ void MathRichEditBox::BackSpace()
 
 void MathRichEditBox::SubmitEquation(EquationSubmissionSource source)
 {
+    // Clear formatting since the graph control doesn't work with bold/underlines
+    auto range = this->TextDocument->GetRange(0, this->TextDocument->Selection->EndPosition);
+
+    if (range != nullptr)
+    {
+        range->CharacterFormat->Bold = FormatEffect::Off;
+        range->CharacterFormat->Underline = UnderlineType::None;
+    }
+
     auto newVal = GetMathTextProperty();
     if (MathText != newVal)
     {

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -330,9 +330,6 @@ void EquationInputArea::SubmitTextbox(TextBox ^ sender)
     {
         val = validateDouble(sender->Text, variableViewModel->Value);
         variableViewModel->Value = val;
-
-        // Assign back to val in case it gets changed due to min/max
-        val = variableViewModel->Value;
     }
     else if (sender->Name == "MinTextBox")
     {

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -272,8 +272,8 @@ public
         void OnEquationChanged(Equation ^ equation);
         void OnEquationStyleChanged(Equation ^ equation);
         void OnEquationLineEnabledChanged(Equation ^ equation);
-        bool TryUpdateGraph(bool keepCurrentView);
-        void TryPlotGraph(bool keepCurrentView, bool shouldRetry);
+        concurrency::task<bool> TryUpdateGraph(bool keepCurrentView);
+        concurrency::task<void> TryPlotGraph(bool keepCurrentView, bool shouldRetry);
         void UpdateGraphOptions(Graphing::IGraphingOptions& options, const std::vector<Equation ^>& validEqs);
         std::vector<Equation ^> GetGraphableEquations();
         void SetGraphArgs();

--- a/src/GraphControl/DirectX/RenderMain.h
+++ b/src/GraphControl/DirectX/RenderMain.h
@@ -45,7 +45,14 @@ namespace GraphControl::DX
 
         void CreateWindowSizeDependentResources();
 
-        bool RunRenderPass();
+        bool RunRenderPass(bool mustRun = false);
+
+        bool RunRenderPassAsync();
+
+        Concurrency::critical_section& GetCriticalSection()
+        {
+            return m_criticalSection;
+        }
 
         // Indicates if we are in active tracing mode (the tracing box is being used and controlled through keyboard input)
         property bool ActiveTracing
@@ -98,6 +105,8 @@ namespace GraphControl::DX
 
     private:
         bool Render();
+
+        bool RunRenderPassInternal();
 
         // Loaded/Unloaded
         void OnLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
@@ -162,5 +171,9 @@ namespace GraphControl::DX
 
         // Are we currently showing the tracing value
         bool m_Tracing;
+
+        Concurrency::critical_section m_criticalSection;
+
+         Windows::Foundation::IAsyncAction ^ m_renderPass = nullptr;
     };
 }

--- a/src/GraphControl/DirectX/RenderMain.h
+++ b/src/GraphControl/DirectX/RenderMain.h
@@ -45,13 +45,18 @@ namespace GraphControl::DX
 
         void CreateWindowSizeDependentResources();
 
-        bool RunRenderPass(bool mustRun = false);
+        bool RunRenderPass(bool allowCancel = true);
 
-        bool RunRenderPassAsync();
+        Windows::Foundation::IAsyncAction ^ RunRenderPassAsync(bool allowCancel = true);
 
         Concurrency::critical_section& GetCriticalSection()
         {
             return m_criticalSection;
+        }
+
+        bool IsRenderPassSuccesful()
+        {
+            return m_isRenderPassSuccesful;
         }
 
         // Indicates if we are in active tracing mode (the tracing box is being used and controlled through keyboard input)
@@ -175,5 +180,7 @@ namespace GraphControl::DX
         Concurrency::critical_section m_criticalSection;
 
          Windows::Foundation::IAsyncAction ^ m_renderPass = nullptr;
+
+         bool m_isRenderPassSuccesful;
     };
 }

--- a/src/GraphControl/DirectX/RenderMain.h
+++ b/src/GraphControl/DirectX/RenderMain.h
@@ -45,7 +45,7 @@ namespace GraphControl::DX
 
         void CreateWindowSizeDependentResources();
 
-        bool RunRenderPass(bool allowCancel = true);
+        bool RunRenderPass();
 
         Windows::Foundation::IAsyncAction ^ RunRenderPassAsync(bool allowCancel = true);
 


### PR DESCRIPTION
## Fixes #980.


### Description of the changes:
- Move graph rendering to the background thread
- Allow variable values larger than the min/max to change the min/max instead of resetting
- Fix a bug where the equation box was no longer clearing bold/underline formatting

### How changes were validated:
- Manual tests
-Render m*sin(x*m)+m and drag the variable slider. Notice that the graph renders while the slider moves without stuttering.

