### PR TITLE
Make it clear to both compilers and programmers the end result of ResolveRuntimeWindowService is to return a service object

### DIFF
--- a/src/Calculator/WindowFrameService.cpp
+++ b/src/Calculator/WindowFrameService.cpp
@@ -154,14 +154,12 @@ namespace CalculatorApp
     {
         auto service = TryResolveRuntimeWindowService(serviceId);
 
-        if (service)
-        {
-            return service;
-        }
-        else
+        if (!service)
         {
             throw ref new InvalidArgumentException(serviceId.Name + L" not found");
         }
+        
+        return service;
     }
 
     _Ret_maybenull_ Object ^ WindowFrameService::TryResolveRuntimeWindowService(TypeName serviceId)


### PR DESCRIPTION
## Fixes #.


### Description of the changes:
- Stylistic change to match the fact the other functions have throw in the if block, not outside of it.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual, automatic

