### PR TITLE
Support other locales for decimal and list separators

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -74,6 +74,8 @@ GraphingCalculator::GraphingCalculator()
     // Update where the pointer value is (ie: where the user cursor from keyboard inputs moves the point to)
     GraphingControl->PointerValueChangedEvent += ref new PointerValueChangedEventHandler(this, &GraphingCalculator::OnPointerPointChanged);
 
+    GraphingControl->UseCommaDecimalSeperator = LocalizationSettings::GetInstance().GetDecimalSeparator() == ',';
+
     // OemMinus and OemAdd aren't declared in the VirtualKey enum, we can't add this accelerator XAML-side
     auto virtualKey = ref new KeyboardAccelerator();
     virtualKey->Key = (VirtualKey)189; // OemPlus key

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.cpp
@@ -9,6 +9,7 @@
 #include "Controls/MathRichEditBox.h"
 
 using namespace CalculatorApp;
+using namespace CalculatorApp::Common;
 
 using namespace Platform;
 using namespace Windows::Foundation;
@@ -60,9 +61,9 @@ static const std::unordered_map<NumbersAndOperatorsEnum, std::tuple<Platform::St
     { NumbersAndOperatorsEnum::LogBaseE, { L"ln()", 3, 0 } },
     { NumbersAndOperatorsEnum::Sqrt, { L"sqrt()", 5, 0 } },
     { NumbersAndOperatorsEnum::CubeRoot, { L"cbrt()", 5, 0 } },
-    { NumbersAndOperatorsEnum::YRootX, { L"root(x,n)", 7, 1 } },
+    { NumbersAndOperatorsEnum::YRootX, { L"root(x" + StringReference(LocalizationSettings::GetInstance().GetListSeparator().data()) + L"n)", 7, 1 } },
     { NumbersAndOperatorsEnum::TwoPowerX, { L"2^", 2, 0 } },
-    { NumbersAndOperatorsEnum::LogBaseX, { L"log(b, x)", 4, 1 } },
+    { NumbersAndOperatorsEnum::LogBaseX, { "log(b" + StringReference(LocalizationSettings::GetInstance().GetListSeparator().data()) + L" x)", 4, 1 } },
     { NumbersAndOperatorsEnum::EPowerX, { L"e^", 4, 0 } },
     { NumbersAndOperatorsEnum::Abs, { L"abs()", 4, 0 } },
     { NumbersAndOperatorsEnum::X, { L"x", 1, 0 } },
@@ -90,13 +91,13 @@ static const std::unordered_map<NumbersAndOperatorsEnum, std::tuple<Platform::St
     { NumbersAndOperatorsEnum::Seven, { L"7", 1, 0 } },
     { NumbersAndOperatorsEnum::Eight, { L"8", 1, 0 } },
     { NumbersAndOperatorsEnum::Nine, { L"9", 1, 0 } },
-    { NumbersAndOperatorsEnum::Decimal, { L".", 1, 0 } },
+    { NumbersAndOperatorsEnum::Decimal, { StringReference(LocalizationSettings::GetInstance().GetDecimalSeparatorStr().data()), 1, 0 } },
 };
 
 GraphingNumPad::GraphingNumPad()
 {
     InitializeComponent();
-    const auto& localizationSettings = CalculatorApp::Common::LocalizationSettings::GetInstance();
+    const auto& localizationSettings = LocalizationSettings::GetInstance();
     DecimalSeparatorButton->Content = localizationSettings.GetDecimalSeparator();
     Num0Button->Content = localizationSettings.GetDigitSymbolFromEnUsDigit('0');
     Num1Button->Content = localizationSettings.GetDigitSymbolFromEnUsDigit('1');

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -518,7 +518,7 @@ namespace GraphControl
         else
         {
             m_solver->ParsingOptions().SetLocalizationType(::LocalizationType::DecimalPointAndListComma);
-            m_solver->FormatOptions().SetLocalizationType(::LocalizationType::DecimalCommaAndListSemicolon);
+            m_solver->FormatOptions().SetLocalizationType(::LocalizationType::DecimalPointAndListComma);
         }
     }
 

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -29,6 +29,7 @@ using namespace Windows::UI::Xaml::Media;
 using namespace GraphControl;
 
 DEPENDENCY_PROPERTY_INITIALIZATION(Grapher, ForceProportionalAxes);
+DEPENDENCY_PROPERTY_INITIALIZATION(Grapher, UseCommaDecimalSeperator);
 DEPENDENCY_PROPERTY_INITIALIZATION(Grapher, Variables);
 DEPENDENCY_PROPERTY_INITIALIZATION(Grapher, Equations);
 DEPENDENCY_PROPERTY_INITIALIZATION(Grapher, AxesColor);
