### PR TITLE
Support regular textbox context menu functions in the EquationTextBox

### DIFF
--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -44,6 +44,11 @@ void EquationTextBox::OnApplyTemplate()
     m_kgfEquationMenuItem = dynamic_cast<MenuFlyoutItem ^>(GetTemplateChild("FunctionAnalysisMenuItem"));
     m_removeMenuItem = dynamic_cast<MenuFlyoutItem ^>(GetTemplateChild("RemoveFunctionMenuItem"));
     m_colorChooserMenuItem = dynamic_cast<MenuFlyoutItem ^>(GetTemplateChild("ChangeFunctionStyleMenuItem"));
+    m_cutMenuItem = dynamic_cast<MenuFlyoutItem ^>(GetTemplateChild("CutMenuItem"));
+    m_copyMenuItem = dynamic_cast<MenuFlyoutItem ^>(GetTemplateChild("CopyMenuItem"));
+    m_pasteMenuItem = dynamic_cast<MenuFlyoutItem ^>(GetTemplateChild("PasteMenuItem"));
+    m_undoMenuItem = dynamic_cast<MenuFlyoutItem ^>(GetTemplateChild("UndoMenuItem"));
+    m_selectAllMenuItem = dynamic_cast<MenuFlyoutItem ^>(GetTemplateChild("SelectAllMenuItem"));
 
     auto resProvider = AppResourceProvider::GetInstance();
 
@@ -65,7 +70,8 @@ void EquationTextBox::OnApplyTemplate()
 
         auto equationButtonMessage = LocalizationStringUtil::GetLocalizedString(
             m_equationButton->IsChecked->Value ? resProvider->GetResourceString(L"showEquationButtonToolTip")
-                                               : resProvider->GetResourceString(L"hideEquationButtonToolTip"), EquationButtonContentIndex);
+                                               : resProvider->GetResourceString(L"hideEquationButtonToolTip"),
+            EquationButtonContentIndex);
 
         toolTip->Content = equationButtonMessage;
         ToolTipService::SetToolTip(m_equationButton, toolTip);
@@ -120,6 +126,31 @@ void EquationTextBox::OnApplyTemplate()
     {
         ColorChooserFlyout->Opened += ref new EventHandler<Object ^>(this, &EquationTextBox::OnColorFlyoutOpened);
         ColorChooserFlyout->Closed += ref new EventHandler<Object ^>(this, &EquationTextBox::OnColorFlyoutClosed);
+    }
+
+    if (m_cutMenuItem != nullptr)
+    {
+        m_cutMenuItem->Click += ref new RoutedEventHandler(this, &EquationTextBox::OnCutClicked);
+    }
+
+    if (m_copyMenuItem != nullptr)
+    {
+        m_copyMenuItem->Click += ref new RoutedEventHandler(this, &EquationTextBox::OnCopyClicked);
+    }
+
+    if (m_pasteMenuItem != nullptr)
+    {
+        m_pasteMenuItem->Click += ref new RoutedEventHandler(this, &EquationTextBox::OnPasteClicked);
+    }
+
+    if (m_undoMenuItem != nullptr)
+    {
+        m_undoMenuItem->Click += ref new RoutedEventHandler(this, &EquationTextBox::OnUndoClicked);
+    }
+
+    if (m_selectAllMenuItem != nullptr)
+    {
+        m_selectAllMenuItem->Click += ref new RoutedEventHandler(this, &EquationTextBox::OnSelectAllClicked);
     }
 
     UpdateCommonVisualState();
@@ -208,7 +239,8 @@ void EquationTextBox::OnEquationButtonClicked(Object ^ sender, RoutedEventArgs ^
 
     auto equationButtonMessage = LocalizationStringUtil::GetLocalizedString(
         m_equationButton->IsChecked->Value ? resProvider->GetResourceString(L"showEquationButtonToolTip")
-                                           : resProvider->GetResourceString(L"hideEquationButtonToolTip"), EquationButtonContentIndex);
+                                           : resProvider->GetResourceString(L"hideEquationButtonToolTip"),
+        EquationButtonContentIndex);
 
     toolTip->Content = equationButtonMessage;
     ToolTipService::SetToolTip(m_equationButton, toolTip);
