### PR TITLE
Fix crash when tabbing through KGF

### DIFF
--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -111,7 +111,10 @@ void MathRichEditBox::SetMathTextProperty(String ^ newValue)
 
 void CalculatorApp::Controls::MathRichEditBox::OnLosingFocus(Windows::UI::Xaml::UIElement ^ sender, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ args)
 {
-    SubmitEquation(EquationSubmissionSource::FOCUS_LOST);
+    if (!IsReadOnly)
+    {
+        SubmitEquation(EquationSubmissionSource::FOCUS_LOST);
+    }
 }
 
 void CalculatorApp::Controls::MathRichEditBox::OnKeyUp(Platform::Object ^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e)

--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -111,7 +111,7 @@ void MathRichEditBox::SetMathTextProperty(String ^ newValue)
 
 void CalculatorApp::Controls::MathRichEditBox::OnLosingFocus(Windows::UI::Xaml::UIElement ^ sender, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ args)
 {
-    if (!IsReadOnly)
+    if (!this->IsReadOnly)
     {
         SubmitEquation(EquationSubmissionSource::FOCUS_LOST);
     }


### PR DESCRIPTION
## Fixes #1033


### Description of the changes:
- Check if textbox is read only before trying to submit an equation on focus lost

### How changes were validated:
- Manual test