@@ -279,7 +280,14 @@ namespace GraphControl
 
                     if (numValidEquations++ > 0)
                     {
-                        request += L"<mo>,</mo>";
+                        if (!UseCommaDecimalSeperator)
+                        {
+                            request += L"<mo>,</mo>";
+                        }
+                        else
+                        {
+                            request += L"<mo>;</mo>";
+                        }
                     }
                     auto equationRequest = eq->GetRequest()->Data();
 
@@ -498,6 +506,20 @@ namespace GraphControl
     {
         m_calculatedForceProportional = newValue;
         TryUpdateGraph(false);
+    }
+
+    void Grapher::OnUseCommaDecimalSeperatorPropertyChanged(bool oldValue, bool newValue)
+    {
+        if (newValue)
+        {
+            m_solver->ParsingOptions().SetLocalizationType(::LocalizationType::DecimalCommaAndListSemicolon);
+            m_solver->FormatOptions().SetLocalizationType(::LocalizationType::DecimalCommaAndListSemicolon);
+        }
+        else
+        {
+            m_solver->ParsingOptions().SetLocalizationType(::LocalizationType::DecimalPointAndListComma);
+            m_solver->FormatOptions().SetLocalizationType(::LocalizationType::DecimalCommaAndListSemicolon);
+        }
     }
 
     void Grapher::OnPointerEntered(PointerRoutedEventArgs ^ e)

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -38,6 +38,7 @@ public
 
         DEPENDENCY_PROPERTY_OWNER(Grapher);
         DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(bool, ForceProportionalAxes, true);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(bool, UseCommaDecimalSeperator, false);
         DEPENDENCY_PROPERTY_WITH_DEFAULT(
             SINGLE_ARG(Windows::Foundation::Collections::IObservableMap<Platform::String ^, double> ^),
             Variables,
@@ -266,6 +267,7 @@ public
 
     private:
         void OnForceProportionalAxesPropertyChanged(bool oldValue, bool newValue);
+        void OnUseCommaDecimalSeperatorPropertyChanged(bool oldValue, bool newValue);
         void OnEquationsPropertyChanged(EquationCollection ^ oldValue, EquationCollection ^ newValue);
         void OnAxesColorPropertyChanged(Windows::UI::Color oldValue, Windows::UI::Color newValue);
         void OnGraphBackgroundPropertyChanged(Windows::UI::Color oldValue, Windows::UI::Color newValue);

--- a/src/GraphingImpl/Mocks/MathSolver.h
+++ b/src/GraphingImpl/Mocks/MathSolver.h
@@ -13,6 +13,10 @@ namespace MockGraphingImpl
         void SetFormatType(Graphing::FormatType type) override
         {
         }
+
+        void SetLocalizationType(Graphing::LocalizationType value) override
+        {
+        }
     };
 
     class EvalOptions : public Graphing::IEvalOptions
@@ -44,6 +48,10 @@ namespace MockGraphingImpl
         }
 
         void SetMathMLPrefix(const std::wstring& value) override
+        {
+        }
+
+        void SetLocalizationType(Graphing::LocalizationType value) override
         {
         }
     };

--- a/src/GraphingInterfaces/IMathSolver.h
+++ b/src/GraphingInterfaces/IMathSolver.h
@@ -50,7 +50,7 @@ namespace Graphing
         virtual ~IFormatOptions() = default;
 
         virtual void SetFormatType(FormatType type) = 0;
-		virtual void SetMathMLPrefix(const std::wstring& value) = 0;
+        virtual void SetMathMLPrefix(const std::wstring& value) = 0;
         virtual void SetLocalizationType(LocalizationType value) = 0;
     };
 

--- a/src/GraphingInterfaces/IMathSolver.h
+++ b/src/GraphingInterfaces/IMathSolver.h
@@ -34,6 +34,7 @@ namespace Graphing
         virtual ~IParsingOptions() = default;
 
         virtual void SetFormatType(FormatType type) = 0;
+        virtual void SetLocalizationType(LocalizationType value) = 0;
     };
 
     struct IEvalOptions : public NonCopyable, public NonMoveable
@@ -50,6 +51,7 @@ namespace Graphing
 
         virtual void SetFormatType(FormatType type) = 0;
 		virtual void SetMathMLPrefix(const std::wstring& value) = 0;
+        virtual void SetLocalizationType(LocalizationType value) = 0;
     };
 
     struct IMathSolver : public NonCopyable, public NonMoveable


### PR DESCRIPTION
## Fixes #1052


### Description of the changes:
- Updates our logic to account for locales that use a comma as a decimal and semi-colon as a list separator 

### How changes were validated:
- Manual tests