@@ -254,6 +286,46 @@ void EquationTextBox::OnColorChooserButtonClicked(Object ^ sender, RoutedEventAr
 void EquationTextBox::OnFunctionButtonClicked(Object ^ sender, RoutedEventArgs ^ e)
 {
     KeyGraphFeaturesButtonClicked(this, ref new RoutedEventArgs());
+}
+
+void EquationTextBox::OnCutClicked(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (m_richEditBox != nullptr)
+    {
+        m_richEditBox->TextDocument->Selection->Cut();
+    }
+}
+
+void EquationTextBox::OnCopyClicked(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (m_richEditBox != nullptr)
+    {
+        m_richEditBox->TextDocument->Selection->Copy();
+    }
+}
+
+void EquationTextBox::OnPasteClicked(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (m_richEditBox != nullptr)
+    {
+        m_richEditBox->TextDocument->Selection->Paste(0);
+    }
+}
+
+void EquationTextBox::OnSelectAllClicked(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (m_richEditBox != nullptr)
+    {
+        m_richEditBox->TextDocument->Selection->SetRange(0, m_richEditBox->TextDocument->Selection->EndPosition);
+    }
+}
+
+void EquationTextBox::OnUndoClicked(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (m_richEditBox != nullptr)
+    {
+        m_richEditBox->TextDocument->Undo();
+    }
 }
 
 void EquationTextBox::UpdateButtonsVisualState()
@@ -354,6 +426,26 @@ void EquationTextBox::OnRichEditMenuOpening(Object ^ /*sender*/, Object ^ /*args
     if (m_colorChooserMenuItem != nullptr)
     {
         m_colorChooserMenuItem->IsEnabled = !HasError && !IsAddEquationMode;
+    }
+
+    if (m_richEditBox != nullptr && m_cutMenuItem != nullptr)
+    {
+        m_cutMenuItem->IsEnabled = m_richEditBox->TextDocument->CanCopy();
+    }
+
+    if (m_richEditBox != nullptr && m_copyMenuItem != nullptr)
+    {
+        m_copyMenuItem->IsEnabled = m_richEditBox->TextDocument->CanCopy();
+    }
+
+    if (m_richEditBox != nullptr && m_pasteMenuItem != nullptr)
+    {
+        m_pasteMenuItem->IsEnabled = m_richEditBox->TextDocument->CanPaste();
+    }
+
+    if (m_richEditBox != nullptr && m_undoMenuItem != nullptr)
+    {
+        m_undoMenuItem->IsEnabled = m_richEditBox->TextDocument->CanUndo();
     }
 }
 

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -430,12 +430,12 @@ void EquationTextBox::OnRichEditMenuOpened(Object ^ /*sender*/, Object ^ /*args*
 
     if (m_richEditBox != nullptr && m_cutMenuItem != nullptr)
     {
-        m_cutMenuItem->IsEnabled = m_richEditBox->TextDocument->CanCopy();
+        m_cutMenuItem->IsEnabled = m_richEditBox->TextDocument->CanCopy() && m_richEditBox->TextDocument->Selection->Length > 0;
     }
 
     if (m_richEditBox != nullptr && m_copyMenuItem != nullptr)
     {
-        m_copyMenuItem->IsEnabled = m_richEditBox->TextDocument->CanCopy();
+        m_copyMenuItem->IsEnabled = m_richEditBox->TextDocument->CanCopy() && m_richEditBox->TextDocument->Selection->Length > 0;
     }
 
     if (m_richEditBox != nullptr && m_pasteMenuItem != nullptr)

--- a/src/Calculator/Controls/EquationTextBox.h
+++ b/src/Calculator/Controls/EquationTextBox.h
@@ -60,6 +60,12 @@ namespace CalculatorApp
             void OnFunctionButtonClicked(Platform::Object^ sender, Windows::UI::Xaml::RoutedEventArgs^ e);
             void OnRichEditMenuOpening(Platform::Object ^ sender, Platform::Object ^ args);
 
+            void OnCutClicked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+            void OnCopyClicked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+            void OnPasteClicked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+            void OnUndoClicked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+            void OnSelectAllClicked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+
             void OnColorFlyoutOpened(Platform::Object ^ sender, Platform::Object ^ e);
             void OnColorFlyoutClosed(Platform::Object ^ sender, Platform::Object ^ e);
 
@@ -73,6 +79,11 @@ namespace CalculatorApp
             Windows::UI::Xaml::Controls::Primitives::ToggleButton ^ m_colorChooserButton;
 
             Windows::UI::Xaml::Controls::MenuFlyout^ m_richEditContextMenu;
+            Windows::UI::Xaml::Controls::MenuFlyoutItem ^ m_cutMenuItem;
+            Windows::UI::Xaml::Controls::MenuFlyoutItem ^ m_copyMenuItem;
+            Windows::UI::Xaml::Controls::MenuFlyoutItem ^ m_pasteMenuItem;
+            Windows::UI::Xaml::Controls::MenuFlyoutItem ^ m_undoMenuItem;
+            Windows::UI::Xaml::Controls::MenuFlyoutItem ^ m_selectAllMenuItem;
             Windows::UI::Xaml::Controls::MenuFlyoutItem^ m_kgfEquationMenuItem;
             Windows::UI::Xaml::Controls::MenuFlyoutItem^ m_removeMenuItem;
             Windows::UI::Xaml::Controls::MenuFlyoutItem^ m_colorChooserMenuItem;

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4258,4 +4258,24 @@
     <value>Enter an equation</value>
     <comment>this is the placeholder text used by the textbox to enter an equation</comment>
   </data>
+  <data name="cutEquationMenuItem.Text" xml:space="preserve">
+    <value>Cut</value>
+    <comment>Cut menu item from the Equation TextBox</comment>
+  </data>
+  <data name="copyEquationMenuItem.Text" xml:space="preserve">
+    <value>Copy</value>
+    <comment>Copy menu item from the Equation TextBox</comment>
+  </data>
+  <data name="pasteEquationMenuItem.Text" xml:space="preserve">
+    <value>Paste</value>
+    <comment>Paste menu item from the Equation TextBox</comment>
+  </data>
+  <data name="undoEquationMenuItem.Text" xml:space="preserve">
+    <value>Undo</value>
+    <comment>Undo menu item from the Equation TextBox</comment>
+  </data>
+  <data name="selectAllEquationMenuItem.Text" xml:space="preserve">
+    <value>Select All</value>
+    <comment>Select all menu item from the Equation TextBox</comment>
+  </data>
 </root>

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -582,6 +582,20 @@
                                                                   TextWrapping="NoWrap">
                                             <controls:MathRichEditBox.ContextFlyout>
                                                 <MenuFlyout x:Name="MathRichEditContextMenu">
+                                                    <MenuFlyoutItem x:Name="CutMenuItem"
+                                                                    x:Uid="cutEquationMenuItem"
+                                                                    Icon="Cut"/>
+                                                    <MenuFlyoutItem x:Name="CopyMenuItem"
+                                                                    x:Uid="copyEquationMenuItem"
+                                                                    Icon="Copy"/>
+                                                    <MenuFlyoutItem x:Name="PasteMenuItem"
+                                                                    x:Uid="pasteEquationMenuItem"
+                                                                    Icon="Paste"/>
+                                                    <MenuFlyoutItem x:Name="UndoMenuItem"
+                                                                    x:Uid="undoEquationMenuItem"
+                                                                    Icon="Undo"/>
+                                                    <MenuFlyoutItem x:Name="SelectAllMenuItem" x:Uid="selectAllEquationMenuItem"/>
+                                                    <MenuFlyoutSeparator/>
                                                     <MenuFlyoutItem x:Name="FunctionAnalysisMenuItem">
                                                         <MenuFlyoutItem.Icon>
                                                             <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xE3B5;"/>


### PR DESCRIPTION
## Fixes #978


### Description of the changes:
Since [TextCommandBarFlyout](https://docs.microsoft.com/en-us/windows/uwp/design/controls-and-patterns/command-bar-flyout#command-bar-flyouts-for-text-controls) is not customizable and we have added custom menu items, we need to manually wire up all of the basic text commands.

Added these items that are normally present in the RichEditBox context menu: cut, copy, paste, undo, select all.
### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual tests

