### PR TITLE
No need to make an Visibility variable if it is either one of two possibilities

### DIFF
--- a/src/Calculator/Converters/VisibilityNegationConverter.cpp
+++ b/src/Calculator/Converters/VisibilityNegationConverter.cpp
@@ -16,12 +16,11 @@ namespace CalculatorApp
         Object ^ VisibilityNegationConverter::Convert(Object ^ value, TypeName /*targetType*/, Object ^ /*parameter*/, String ^ /*language*/)
         {
             auto boxedVisibility = dynamic_cast<Box<Visibility> ^>(value);
-            Visibility visibility = Visibility::Collapsed;
             if (boxedVisibility != nullptr && boxedVisibility->Value == Visibility::Collapsed)
             {
-                visibility = Visibility::Visible;
+                return Visibility::Visible;
             }
-            return visibility;
+            return Visibility::Collapsed;
         }
 
         Object ^ VisibilityNegationConverter::ConvertBack(Object ^ value, TypeName targetType, Object ^ parameter, String ^ language)


### PR DESCRIPTION
Visibility variable holding collapsed but then turning into visible is unnecessary when one can return Visibility::Collapsed or Visibility::Visible.

## Fixes #.


### Description of the changes:
- Removed Visibility local variable
- Replaced with returning Visibility::Collasped or Visibility::Visible

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual
- Automated

