### PR TITLE
Make unit converters stil working when users opened 'Currency' while offline

### DIFF
--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -171,9 +171,6 @@ void UnitConverterViewModel::OnCategoryChanged(Object ^ parameter)
 
 void UnitConverterViewModel::ResetCategory()
 {
-    UCM::Category currentCategory = CurrentCategory->GetModelCategory();
-    IsCurrencyCurrentCategory = currentCategory.id == NavCategory::Serialize(ViewMode::Currency);
-
     m_isInputBlocked = false;
     SetSelectedUnits();
 

--- a/src/CalcViewModel/UnitConverterViewModel.h
+++ b/src/CalcViewModel/UnitConverterViewModel.h
@@ -143,7 +143,6 @@ namespace CalculatorApp
             OBSERVABLE_OBJECT_CALLBACK(OnPropertyChanged);
 
             OBSERVABLE_PROPERTY_R(Windows::Foundation::Collections::IObservableVector<Category ^> ^, Categories);
-            OBSERVABLE_PROPERTY_RW(Category ^, CurrentCategory);
             OBSERVABLE_PROPERTY_RW(CalculatorApp::Common::ViewMode, Mode);
             OBSERVABLE_PROPERTY_R(Windows::Foundation::Collections::IObservableVector<Unit ^> ^, Units);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, CurrencySymbol1);
@@ -164,13 +163,33 @@ namespace CalculatorApp
             OBSERVABLE_PROPERTY_RW(bool, IsDropDownOpen);
             OBSERVABLE_PROPERTY_RW(bool, IsDropDownEnabled);
             OBSERVABLE_NAMED_PROPERTY_RW(bool, IsCurrencyLoadingVisible);
-            OBSERVABLE_PROPERTY_RW(bool, IsCurrencyCurrentCategory);
+            OBSERVABLE_NAMED_PROPERTY_R(bool, IsCurrencyCurrentCategory);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, CurrencyRatioEquality);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, CurrencyRatioEqualityAutomationName);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, CurrencyTimestamp);
             OBSERVABLE_NAMED_PROPERTY_RW(CalculatorApp::NetworkAccessBehavior, NetworkBehavior);
             OBSERVABLE_NAMED_PROPERTY_RW(bool, CurrencyDataLoadFailed);
             OBSERVABLE_NAMED_PROPERTY_RW(bool, CurrencyDataIsWeekOld);
+
+        public:
+            property Category ^ CurrentCategory
+            {
+                Category ^ get() { return m_CurrentCategory; }
+                void set(Category ^ value)
+                {
+                    if (m_CurrentCategory == value)
+                    {
+                        return;
+                    }
+                    m_CurrentCategory = value;
+                    if (value != nullptr)
+                    {
+                        auto currentCategory = value->GetModelCategory();
+                        IsCurrencyCurrentCategory = currentCategory.id == CalculatorApp::Common::NavCategory::Serialize(CalculatorApp::Common::ViewMode::Currency);
+                    }
+                    OnPropertyChanged("CurrentCategory");
+                }
+            }
 
             property Windows::UI::Xaml::Visibility SupplementaryVisibility
             {
@@ -321,7 +340,7 @@ namespace CalculatorApp
             std::wstring m_lastAnnouncedFrom;
             std::wstring m_lastAnnouncedTo;
             Platform::String ^ m_lastAnnouncedConversionResult;
-
+            Category ^ m_CurrentCategory;
             bool m_isCurrencyDataLoaded;
         };
 

--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -32,11 +32,13 @@
                        TextWrapping="NoWrap"/>
         </DataTemplate>
 
-        <DataTemplate x:Key="SelectedUnitTemplate" x:DataType="vm:Unit">
+        <!-- Native bindings can't be use with this template, it will launch an exception when ComboxBox.SelectedItem == null -->
+        <!-- if you switch between modes when no currencies are available for example) -->
+        <DataTemplate x:Key="SelectedUnitTemplate">
             <TextBlock Style="{ThemeResource BodyTextBlockStyle}"
                        FontWeight="SemiBold"
-                       AutomationProperties.Name="{x:Bind AccessibleName}"
-                       Text="{x:Bind Name}"
+                       AutomationProperties.Name="{Binding AccessibleName, Mode=OneTime, FallbackValue=''}"
+                       Text="{Binding Name, Mode=OneTime, FallbackValue=''}"
                        TextWrapping="NoWrap"/>
         </DataTemplate>
 
@@ -440,9 +442,9 @@
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
-            <VisualStateGroup x:Name="CurrencyLoadingStates">
+            <VisualStateGroup x:Name="UnitLoadedStates">
                 <VisualStateGroup.Transitions>
-                    <VisualTransition From="CurrencyLoadingState" To="CurrencyLoadedState">
+                    <VisualTransition From="UnitNotLoadedState" To="UnitLoadedState">
                         <Storyboard>
                             <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Units1" Storyboard.TargetProperty="Visibility">
                                 <DiscreteObjectKeyFrame KeyTime="0:0:0" Value="Visible"/>
@@ -489,7 +491,7 @@
                         </Storyboard>
                     </VisualTransition>
                 </VisualStateGroup.Transitions>
