### PR TITLE
Check for ctrl when navigating to handle AltGr

### DIFF
--- a/src/Calculator/Common/KeyboardShortcutManager.cpp
+++ b/src/Calculator/Common/KeyboardShortcutManager.cpp
@@ -642,6 +642,13 @@ void KeyboardShortcutManager::OnAcceleratorKeyActivated(CoreDispatcher ^, Accele
             return;
         }
 
+        // Ctrl is pressed in addition to alt, this means Alt Gr is intended.  do not navigate.
+        if ((static_cast<short>(Window::Current->CoreWindow->GetKeyState(VirtualKey::Control)) & static_cast<short>(CoreVirtualKeyStates::Down))
+            == static_cast<short>(CoreVirtualKeyStates::Down))
+        {
+            return;
+        }
+
         const auto& lookupMap = GetCurrentKeyDictionary(static_cast<MyVirtualKey>(key), altPressed);
         auto listItems = lookupMap.equal_range(static_cast<MyVirtualKey>(key));
         for (auto listIterator = listItems.first; listIterator != listItems.second; ++listIterator)


### PR DESCRIPTION
## Fixes #1009 .

Detect Ctrl when handling accelerator shortcuts to avoid Alt Gr triggering navigation
### Description of the changes:
- Checks for ctlr being pressed when handling nav bar shortcut

### How changes were validated:
manually
