### PR TITLE
No need for else after break

### DIFF
--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -361,11 +361,9 @@ wstring UnitConverter::Unquote(wstring_view s)
                 // Badly formatted
                 break;
             }
-            else
-            {
-                quotedSubString += *cursor;
-                unquotedString += unquoteConversions[quotedSubString];
-            }
+
+            quotedSubString += *cursor;
+            unquotedString += unquoteConversions[quotedSubString];
         }
         else
         {


### PR DESCRIPTION
## Fixes #.


### Description of the changes:
- There is no need to have an else statement after an if statement that only contains a break command.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual
- Automated