-                <VisualState x:Name="CurrencyLoadingState">
+                <VisualState x:Name="UnitNotLoadedState">
                     <VisualState.Setters>
                         <Setter Target="CurrencyRatioEqualityBlock.Opacity" Value="0"/>
                         <Setter Target="CurrencyTimestampTextBlock.Opacity" Value="0"/>
@@ -500,17 +502,7 @@
                         <Setter Target="Value2Container.Visibility" Value="Collapsed"/>
                     </VisualState.Setters>
                 </VisualState>
-                <VisualState x:Name="CurrencyLoadedState">
-                    <VisualState.Setters>
-                        <Setter Target="CurrencyRatioEqualityBlock.Opacity" Value="1"/>
-                        <Setter Target="CurrencyTimestampTextBlock.Opacity" Value="1"/>
-                        <Setter Target="CurrencyLoadingGrid.Visibility" Value="Collapsed"/>
-                        <Setter Target="Units1.Visibility" Value="Visible"/>
-                        <Setter Target="Value1Container.Visibility" Value="Visible"/>
-                        <Setter Target="Units2.Visibility" Value="Visible"/>
-                        <Setter Target="Value2Container.Visibility" Value="Visible"/>
-                    </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="UnitLoadedState"/>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
@@ -576,12 +568,12 @@
                   DropDownClosed="UpdateDropDownState"
                   DropDownOpened="UpdateDropDownState"
                   FlowDirection="{x:Bind LayoutDirection}"
-                  IsEnabled="{Binding IsDropDownEnabled}"
                   IsEnabledChanged="Units1_IsEnabledChanged"
                   ItemTemplate="{StaticResource UnitTemplate}"
                   ItemsSource="{Binding Units, Converter={StaticResource AlwaysSelectedConverter}}"
                   SelectedItem="{Binding Unit1, Mode=TwoWay, Converter={StaticResource ValidSelectedItemConverter}}"
-                  TabIndex="2"/>
+                  TabIndex="2"
+                  IsEnabled="{Binding IsDropDownEnabled}"/>
 
         <Grid x:Name="Value2Container"
               Grid.Row="3"
@@ -626,11 +618,11 @@
                   DropDownClosed="UpdateDropDownState"
                   DropDownOpened="UpdateDropDownState"
                   FlowDirection="{x:Bind LayoutDirection}"
-                  IsEnabled="{Binding IsDropDownEnabled}"
                   ItemTemplate="{StaticResource UnitTemplate}"
                   ItemsSource="{Binding Units, Converter={StaticResource AlwaysSelectedConverter}}"
                   SelectedItem="{Binding Unit2, Mode=TwoWay, Converter={StaticResource ValidSelectedItemConverter}}"
-                  TabIndex="4"/>
+                  TabIndex="4"
+                  IsEnabled="{Binding IsDropDownEnabled}"/>
 
         <StackPanel x:Name="SupplementaryResultsPanelInGrid"
                     Grid.Row="5"

--- a/src/Calculator/Views/UnitConverter.xaml.cpp
+++ b/src/Calculator/Views/UnitConverter.xaml.cpp
@@ -81,7 +81,9 @@ void UnitConverter::OnPropertyChanged(_In_ Object ^ sender, _In_ PropertyChanged
     {
         SetCurrencyTimestampFontWeight();
     }
-    else if (propertyName == UnitConverterViewModel::IsCurrencyLoadingVisiblePropertyName)
+    else if (
+        propertyName == UnitConverterViewModel::IsCurrencyLoadingVisiblePropertyName
+        || propertyName == UnitConverterViewModel::IsCurrencyCurrentCategoryPropertyName)
     {
         OnIsDisplayVisibleChanged();
     }
@@ -318,18 +320,21 @@ void UnitConverter::Units1_IsEnabledChanged(Object ^ sender, DependencyPropertyC
 
 void UnitConverter::OnIsDisplayVisibleChanged()
 {
-    if (Model->IsCurrencyLoadingVisible)
+    if (!Model->IsCurrencyCurrentCategory)
     {
-        VisualStateManager::GoToState(this, L"CurrencyLoadingState", false);
-        StartProgressRingWithDelay();
+        VisualStateManager::GoToState(this, UnitLoadedState->Name, false);
     }
     else
     {
-        HideProgressRing();
-
-        if (Model->IsCurrencyCurrentCategory && !Model->CurrencyTimestamp->IsEmpty())
+        if (Model->IsCurrencyLoadingVisible)
         {
-            VisualStateManager::GoToState(this, L"CurrencyLoadedState", true);
+            VisualStateManager::GoToState(this, UnitNotLoadedState->Name, false);
+            StartProgressRingWithDelay();
+        }
+        else
+        {
+            HideProgressRing();
+            VisualStateManager::GoToState(this, !Model->CurrencyTimestamp->IsEmpty() ? UnitLoadedState->Name : UnitNotLoadedState->Name, true);
         }
     }
 }


### PR DESCRIPTION
## Fixes #973


### Description of the changes:
- Modify how `UnitConverter.xaml` manages its visual state
- Modify how `UnitConverterViewModel` manages `IsCurrencyCurrentCategory` to be sure to always match be up to date
- Fix crashes related to SelectedUnitTemplate when no units are selected.

### How changes were validated:
- manually

