### PR TITLE
Fix some code analysis warnings in CalcManager

### DIFF
--- a/src/CalcManager/CEngine/History.cpp
+++ b/src/CalcManager/CEngine/History.cpp
@@ -210,7 +210,7 @@ bool CHistoryCollector::FOpndAddedToHistory()
 // This is does the postfix to prefix translation of the input and adds the text to the history. Eg. doing 2 + 4 (sqrt),
 // this routine will ensure the last sqrt call unary operator, actually goes back in history and wraps 4 in sqrt(4)
 //
-void CHistoryCollector::AddUnaryOpToHistory(int nOpCode, bool fInv, ANGLE_TYPE angletype)
+void CHistoryCollector::AddUnaryOpToHistory(int nOpCode, bool fInv, AngleType angletype)
 {
     int iCommandEnd;
     // When successfully applying a unary op, there should be an opnd already
@@ -230,15 +230,15 @@ void CHistoryCollector::AddUnaryOpToHistory(int nOpCode, bool fInv, ANGLE_TYPE a
         else
         {
             CalculationManager::Command angleOpCode;
-            if (angletype == ANGLE_DEG)
+            if (angletype == AngleType::Degrees)
             {
                 angleOpCode = CalculationManager::Command::CommandDEG;
             }
-            else if (angletype == ANGLE_RAD)
+            else if (angletype == AngleType::Radians)
             {
                 angleOpCode = CalculationManager::Command::CommandRAD;
             }
-            else // (angletype == ANGLE_GRAD)
+            else // (angletype == AngleType::Gradians)
             {
                 angleOpCode = CalculationManager::Command::CommandGRAD;
             }

--- a/src/CalcManager/CEngine/Rational.cpp
+++ b/src/CalcManager/CEngine/Rational.cpp
@@ -460,7 +460,7 @@ namespace CalcEngine
         return !(lhs < rhs);
     }
 
-    wstring Rational::ToString(uint32_t radix, NUMOBJ_FMT fmt, int32_t precision) const
+    wstring Rational::ToString(uint32_t radix, NumberFormat fmt, int32_t precision) const
     {
         PRAT rat = this->ToPRAT();
         wstring result{};

--- a/src/CalcManager/CEngine/RationalMath.cpp
+++ b/src/CalcManager/CEngine/RationalMath.cpp
@@ -147,7 +147,7 @@ Rational RationalMath::Abs(Rational const& rat)
     return Rational{ Number{ 1, rat.P().Exp(), rat.P().Mantissa() }, Number{ 1, rat.Q().Exp(), rat.Q().Mantissa() } };
 }
 
-Rational RationalMath::Sin(Rational const& rat, ANGLE_TYPE angletype)
+Rational RationalMath::Sin(Rational const& rat, AngleType angletype)
 {
     PRAT prat = rat.ToPRAT();
 
@@ -167,7 +167,7 @@ Rational RationalMath::Sin(Rational const& rat, ANGLE_TYPE angletype)
     return result;
 }
 
-Rational RationalMath::Cos(Rational const& rat, ANGLE_TYPE angletype)
+Rational RationalMath::Cos(Rational const& rat, AngleType angletype)
 {
     PRAT prat = rat.ToPRAT();
 
@@ -187,7 +187,7 @@ Rational RationalMath::Cos(Rational const& rat, ANGLE_TYPE angletype)
     return result;
 }
 
-Rational RationalMath::Tan(Rational const& rat, ANGLE_TYPE angletype)
+Rational RationalMath::Tan(Rational const& rat, AngleType angletype)
 {
     PRAT prat = rat.ToPRAT();
 
@@ -207,7 +207,7 @@ Rational RationalMath::Tan(Rational const& rat, ANGLE_TYPE angletype)
     return result;
 }
 
-Rational RationalMath::ASin(Rational const& rat, ANGLE_TYPE angletype)
+Rational RationalMath::ASin(Rational const& rat, AngleType angletype)
 {
     PRAT prat = rat.ToPRAT();
 
@@ -227,7 +227,7 @@ Rational RationalMath::ASin(Rational const& rat, ANGLE_TYPE angletype)
     return result;
 }
 
-Rational RationalMath::ACos(Rational const& rat, ANGLE_TYPE angletype)
+Rational RationalMath::ACos(Rational const& rat, AngleType angletype)
 {
     PRAT prat = rat.ToPRAT();
 
@@ -247,7 +247,7 @@ Rational RationalMath::ACos(Rational const& rat, ANGLE_TYPE angletype)
     return result;
 }
 
-Rational RationalMath::ATan(Rational const& rat, ANGLE_TYPE angletype)
+Rational RationalMath::ATan(Rational const& rat, AngleType angletype)
 {
     PRAT prat = rat.ToPRAT();
 

--- a/src/CalcManager/CEngine/calc.cpp
+++ b/src/CalcManager/CEngine/calc.cpp
@@ -105,7 +105,7 @@ CCalcEngine::CCalcEngine(
 
     m_maxTrigonometricNum = RationalMath::Pow(10, 100);
 
-    SetRadixTypeAndNumWidth(DEC_RADIX, m_numwidth);
+    SetRadixTypeAndNumWidth(RadixType::Decimal, m_numwidth);
     SettingsChanged();
     DisplayNum();
 }

--- a/src/CalcManager/CEngine/calc.cpp
+++ b/src/CalcManager/CEngine/calc.cpp
@@ -73,7 +73,7 @@ CCalcEngine::CCalcEngine(
     , m_bRecord(false)
     , m_bSetCalcState(false)
     , m_input(DEFAULT_DEC_SEPARATOR)
-    , m_nFE(FMT_FLOAT)
+    , m_nFE(NumberFormat::Float)
     , m_memoryValue{ make_unique<Rational>() }
     , m_holdVal{}
     , m_currentVal{}
@@ -94,8 +94,8 @@ CCalcEngine::CCalcEngine(
     , m_nPrecOp()
     , m_precedenceOpCount(0)
     , m_nLastCom(0)
-    , m_angletype(ANGLE_DEG)
-    , m_numwidth(QWORD_WIDTH)
+    , m_angletype(AngleType::Degrees)
+    , m_numwidth(NUM_WIDTH::QWORD_WIDTH)
     , m_HistoryCollector(pCalcDisplay, pHistoryDisplay, DEFAULT_DEC_SEPARATOR)
     , m_groupSeparator(DEFAULT_GRP_SEPARATOR)
 {
@@ -128,8 +128,18 @@ void CCalcEngine::InitChopNumbers()
         auto maxVal = m_chopNumbers[i] / 2;
         maxVal = RationalMath::Integer(maxVal);
 
-        m_maxDecimalValueStrings[i] = maxVal.ToString(10, FMT_FLOAT, m_precision);
+        m_maxDecimalValueStrings[i] = maxVal.ToString(10, NumberFormat::Float, m_precision);
     }
+}
+
+CalcEngine::Rational CCalcEngine::GetChopNumber() const
+{
+    return m_chopNumbers[static_cast<int>(m_numwidth)];
+}
+
+std::wstring CCalcEngine::GetMaxDecimalValueString() const
+{
+    return m_maxDecimalValueStrings[static_cast<int>(m_numwidth)];
 }
 
 // Gets the number in memory for UI to keep it persisted and set it again to a different instance

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -633,7 +633,7 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
     case IDM_OCT:
     case IDM_BIN:
     {
-        SetRadixTypeAndNumWidth((RADIX_TYPE)(wParam - IDM_HEX), (NUM_WIDTH)-1);
+        SetRadixTypeAndNumWidth((RadixType)(wParam - IDM_HEX), (NUM_WIDTH)-1);
         m_HistoryCollector.UpdateHistoryExpression(m_radix, m_precision);
         break;
     }
@@ -649,7 +649,7 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         }
 
         // Compat. mode BaseX: Qword, Dword, Word, Byte
-        SetRadixTypeAndNumWidth((RADIX_TYPE)-1, (NUM_WIDTH)(wParam - IDM_QWORD));
+        SetRadixTypeAndNumWidth((RadixType)-1, (NUM_WIDTH)(wParam - IDM_QWORD));
         break;
 
     case IDM_DEG:

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -185,7 +185,7 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
             return;
         }
 
-        if (!m_input.TryAddDigit(iValue, m_radix, m_fIntegerMode, m_maxDecimalValueStrings[m_numwidth], m_dwWordBitWidth, m_cIntDigitsSav))
+        if (!m_input.TryAddDigit(iValue, m_radix, m_fIntegerMode, GetMaxDecimalValueString(), m_dwWordBitWidth, m_cIntDigitsSav))
         {
             HandleErrorCommand(wParam);
             HandleMaxDigitsReached();
@@ -655,14 +655,14 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
     case IDM_DEG:
     case IDM_RAD:
     case IDM_GRAD:
-        m_angletype = static_cast<ANGLE_TYPE>(wParam - IDM_DEG);
+        m_angletype = static_cast<AngleType>(wParam - IDM_DEG);
         break;
 
     case IDC_SIGN:
     {
         if (m_bRecord)
         {
-            if (m_input.TryToggleSign(m_fIntegerMode, m_maxDecimalValueStrings[m_numwidth]))
+            if (m_input.TryToggleSign(m_fIntegerMode, GetMaxDecimalValueString()))
             {
                 DisplayNum();
             }
@@ -780,7 +780,7 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         break;
     case IDC_FE:
         // Toggle exponential notation display.
-        m_nFE = NUMOBJ_FMT(!(int)m_nFE);
+        m_nFE = NumberFormat(!(int)m_nFE);
         DisplayNum();
         break;
 
@@ -975,7 +975,7 @@ static const std::unordered_map<int, FunctionNameElement> operatorStringTable =
     { IDC_MOD, {SIDS_MOD, L"", L"", L"", L"", L"", SIDS_PROGRAMMER_MOD} },
 };
 
-wstring_view CCalcEngine::OpCodeToUnaryString(int nOpCode, bool fInv, ANGLE_TYPE angletype)
+wstring_view CCalcEngine::OpCodeToUnaryString(int nOpCode, bool fInv, AngleType angletype)
 {
     // Try to lookup the ID in the UFNE table
     wstring ids = L"";
@@ -983,7 +983,7 @@ wstring_view CCalcEngine::OpCodeToUnaryString(int nOpCode, bool fInv, ANGLE_TYPE
     if (auto pair = operatorStringTable.find(nOpCode); pair != operatorStringTable.end())
     {
         const FunctionNameElement& element = pair->second;
-        if (!element.hasAngleStrings || ANGLE_DEG == angletype)
+        if (!element.hasAngleStrings || AngleType::Degrees == angletype)
         {
             if (fInv)
             {
@@ -995,7 +995,7 @@ wstring_view CCalcEngine::OpCodeToUnaryString(int nOpCode, bool fInv, ANGLE_TYPE
                 ids = element.degreeString;
             }
         }
-        else if (ANGLE_RAD == angletype)
+        else if (AngleType::Radians == angletype)
         {
             if (fInv)
             {
@@ -1006,7 +1006,7 @@ wstring_view CCalcEngine::OpCodeToUnaryString(int nOpCode, bool fInv, ANGLE_TYPE
                 ids = element.radString;
             }
         }
-        else if (ANGLE_GRAD == angletype)
+        else if (AngleType::Gradians == angletype)
         {
             if (fInv)
             {
@@ -1108,7 +1108,7 @@ wstring CCalcEngine::GetStringForDisplay(Rational const& rat, uint32_t radix)
             if ((radix == 10) && fMsb)
             {
                 // If high bit is set, then get the decimal number in negative 2's complement form.
-                tempRat = -((tempRat ^ m_chopNumbers[m_numwidth]) + 1);
+                tempRat = -((tempRat ^ GetChopNumber()) + 1);
             }
 
             result = tempRat.ToString(radix, m_nFE, m_precision);

--- a/src/CalcManager/CEngine/scidisp.cpp
+++ b/src/CalcManager/CEngine/scidisp.cpp
@@ -67,10 +67,10 @@ CalcEngine::Rational CCalcEngine::TruncateNumForIntMath(CalcEngine::Rational con
     {
         // if negative make positive by doing a twos complement
         result = -(result)-1;
-        result ^= m_chopNumbers[m_numwidth];
+        result ^= GetChopNumber();
     }
 
-    result &= m_chopNumbers[m_numwidth];
+    result &= GetChopNumber();
 
     return result;
 }

--- a/src/CalcManager/CEngine/scifunc.cpp
+++ b/src/CalcManager/CEngine/scifunc.cpp
@@ -42,7 +42,7 @@ CalcEngine::Rational CCalcEngine::SciCalcFunctions(CalcEngine::Rational const& r
             }
             else
             {
-                result = rat ^ m_chopNumbers[m_numwidth];
+                result = rat ^ GetChopNumber();
             }
             break;
 

--- a/src/CalcManager/CEngine/scioper.cpp
+++ b/src/CalcManager/CEngine/scioper.cpp
@@ -29,11 +29,11 @@ CalcEngine::Rational CCalcEngine::DoOperation(int operation, CalcEngine::Rationa
             break;
 
         case IDC_NAND:
-            result = (result & rhs) ^ m_chopNumbers[m_numwidth];
+            result = (result & rhs) ^ GetChopNumber();
             break;
 
         case IDC_NOR:
-            result = (result | rhs) ^ m_chopNumbers[m_numwidth];
+            result = (result | rhs) ^ GetChopNumber();
             break;
 
         case IDC_RSHF:
@@ -53,10 +53,10 @@ CalcEngine::Rational CCalcEngine::DoOperation(int operation, CalcEngine::Rationa
             {
                 result = Integer(result);
 
-                auto tempRat = m_chopNumbers[m_numwidth] >> holdVal;
+                auto tempRat = GetChopNumber() >> holdVal;
                 tempRat = Integer(tempRat);
 
-                result |= tempRat ^ m_chopNumbers[m_numwidth];
+                result |= tempRat ^ GetChopNumber();
             }
             break;
         }
@@ -105,7 +105,7 @@ CalcEngine::Rational CCalcEngine::DoOperation(int operation, CalcEngine::Rationa
 
                 if (fMsb)
                 {
-                    result = (rhs ^ m_chopNumbers[m_numwidth]) + 1;
+                    result = (rhs ^ GetChopNumber()) + 1;
 
                     iNumeratorSign = -1;
                 }
@@ -115,7 +115,7 @@ CalcEngine::Rational CCalcEngine::DoOperation(int operation, CalcEngine::Rationa
 
                 if (fMsb)
                 {
-                    temp = (temp ^ m_chopNumbers[m_numwidth]) + 1;
+                    temp = (temp ^ GetChopNumber()) + 1;
 
                     iDenominatorSign = -1;
                 }

--- a/src/CalcManager/CEngine/sciset.cpp
+++ b/src/CalcManager/CEngine/sciset.cpp
@@ -24,7 +24,7 @@ void CCalcEngine::SetRadixTypeAndNumWidth(RadixType radixtype, NUM_WIDTH numwidt
         if (fMsb)
         {
             // If high bit is set, then get the decimal number in -ve 2'scompl form.
-            auto tempResult = m_currentVal ^ m_chopNumbers[m_numwidth];
+            auto tempResult = m_currentVal ^ GetChopNumber();
 
             m_currentVal = -(tempResult + 1);
         }
@@ -36,7 +36,7 @@ void CCalcEngine::SetRadixTypeAndNumWidth(RadixType radixtype, NUM_WIDTH numwidt
         // radixtype is not even saved
     }
 
-    if (numwidth >= QWORD_WIDTH && numwidth <= BYTE_WIDTH)
+    if (numwidth >= NUM_WIDTH::QWORD_WIDTH && numwidth <= NUM_WIDTH::BYTE_WIDTH)
     {
         m_numwidth = numwidth;
         m_dwWordBitWidth = DwWordBitWidthFromeNumWidth(numwidth);
@@ -50,16 +50,20 @@ void CCalcEngine::SetRadixTypeAndNumWidth(RadixType radixtype, NUM_WIDTH numwidt
     DisplayNum();
 }
 
-int32_t CCalcEngine::DwWordBitWidthFromeNumWidth(NUM_WIDTH /*numwidth*/)
+int32_t CCalcEngine::DwWordBitWidthFromeNumWidth(NUM_WIDTH numwidth)
 {
-    static constexpr int nBitMax[] = { 64, 32, 16, 8 };
-    int32_t wmax = nBitMax[0];
-
-    if (m_numwidth >= 0 && (size_t)m_numwidth < size(nBitMax))
+    switch (numwidth)
     {
-        wmax = nBitMax[m_numwidth];
+    case NUM_WIDTH::DWORD_WIDTH:
+        return 32;
+    case NUM_WIDTH::WORD_WIDTH:
+        return 16;
+    case NUM_WIDTH::BYTE_WIDTH:
+        return 8;
+    case NUM_WIDTH::QWORD_WIDTH:
+    default:
+        return 64;
     }
-    return wmax;
 }
 
 uint32_t CCalcEngine::NRadixFromRadixType(RadixType radixtype)
@@ -144,7 +148,7 @@ void CCalcEngine::UpdateMaxIntDigits()
         // if in integer mode you still have to honor the max digits you can enter based on bit width
         if (m_fIntegerMode)
         {
-            m_cIntDigitsSav = static_cast<int>(m_maxDecimalValueStrings[m_numwidth].length()) - 1;
+            m_cIntDigitsSav = static_cast<int>(GetMaxDecimalValueString().length()) - 1;
             // This is the max digits you can enter a decimal in fixed width mode aka integer mode -1. The last digit
             // has to be checked separately
         }

--- a/src/CalcManager/CEngine/sciset.cpp
+++ b/src/CalcManager/CEngine/sciset.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 // To be called when either the radix or num width changes. You can use -1 in either of these values to mean
 // dont change that.
-void CCalcEngine::SetRadixTypeAndNumWidth(RADIX_TYPE radixtype, NUM_WIDTH numwidth)
+void CCalcEngine::SetRadixTypeAndNumWidth(RadixType radixtype, NUM_WIDTH numwidth)
 {
     // When in integer mode, the number is represented in 2's complement form. When a bit width is changing, we can
     // change the number representation back to sign, abs num form in ratpak. Soon when display sees this, it will
@@ -30,7 +30,7 @@ void CCalcEngine::SetRadixTypeAndNumWidth(RADIX_TYPE radixtype, NUM_WIDTH numwid
         }
     }
 
-    if (radixtype >= HEX_RADIX && radixtype <= BIN_RADIX)
+    if (radixtype >= RadixType::Hex && radixtype <= RadixType::Binary)
     {
         m_radix = NRadixFromRadixType(radixtype);
         // radixtype is not even saved
@@ -62,17 +62,20 @@ int32_t CCalcEngine::DwWordBitWidthFromeNumWidth(NUM_WIDTH /*numwidth*/)
     return wmax;
 }
 
-uint32_t CCalcEngine::NRadixFromRadixType(RADIX_TYPE radixtype)
+uint32_t CCalcEngine::NRadixFromRadixType(RadixType radixtype)
 {
-    static constexpr uint32_t rgnRadish[4] = { 16, 10, 8, 2 }; /* Number bases in the same order as radixtype */
-    uint32_t radix = 10;
-
-    // convert special bases into symbolic values
-    if (radixtype >= 0 && (size_t)radixtype < size(rgnRadish))
+    switch (radixtype)
     {
-        radix = rgnRadish[radixtype];
+    case RadixType::Hex:
+        return 16;
+    case RadixType::Octal:
+        return 8;
+    case RadixType::Binary:
+        return 2;
+    case RadixType::Decimal:
+    default:
+        return 10;
     }
-    return radix;
 }
 
 //  Toggles a given bit into the number representation. returns true if it changed it actually.

--- a/src/CalcManager/CalculatorHistory.h
+++ b/src/CalcManager/CalculatorHistory.h
@@ -7,12 +7,6 @@
 
 namespace CalculationManager
 {
-    enum CALCULATOR_MODE
-    {
-        CM_STD = 0,
-        CM_SCI,
-    };
-
     struct HISTORYITEMVECTOR
     {
         std::shared_ptr<std::vector<std::pair<std::wstring, int>>> spTokens;

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -551,9 +551,9 @@ namespace CalculationManager
         return m_pHistory->GetHistory();
     }
 
-    vector<shared_ptr<HISTORYITEM>> const& CalculatorManager::GetHistoryItems(_In_ CALCULATOR_MODE mode)
+    vector<shared_ptr<HISTORYITEM>> const& CalculatorManager::GetHistoryItems(_In_ CalculatorMode mode)
     {
-        return (mode == CM_STD) ? m_pStdHistory->GetHistory() : m_pSciHistory->GetHistory();
+        return (mode == CalculatorMode::Standard) ? m_pStdHistory->GetHistory() : m_pSciHistory->GetHistory();
     }
 
     shared_ptr<HISTORYITEM> const& CalculatorManager::GetHistoryItem(_In_ unsigned int uIdx)
@@ -623,16 +623,16 @@ namespace CalculationManager
         return m_currentDegreeMode;
     }
 
-    void CalculatorManager::SetHistory(_In_ CALCULATOR_MODE eMode, _In_ vector<shared_ptr<HISTORYITEM>> const& history)
+    void CalculatorManager::SetHistory(_In_ CalculatorMode eMode, _In_ vector<shared_ptr<HISTORYITEM>> const& history)
     {
         CalculatorHistory* pHistory = nullptr;
 
         switch (eMode)
         {
-        case CM_STD:
+        case CalculatorMode::Standard:
             pHistory = m_pStdHistory.get();
             break;
-        case CM_SCI:
+        case CalculatorMode::Scientific:
             pHistory = m_pSciHistory.get();
             break;
         }

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -576,20 +576,20 @@ namespace CalculationManager
         m_pHistory->ClearHistory();
     }
 
-    void CalculatorManager::SetRadix(RADIX_TYPE iRadixType)
+    void CalculatorManager::SetRadix(RadixType iRadixType)
     {
         switch (iRadixType)
         {
-        case RADIX_TYPE::HEX_RADIX:
+        case RadixType::Hex:
             m_currentCalculatorEngine->ProcessCommand(IDC_HEX);
             break;
-        case RADIX_TYPE::DEC_RADIX:
+        case RadixType::Decimal:
             m_currentCalculatorEngine->ProcessCommand(IDC_DEC);
             break;
-        case RADIX_TYPE::OCT_RADIX:
+        case RadixType::Octal:
             m_currentCalculatorEngine->ProcessCommand(IDC_OCT);
             break;
-        case RADIX_TYPE::BIN_RADIX:
+        case RadixType::Binary:
             m_currentCalculatorEngine->ProcessCommand(IDC_BIN);
             break;
         default:

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -33,6 +33,7 @@ namespace CalculationManager
         , m_savedDegreeMode(Command::CommandDEG)
         , m_pStdHistory(new CalculatorHistory(MAX_HISTORY_ITEMS))
         , m_pSciHistory(new CalculatorHistory(MAX_HISTORY_ITEMS))
+        , m_pHistory(nullptr)
     {
         CCalcEngine::InitialOneTimeOnlySetup(*m_resourceProvider);
     }

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -116,7 +116,7 @@ namespace CalculationManager
         {
             return m_savedCommands;
         }
-        void SetRadix(RADIX_TYPE iRadixType);
+        void SetRadix(RadixType iRadixType);
         void SetMemorizedNumbersString();
         std::wstring GetResultForRadix(uint32_t radix, int32_t precision, bool groupDigitsPerRadix);
         void SetPrecision(int32_t precision);

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -15,9 +15,8 @@ namespace CalculationManager
 
     enum class CalculatorMode
     {
-        StandardMode,
-        ScientificMode,
-        ProgrammerMode,
+        Standard = 0,
+        Scientific,
     };
 
     enum class CalculatorPrecision
@@ -125,7 +124,7 @@ namespace CalculationManager
         wchar_t DecimalSeparator();
 
         std::vector<std::shared_ptr<HISTORYITEM>> const& GetHistoryItems();
-        std::vector<std::shared_ptr<HISTORYITEM>> const& GetHistoryItems(_In_ CalculationManager::CALCULATOR_MODE mode);
+        std::vector<std::shared_ptr<HISTORYITEM>> const& GetHistoryItems(_In_ CalculatorMode mode);
         std::shared_ptr<HISTORYITEM> const& GetHistoryItem(_In_ unsigned int uIdx);
         bool RemoveHistoryItem(_In_ unsigned int uIdx);
         void ClearHistory();
@@ -134,7 +133,7 @@ namespace CalculationManager
             return m_pHistory->MaxHistorySize();
         }
         CalculationManager::Command GetCurrentDegreeMode();
-        void SetHistory(_In_ CALCULATOR_MODE eMode, _In_ std::vector<std::shared_ptr<HISTORYITEM>> const& history);
+        void SetHistory(_In_ CalculatorMode eMode, _In_ std::vector<std::shared_ptr<HISTORYITEM>> const& history);
         void SetInHistoryItemLoadMode(_In_ bool isHistoryItemLoadMode);
     };
 }

--- a/src/CalcManager/ExpressionCommand.cpp
+++ b/src/CalcManager/ExpressionCommand.cpp
@@ -277,7 +277,7 @@ wstring COpndCommand::GetString(uint32_t radix, int32_t precision)
 {
     if (m_fInitialized)
     {
-        return m_value.ToString(radix, eNUMOBJ_FMT::FMT_FLOAT, precision);
+        return m_value.ToString(radix, NumberFormat::Float, precision);
     }
 
     return wstring{};

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -179,9 +179,9 @@ private:
     CalcEngine::Rational TruncateNumForIntMath(CalcEngine::Rational const& rat);
     CalcEngine::Rational SciCalcFunctions(CalcEngine::Rational const& rat, uint32_t op);
     CalcEngine::Rational DoOperation(int operation, CalcEngine::Rational const& lhs, CalcEngine::Rational const& rhs);
-    void SetRadixTypeAndNumWidth(RADIX_TYPE radixtype, NUM_WIDTH numwidth);
+    void SetRadixTypeAndNumWidth(RadixType radixtype, NUM_WIDTH numwidth);
     int32_t DwWordBitWidthFromeNumWidth(NUM_WIDTH numwidth);
-    uint32_t NRadixFromRadixType(RADIX_TYPE radixtype);
+    uint32_t NRadixFromRadixType(RadixType radixtype);
     double GenerateRandomNumber();
 
     bool TryToggleBit(CalcEngine::Rational& rat, uint32_t wbitno);

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -31,14 +31,13 @@
 // The real exports follows later
 
 // This is expected to be in same order as IDM_QWORD, IDM_DWORD etc.
-enum eNUM_WIDTH
+enum class NUM_WIDTH
 {
-    QWORD_WIDTH, // Number width of 64 bits mode (default)
+    QWORD_WIDTH = 0, // Number width of 64 bits mode (default)
     DWORD_WIDTH, // Number width of 32 bits mode
     WORD_WIDTH,  // Number width of 16 bits mode
     BYTE_WIDTH   // Number width of 16 bits mode
 };
-typedef enum eNUM_WIDTH NUM_WIDTH;
 static constexpr size_t NUM_WIDTH_LENGTH = 4;
 
 namespace CalculationManager
@@ -106,7 +105,7 @@ public:
     {
         return GetString(IdStrFromCmdId(nOpCode));
     }
-    static std::wstring_view OpCodeToUnaryString(int nOpCode, bool fInv, ANGLE_TYPE angletype);
+    static std::wstring_view OpCodeToUnaryString(int nOpCode, bool fInv, AngleType angletype);
     static std::wstring_view OpCodeToBinaryString(int nOpCode, bool isIntegerMode);
 
 private:
@@ -117,11 +116,11 @@ private:
     int m_nOpCode;     /* ID value of operation.                       */
     int m_nPrevOpCode; // opcode which computed the number in m_currentVal. 0 if it is already bracketed or plain number or
     // if it hasn't yet been computed
-    bool m_bChangeOp;              /* Flag for changing operation.       */
+    bool m_bChangeOp;              // Flag for changing operation
     bool m_bRecord;                // Global mode: recording or displaying
     bool m_bSetCalcState;          // Flag for setting the engine result state
     CalcEngine::CalcInput m_input; // Global calc input object for decimal strings
-    eNUMOBJ_FMT m_nFE;             /* Scientific notation conversion flag.       */
+    NumberFormat m_nFE;              // Scientific notation conversion flag
     CalcEngine::Rational m_maxTrigonometricNum;
     std::unique_ptr<CalcEngine::Rational> m_memoryValue; // Current memory value.
 
@@ -148,7 +147,7 @@ private:
     std::array<int, MAXPRECDEPTH> m_nPrecOp; /* Holding array for precedence  operations.    */
     size_t m_precedenceOpCount;              /* Current number of precedence ops in holding. */
     int m_nLastCom;                          // Last command entered.
-    ANGLE_TYPE m_angletype;                  // Current Angle type when in dec mode. one of deg, rad or grad
+    AngleType m_angletype;                  // Current Angle type when in dec mode. one of deg, rad or grad
     NUM_WIDTH m_numwidth;                    // one of qword, dword, word or byte mode.
     int32_t m_dwWordBitWidth;                // # of bits in currently selected word size
 
@@ -188,6 +187,8 @@ private:
     void CheckAndAddLastBinOpToHistory(bool addToHistory = true);
 
     void InitChopNumbers();
+    CalcEngine::Rational GetChopNumber() const;
+    std::wstring GetMaxDecimalValueString() const;
 
     static void LoadEngineStrings(CalculationManager::IResourceProvider& resourceProvider);
     static int IdStrFromCmdId(int id)

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -33,7 +33,7 @@
 // This is expected to be in same order as IDM_QWORD, IDM_DWORD etc.
 enum class NUM_WIDTH
 {
-    QWORD_WIDTH = 0, // Number width of 64 bits mode (default)
+    QWORD_WIDTH, // Number width of 64 bits mode (default)
     DWORD_WIDTH, // Number width of 32 bits mode
     WORD_WIDTH,  // Number width of 16 bits mode
     BYTE_WIDTH   // Number width of 16 bits mode

--- a/src/CalcManager/Header Files/History.h
+++ b/src/CalcManager/Header Files/History.h
@@ -23,7 +23,7 @@ public:
     void RemoveLastOpndFromHistory();
     void AddBinOpToHistory(int nOpCode, bool isIntgerMode, bool fNoRepetition = true);
     void ChangeLastBinOp(int nOpCode, bool fPrecInvToHigher, bool isIntgerMode);
-    void AddUnaryOpToHistory(int nOpCode, bool fInv, ANGLE_TYPE angletype);
+    void AddUnaryOpToHistory(int nOpCode, bool fInv, AngleType angletype);
     void AddOpenBraceToHistory();
     void AddCloseBraceToHistory();
     void PushLastOpndStart(int ichOpndStart = -1);

--- a/src/CalcManager/Header Files/RadixType.h
+++ b/src/CalcManager/Header Files/RadixType.h
@@ -4,11 +4,10 @@
 #pragma once
 
 // This is expected to be in same order as IDM_HEX, IDM_DEC, IDM_OCT, IDM_BIN
-enum eRADIX_TYPE
+enum class RadixType
 {
-    HEX_RADIX,
-    DEC_RADIX,
-    OCT_RADIX,
-    BIN_RADIX
+    Hex,
+    Decimal,
+    Octal,
+    Binary
 };
-typedef enum eRADIX_TYPE RADIX_TYPE;

--- a/src/CalcManager/Header Files/Rational.h
+++ b/src/CalcManager/Header Files/Rational.h
@@ -64,7 +64,7 @@ namespace CalcEngine
         friend bool operator<=(Rational const& lhs, Rational const& rhs);
         friend bool operator>=(Rational const& lhs, Rational const& rhs);
 
-        std::wstring ToString(uint32_t radix, NUMOBJ_FMT format, int32_t precision) const;
+        std::wstring ToString(uint32_t radix, NumberFormat format, int32_t precision) const;
         uint64_t ToUInt64_t() const;
 
     private:

--- a/src/CalcManager/Header Files/RationalMath.h
+++ b/src/CalcManager/Header Files/RationalMath.h
@@ -22,12 +22,12 @@ namespace CalcEngine::RationalMath
     Rational Invert(Rational const& rat);
     Rational Abs(Rational const& rat);
 
-    Rational Sin(Rational const& rat, ANGLE_TYPE angletype);
-    Rational Cos(Rational const& rat, ANGLE_TYPE angletype);
-    Rational Tan(Rational const& rat, ANGLE_TYPE angletype);
-    Rational ASin(Rational const& rat, ANGLE_TYPE angletype);
-    Rational ACos(Rational const& rat, ANGLE_TYPE angletype);
-    Rational ATan(Rational const& rat, ANGLE_TYPE angletype);
+    Rational Sin(Rational const& rat, AngleType angletype);
+    Rational Cos(Rational const& rat, AngleType angletype);
+    Rational Tan(Rational const& rat, AngleType angletype);
+    Rational ASin(Rational const& rat, AngleType angletype);
+    Rational ACos(Rational const& rat, AngleType angletype);
+    Rational ATan(Rational const& rat, AngleType angletype);
 
     Rational Sinh(Rational const& rat);
     Rational Cosh(Rational const& rat);

--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -1073,27 +1073,27 @@ bool stripzeroesnum(_Inout_ PNUMBER pnum, int32_t starting)
 //    FUNCTION: NumberToString
 //
 //    ARGUMENTS: number representation
-//          fmt, one of FMT_FLOAT FMT_SCIENTIFIC or
-//          FMT_ENGINEERING
+//          fmt, one of NumberFormat::Float, NumberFormat::Scientific or
+//          NumberFormat::Engineering
 //          integer radix and int32_t precision value
 //
 //    RETURN: String representation of number.
 //
-//    DESCRIPTION: Converts a number to it's string
+//    DESCRIPTION: Converts a number to its string
 //    representation.
 //
 //-----------------------------------------------------------------------------
-wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_t precision)
+wstring NumberToString(_Inout_ PNUMBER& pnum, NumberFormat format, uint32_t radix, int32_t precision)
 {
     stripzeroesnum(pnum, precision + 2);
     int32_t length = pnum->cdigit;
     int32_t exponent = pnum->exp + length; // Actual number of digits to the left of decimal
 
-    int32_t oldFormat = format;
-    if (exponent > precision && format == FMT_FLOAT)
+    NumberFormat oldFormat = format;
+    if (exponent > precision && format == NumberFormat::Float)
     {
         // Force scientific mode to prevent user from assuming 33rd digit is exact.
-        format = FMT_SCIENTIFIC;
+        format = NumberFormat::Scientific;
     }
 
     // Make length small enough to fit in pret.
@@ -1113,7 +1113,7 @@ wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_
         divnum(&round, num_two, radix, precision);
 
         // Make round number exponent one below the LSD for the number.
-        if (exponent > 0 || format == FMT_FLOAT)
+        if (exponent > 0 || format == NumberFormat::Float)
         {
             round->exp = pnum->exp + pnum->cdigit - round->cdigit - precision;
         }
@@ -1126,7 +1126,7 @@ wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_
         round->sign = pnum->sign;
     }
 
-    if (format == FMT_FLOAT)
+    if (format == NumberFormat::Float)
     {
         // Figure out if the exponent will fill more space than the non-exponent field.
         if ((length - exponent > precision) || (exponent > precision + 3))
@@ -1140,7 +1140,7 @@ wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_
             {
                 // Case where too many zeros are to the right or left of the
                 // decimal pt. And we are forced to switch to scientific form.
-                format = FMT_SCIENTIFIC;
+                format = NumberFormat::Scientific;
             }
         }
         else if (length + abs(exponent) < precision && round)
@@ -1173,13 +1173,13 @@ wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_
     int32_t eout = exponent - 1; // Displayed exponent.
     MANTTYPE* pmant = pnum->mant + pnum->cdigit - 1;
     // Case where too many digits are to the left of the decimal or
-    // FMT_SCIENTIFIC or FMT_ENGINEERING was specified.
-    if ((format == FMT_SCIENTIFIC) || (format == FMT_ENGINEERING))
+    // NumberFormat::Scientific or NumberFormat::Engineering was specified.
+    if ((format == NumberFormat::Scientific) || (format == NumberFormat::Engineering))
     {
         useSciForm = true;
         if (eout != 0)
         {
-            if (format == FMT_ENGINEERING)
+            if (format == NumberFormat::Engineering)
             {
                 exponent = (eout % 3);
                 eout -= exponent;
@@ -1280,7 +1280,7 @@ wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_
 //  ARGUMENTS:
 //              PRAT *representation of a number.
 //              i32 representation of base  to  dump to screen.
-//              fmt, one of FMT_FLOAT FMT_SCIENTIFIC or FMT_ENGINEERING
+//              fmt, one of NumberFormat::Float, NumberFormat::Scientific, or NumberFormat::Engineering
 //              precision uint32_t
 //
 //  RETURN: string
@@ -1293,7 +1293,7 @@ wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_
 //       why a pointer to the rational is passed in.
 //
 //-----------------------------------------------------------------------------
-wstring RatToString(_Inout_ PRAT& prat, int format, uint32_t radix, int32_t precision)
+wstring RatToString(_Inout_ PRAT& prat, NumberFormat format, uint32_t radix, int32_t precision)
 {
     PNUMBER p = RatToNumber(prat, radix, precision);
 

--- a/src/CalcManager/Ratpack/itrans.cpp
+++ b/src/CalcManager/Ratpack/itrans.cpp
@@ -17,17 +17,17 @@
 //-----------------------------------------------------------------------------
 #include "ratpak.h"
 
-void ascalerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, int32_t precision)
+void ascalerat(_Inout_ PRAT* pa, AngleType angletype, int32_t precision)
 {
     switch (angletype)
     {
-    case ANGLE_RAD:
+    case AngleType::Radians:
         break;
-    case ANGLE_DEG:
+    case AngleType::Degrees:
         divrat(pa, two_pi, precision);
         mulrat(pa, rat_360, precision);
         break;
-    case ANGLE_GRAD:
+    case AngleType::Gradians:
         divrat(pa, two_pi, precision);
         mulrat(pa, rat_400, precision);
         break;
@@ -76,7 +76,7 @@ void _asinrat(PRAT* px, int32_t precision)
     DESTROYTAYLOR();
 }
 
-void asinanglerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t precision)
+void asinanglerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t precision)
 
 {
     asinrat(pa, radix, precision);
@@ -164,7 +164,7 @@ void asinrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void acosanglerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t precision)
+void acosanglerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t precision)
 
 {
     acosrat(pa, radix, precision);
@@ -249,7 +249,7 @@ void acosrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
 //
 //-----------------------------------------------------------------------------
 
-void atananglerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t precision)
+void atananglerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t precision)
 
 {
     atanrat(pa, radix, precision);

--- a/src/CalcManager/Ratpack/ratpak.h
+++ b/src/CalcManager/Ratpack/ratpak.h
@@ -31,24 +31,19 @@ static constexpr uint32_t BASEX = 0x80000000; // Internal radix used in calculat
 typedef uint32_t MANTTYPE;
 typedef uint64_t TWO_MANTTYPE;
 
-enum eNUMOBJ_FMT
+enum class NumberFormat
 {
-    FMT_FLOAT,      // returns floating point, or exponential if number is too big
-    FMT_SCIENTIFIC, // always returns scientific notation
-    FMT_ENGINEERING // always returns engineering notation such that exponent is a multiple of 3
-
+    Float,      // returns floating point, or exponential if number is too big
+    Scientific, // always returns scientific notation
+    Engineering // always returns engineering notation such that exponent is a multiple of 3
 };
 
-enum eANGLE_TYPE
+enum class AngleType
 {
-    ANGLE_DEG, // Calculate trig using 360 degrees per revolution
-    ANGLE_RAD, // Calculate trig using 2 pi  radians per revolution
-    ANGLE_GRAD // Calculate trig using 400 gradients per revolution
-
+    Degrees, // Calculate trig using 360 degrees per revolution
+    Radians, // Calculate trig using 2 pi radians per revolution
+    Gradians // Calculate trig using 400 gradians per revolution
 };
-
-typedef enum eNUMOBJ_FMT NUMOBJ_FMT;
-typedef enum eANGLE_TYPE ANGLE_TYPE;
 
 //-----------------------------------------------------------------------------
 //
@@ -341,10 +336,10 @@ extern bool equnum(_In_ PNUMBER a, _In_ PNUMBER b);  // returns true of a == b
 extern bool lessnum(_In_ PNUMBER a, _In_ PNUMBER b); // returns true of a < b
 extern bool zernum(_In_ PNUMBER a);                  // returns true of a == 0
 extern bool zerrat(_In_ PRAT a);                     // returns true if a == 0/q
-extern std::wstring NumberToString(_Inout_ PNUMBER& pnum, int format, uint32_t radix, int32_t precision);
+extern std::wstring NumberToString(_Inout_ PNUMBER& pnum, NumberFormat format, uint32_t radix, int32_t precision);
 
 // returns a text representation of a PRAT
-extern std::wstring RatToString(_Inout_ PRAT& prat, int format, uint32_t radix, int32_t precision);
+extern std::wstring RatToString(_Inout_ PRAT& prat, NumberFormat format, uint32_t radix, int32_t precision);
 // converts a PRAT into a PNUMBER
 extern PNUMBER RatToNumber(_In_ PRAT prat, uint32_t radix, int32_t precision);
 // flattens a PRAT by converting it to a PNUMBER and back to a PRAT
@@ -376,7 +371,7 @@ extern PRAT _createrat(void);
 
 // returns a new rat structure with the acos of x->p/x->q taking into account
 // angle type
-extern void acosanglerat(_Inout_ PRAT* px, ANGLE_TYPE angletype, uint32_t radix, int32_t precision);
+extern void acosanglerat(_Inout_ PRAT* px, AngleType angletype, uint32_t radix, int32_t precision);
 
 // returns a new rat structure with the acosh of x->p/x->q
 extern void acoshrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
@@ -386,7 +381,7 @@ extern void acosrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
 
 // returns a new rat structure with the asin of x->p/x->q taking into account
 // angle type
-extern void asinanglerat(_Inout_ PRAT* px, ANGLE_TYPE angletype, uint32_t radix, int32_t precision);
+extern void asinanglerat(_Inout_ PRAT* px, AngleType angletype, uint32_t radix, int32_t precision);
 
 extern void asinhrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
 // returns a new rat structure with the asinh of x->p/x->q
@@ -396,7 +391,7 @@ extern void asinrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
 
 // returns a new rat structure with the atan of x->p/x->q taking into account
 // angle type
-extern void atananglerat(_Inout_ PRAT* px, ANGLE_TYPE angletype, uint32_t radix, int32_t precision);
+extern void atananglerat(_Inout_ PRAT* px, AngleType angletype, uint32_t radix, int32_t precision);
 
 // returns a new rat structure with the atanh of x->p/x->q
 extern void atanhrat(_Inout_ PRAT* px, int32_t precision);
@@ -412,7 +407,7 @@ extern void cosrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
 
 // returns a new rat structure with the cos of x->p/x->q taking into account
 // angle type
-extern void cosanglerat(_Inout_ PRAT* px, ANGLE_TYPE angletype, uint32_t radix, int32_t precision);
+extern void cosanglerat(_Inout_ PRAT* px, AngleType angletype, uint32_t radix, int32_t precision);
 
 // returns a new rat structure with the exp of x->p/x->q this should not be called explicitly.
 extern void _exprat(_Inout_ PRAT* px, int32_t precision);
@@ -435,14 +430,14 @@ extern void sinrat(_Inout_ PRAT* px);
 
 // returns a new rat structure with the sin of x->p/x->q taking into account
 // angle type
-extern void sinanglerat(_Inout_ PRAT* px, ANGLE_TYPE angletype, uint32_t radix, int32_t precision);
+extern void sinanglerat(_Inout_ PRAT* px, AngleType angletype, uint32_t radix, int32_t precision);
 
 extern void tanhrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
 extern void tanrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision);
 
 // returns a new rat structure with the tan of x->p/x->q taking into account
 // angle type
-extern void tananglerat(_Inout_ PRAT* px, ANGLE_TYPE angletype, uint32_t radix, int32_t precision);
+extern void tananglerat(_Inout_ PRAT* px, AngleType angletype, uint32_t radix, int32_t precision);
 
 extern void _dupnum(_In_ PNUMBER dest, _In_ const NUMBER* const src);
 

--- a/src/CalcManager/Ratpack/trans.cpp
+++ b/src/CalcManager/Ratpack/trans.cpp
@@ -16,17 +16,17 @@
 
 #include "ratpak.h"
 
-void scalerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t precision)
+void scalerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t precision)
 {
     switch (angletype)
     {
-    case ANGLE_RAD:
+    case AngleType::Radians:
         scale2pi(pa, radix, precision);
         break;
-    case ANGLE_DEG:
+    case AngleType::Degrees:
         scale(pa, rat_360, radix, precision);
         break;
-    case ANGLE_GRAD:
+    case AngleType::Gradians:
         scale(pa, rat_400, radix, precision);
         break;
     }
@@ -98,13 +98,13 @@ void sinrat(PRAT* px, uint32_t radix, int32_t precision)
     _sinrat(px, precision);
 }
 
-void sinanglerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t precision)
+void sinanglerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t precision)
 
 {
     scalerat(pa, angletype, radix, precision);
     switch (angletype)
     {
-    case ANGLE_DEG:
+    case AngleType::Degrees:
         if (rat_gt(*pa, rat_180, precision))
         {
             subrat(pa, rat_360, precision);
@@ -112,7 +112,7 @@ void sinanglerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t
         divrat(pa, rat_180, precision);
         mulrat(pa, pi, precision);
         break;
-    case ANGLE_GRAD:
+    case AngleType::Gradians:
         if (rat_gt(*pa, rat_200, precision))
         {
             subrat(pa, rat_400, precision);
@@ -193,13 +193,13 @@ void cosrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
     _cosrat(px, radix, precision);
 }
 
-void cosanglerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t precision)
+void cosanglerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t precision)
 
 {
     scalerat(pa, angletype, radix, precision);
     switch (angletype)
     {
-    case ANGLE_DEG:
+    case AngleType::Degrees:
         if (rat_gt(*pa, rat_180, precision))
         {
             PRAT ptmp = nullptr;
@@ -211,7 +211,7 @@ void cosanglerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t
         divrat(pa, rat_180, precision);
         mulrat(pa, pi, precision);
         break;
-    case ANGLE_GRAD:
+    case AngleType::Gradians:
         if (rat_gt(*pa, rat_200, precision))
         {
             PRAT ptmp = nullptr;
@@ -263,13 +263,13 @@ void tanrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
     _tanrat(px, radix, precision);
 }
 
-void tananglerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t precision)
+void tananglerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t precision)
 
 {
     scalerat(pa, angletype, radix, precision);
     switch (angletype)
     {
-    case ANGLE_DEG:
+    case AngleType::Degrees:
         if (rat_gt(*pa, rat_180, precision))
         {
             subrat(pa, rat_180, precision);
@@ -277,7 +277,7 @@ void tananglerat(_Inout_ PRAT* pa, ANGLE_TYPE angletype, uint32_t radix, int32_t
         divrat(pa, rat_180, precision);
         mulrat(pa, pi, precision);
         break;
-    case ANGLE_GRAD:
+    case AngleType::Gradians:
         if (rat_gt(*pa, rat_200, precision))
         {
             subrat(pa, rat_200, precision);

--- a/src/CalcViewModel/HistoryViewModel.cpp
+++ b/src/CalcViewModel/HistoryViewModel.cpp
@@ -41,11 +41,11 @@ void HistoryViewModel::ReloadHistory(_In_ ViewMode currentMode)
 {
     if (currentMode == ViewMode::Standard)
     {
-        m_currentMode = CalculationManager::CALCULATOR_MODE::CM_STD;
+        m_currentMode = CalculationManager::CalculatorMode::Standard;
     }
     else if (currentMode == ViewMode::Scientific)
     {
-        m_currentMode = CalculationManager::CALCULATOR_MODE::CM_SCI;
+        m_currentMode = CalculationManager::CalculatorMode::Scientific;
     }
     else
     {
@@ -127,7 +127,7 @@ void HistoryViewModel::DeleteItem(_In_ HistoryItemViewModel ^ e)
         {
             // Keys for the history container are index based.
             // SaveHistory() re-inserts the items anyway, so it's faster to just clear out the container.
-            CalculationManager::CALCULATOR_MODE currentMode = m_currentMode;
+            CalculationManager::CalculatorMode currentMode = m_currentMode;
             ApplicationDataContainer ^ historyContainer = GetHistoryContainer(currentMode);
             historyContainer->Values->Clear();
 
@@ -152,7 +152,7 @@ void HistoryViewModel::OnClearCommand(_In_ Platform::Object ^ e)
 
         if (Items->Size > 0)
         {
-            CalculationManager::CALCULATOR_MODE currentMode = m_currentMode;
+            CalculationManager::CalculatorMode currentMode = m_currentMode;
             ClearHistoryContainer(currentMode);
             Items->Clear();
             UpdateItemSize();
@@ -167,7 +167,7 @@ void HistoryViewModel::OnClearCommand(_In_ Platform::Object ^ e)
 }
 
 // this method restores history vector per mode
-void HistoryViewModel::RestoreHistory(_In_ CalculationManager::CALCULATOR_MODE cMode)
+void HistoryViewModel::RestoreHistory(_In_ CalculationManager::CalculatorMode cMode)
 {
     ApplicationDataContainer ^ historyContainer = GetHistoryContainer(cMode);
     std::shared_ptr<std::vector<std::shared_ptr<CalculationManager::HISTORYITEM>>> historyVector =
@@ -209,13 +209,13 @@ void HistoryViewModel::RestoreHistory(_In_ CalculationManager::CALCULATOR_MODE c
     }
 }
 
-Platform::String ^ HistoryViewModel::GetHistoryContainerKey(_In_ CalculationManager::CALCULATOR_MODE cMode)
+Platform::String ^ HistoryViewModel::GetHistoryContainerKey(_In_ CalculationManager::CalculatorMode cMode)
 {
     Platform::ValueType ^ modeValue = static_cast<int>(cMode);
     return Platform::String::Concat(modeValue->ToString(), L"_History");
 }
 
-ApplicationDataContainer ^ HistoryViewModel::GetHistoryContainer(_In_ CalculationManager::CALCULATOR_MODE cMode)
+ApplicationDataContainer ^ HistoryViewModel::GetHistoryContainer(_In_ CalculationManager::CalculatorMode cMode)
 {
     ApplicationDataContainer ^ localSettings = ApplicationData::Current->LocalSettings;
     ApplicationDataContainer ^ historyContainer;
@@ -238,14 +238,14 @@ ApplicationDataContainer ^ HistoryViewModel::GetHistoryContainer(_In_ Calculatio
     return historyContainer;
 }
 
-void HistoryViewModel::ClearHistoryContainer(_In_ CalculationManager::CALCULATOR_MODE cMode)
+void HistoryViewModel::ClearHistoryContainer(_In_ CalculationManager::CalculatorMode cMode)
 {
     ApplicationDataContainer ^ localSettings = ApplicationData::Current->LocalSettings;
     localSettings->DeleteContainer(GetHistoryContainerKey(cMode));
 }
 
 // this method will be used to update the history item length
-void HistoryViewModel::UpdateHistoryVectorLength(_In_ int newValue, _In_ CalculationManager::CALCULATOR_MODE cMode)
+void HistoryViewModel::UpdateHistoryVectorLength(_In_ int newValue, _In_ CalculationManager::CalculatorMode cMode)
 {
     ApplicationDataContainer ^ historyContainer = GetHistoryContainer(cMode);
     historyContainer->Values->Remove(HistoryVectorLengthKey);
@@ -254,8 +254,8 @@ void HistoryViewModel::UpdateHistoryVectorLength(_In_ int newValue, _In_ Calcula
 
 void HistoryViewModel::ClearHistory()
 {
-    ClearHistoryContainer(CalculationManager::CALCULATOR_MODE::CM_STD);
-    ClearHistoryContainer(CalculationManager::CALCULATOR_MODE::CM_SCI);
+    ClearHistoryContainer(CalculationManager::CalculatorMode::Standard);
+    ClearHistoryContainer(CalculationManager::CalculatorMode::Scientific);
 }
 
 void HistoryViewModel::SaveHistory()

--- a/src/CalcViewModel/HistoryViewModel.h
+++ b/src/CalcViewModel/HistoryViewModel.h
@@ -55,16 +55,16 @@ namespace CalculatorApp
         private:
             CalculationManager::CalculatorManager* const m_calculatorManager;
             CalculatorDisplay m_calculatorDisplay;
-            CalculationManager::CALCULATOR_MODE m_currentMode;
+            CalculationManager::CalculatorMode m_currentMode;
             Platform::String ^ m_localizedHistoryCleared;
 
-            void RestoreHistory(_In_ CalculationManager::CALCULATOR_MODE cMode);
+            void RestoreHistory(_In_ CalculationManager::CalculatorMode cMode);
             CalculationManager::HISTORYITEM
             DeserializeHistoryItem(_In_ Platform::String ^ historyItemKey, _In_ Windows::Storage::ApplicationDataContainer ^ historyContainer);
-            Windows::Storage::ApplicationDataContainer ^ GetHistoryContainer(_In_ CalculationManager::CALCULATOR_MODE cMode);
-            Platform::String ^ GetHistoryContainerKey(_In_ CalculationManager::CALCULATOR_MODE cMode);
-            void ClearHistoryContainer(_In_ CalculationManager::CALCULATOR_MODE cMode);
-            void UpdateHistoryVectorLength(_In_ int newValue, _In_ CalculationManager::CALCULATOR_MODE cMode);
+            Windows::Storage::ApplicationDataContainer ^ GetHistoryContainer(_In_ CalculationManager::CalculatorMode cMode);
+            Platform::String ^ GetHistoryContainerKey(_In_ CalculationManager::CalculatorMode cMode);
+            void ClearHistoryContainer(_In_ CalculationManager::CalculatorMode cMode);
+            void UpdateHistoryVectorLength(_In_ int newValue, _In_ CalculationManager::CalculatorMode cMode);
             bool IsValid(_In_ CalculationManager::HISTORYITEM item);
 
             friend class CalculatorDisplay;

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1253,16 +1253,16 @@ void StandardCalculatorViewModel::SetMemorizedNumbersString()
     m_standardCalculatorManager.SetMemorizedNumbersString();
 }
 
-ANGLE_TYPE GetAngleTypeFromCommand(Command command)
+AngleType GetAngleTypeFromCommand(Command command)
 {
     switch (command)
     {
     case Command::CommandDEG:
-        return ANGLE_DEG;
+        return AngleType::Degrees;
     case Command::CommandRAD:
-        return ANGLE_RAD;
+        return AngleType::Radians;
     case Command::CommandGRAD:
-        return ANGLE_GRAD;
+        return AngleType::Gradians;
     default:
         throw ref new Exception(E_FAIL, L"Invalid command type");
     }
@@ -1279,7 +1279,7 @@ void StandardCalculatorViewModel::SaveEditedCommand(_In_ unsigned int tokenPosit
     if (IsUnaryOp(command) && command != Command::CommandSIGN)
     {
         int angleCmd = static_cast<int>(m_standardCalculatorManager.GetCurrentDegreeMode());
-        ANGLE_TYPE angleType = GetAngleTypeFromCommand(static_cast<Command>(angleCmd));
+        AngleType angleType = GetAngleTypeFromCommand(static_cast<Command>(angleCmd));
 
         if (IsTrigOp(command))
         {

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -679,18 +679,18 @@ void StandardCalculatorViewModel::OnButtonPressed(Object ^ parameter)
     }
 }
 
-RADIX_TYPE StandardCalculatorViewModel::GetRadixTypeFromNumberBase(NumberBase base)
+RadixType StandardCalculatorViewModel::GetRadixTypeFromNumberBase(NumberBase base)
 {
     switch (base)
     {
     case NumberBase::BinBase:
-        return RADIX_TYPE::BIN_RADIX;
+        return RadixType::Binary;
     case NumberBase::HexBase:
-        return RADIX_TYPE::HEX_RADIX;
+        return RadixType::Hex;
     case NumberBase::OctBase:
-        return RADIX_TYPE::OCT_RADIX;
+        return RadixType::Octal;
     default:
-        return RADIX_TYPE::DEC_RADIX;
+        return RadixType::Decimal;
     }
 }
 
@@ -1228,7 +1228,7 @@ void StandardCalculatorViewModel::ResetDisplay()
 {
     AreHEXButtonsEnabled = false;
     CurrentRadixType = NumberBase::DecBase;
-    m_standardCalculatorManager.SetRadix(DEC_RADIX);
+    m_standardCalculatorManager.SetRadix(RadixType::Decimal);
 }
 
 void StandardCalculatorViewModel::SetPrecision(int32_t precision)

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -307,7 +307,7 @@ namespace CalculatorApp
                 _Inout_ std::shared_ptr<std::vector<std::shared_ptr<IExpressionCommand>>> const& commands);
             void SetTokens(_Inout_ std::shared_ptr<std::vector<std::pair<std::wstring, int>>> const& tokens);
             NumbersAndOperatorsEnum ConvertIntegerToNumbersAndOperatorsEnum(unsigned int parameter);
-            static RADIX_TYPE GetRadixTypeFromNumberBase(CalculatorApp::Common::NumberBase base);
+            static RadixType GetRadixTypeFromNumberBase(CalculatorApp::Common::NumberBase base);
             NumbersAndOperatorsEnum m_CurrentAngleType;
             wchar_t m_decimalSeparator;
             CalculatorDisplay m_calculatorDisplay;

--- a/src/Calculator/Converters/RadixToStringConverter.cpp
+++ b/src/Calculator/Converters/RadixToStringConverter.cpp
@@ -26,22 +26,22 @@ namespace CalculatorApp
             auto resourceLoader = AppResourceProvider::GetInstance();
             switch (boxedInt->Value)
             {
-            case RADIX_TYPE::BIN_RADIX:
+            case RadixType::Binary:
             {
                 convertedValue = resourceLoader->GetResourceString("Bin");
                 break;
             }
-            case RADIX_TYPE::OCT_RADIX:
+            case RadixType::Octal:
             {
                 convertedValue = resourceLoader->GetResourceString("Oct");
                 break;
             }
-            case RADIX_TYPE::DEC_RADIX:
+            case RadixType::Decimal:
             {
                 convertedValue = resourceLoader->GetResourceString("Dec");
                 break;
             }
-            case RADIX_TYPE::HEX_RADIX:
+            case RadixType::Hex:
             {
                 convertedValue = resourceLoader->GetResourceString("Hex");
                 break;

--- a/src/CalculatorUnitTests/HistoryTests.cpp
+++ b/src/CalculatorUnitTests/HistoryTests.cpp
@@ -65,7 +65,7 @@ namespace CalculatorFunctionalTests
             return !(localSettings->Containers->HasKey(historyContainerKey));
         }
 
-        String^ GetHistoryContainerKeyHelper(CalculationManager::CALCULATOR_MODE cMode)
+        String^ GetHistoryContainerKeyHelper(CalculationManager::CalculatorMode cMode)
         {
             ValueType^ modeValue = static_cast<int>(cMode);
             return String::Concat(modeValue->ToString(), L"_History");
@@ -204,8 +204,8 @@ namespace CalculatorFunctionalTests
             m_standardViewModel->m_standardCalculatorManager.SendCommand(Command::CommandEQU);
             m_historyViewModel->OnClearCommand(nullptr);
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemSize);
-            VERIFY_IS_TRUE(IsHistoryContainerEmpty(GetHistoryContainerKeyHelper(CM_STD)));
-            VERIFY_IS_TRUE(IsHistoryContainerEmpty(GetHistoryContainerKeyHelper(CM_SCI)));
+            VERIFY_IS_TRUE(IsHistoryContainerEmpty(GetHistoryContainerKeyHelper(CalculatorMode::Standard)));
+            VERIFY_IS_TRUE(IsHistoryContainerEmpty(GetHistoryContainerKeyHelper(CalculatorMode::Scientific)));
             Cleanup();
         }
 

--- a/src/CalculatorUnitTests/RationalTest.cpp
+++ b/src/CalculatorUnitTests/RationalTest.cpp
@@ -78,25 +78,25 @@ TEST_METHOD(TestModuloRational)
 {
     // Test with rational numbers
     auto res = Mod(Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })), Rational(89));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"2.5");
     res = Mod(Rational(Number(1, 0, { 3330 }), Number(1, 0, { 1332 })), Rational(1));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"0.5");
     res = Mod(Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(10));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"2.5");
     res = Mod(Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(10));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"7.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"7.5");
     res = Mod(Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(-10));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-2.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"-2.5");
     res = Mod(Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })), Rational(-10));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-7.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"-7.5");
     res = Mod(Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })), Rational(1));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.33333333");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"0.33333333");
     res = Mod(Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })), Rational(-10));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-6.6666667");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"-6.6666667");
     res = Mod(Rational(834345), Rational(Number(1, 0, { 103 }), Number(1, 0, { 100 })));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.71");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"0.71");
     res = Mod(Rational(834345), Rational(Number(-1, 0, { 103 }), Number(1, 0, { 100 })));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-0.32");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"-0.32");
 }
 
 TEST_METHOD(TestRemainderOperandsNotModified)
@@ -192,29 +192,29 @@ TEST_METHOD(TestRemainderRational)
 {
     // Test with rational numbers
     auto res = Rational(Number(1, 0, { 250 }), Number(1, 0, { 100 })) % Rational(89);
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"2.5");
     res = Rational(Number(1, 0, { 3330 }), Number(1, 0, { 1332 })) % Rational(1);
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"0.5");
     res = Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(10);
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"2.5");
     res = Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(10);
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-2.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"-2.5");
     res = Rational(Number(-1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(-10);
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-2.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"-2.5");
     res = Rational(Number(1, 0, { 12250 }), Number(1, 0, { 100 })) % Rational(-10);
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"2.5");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"2.5");
     res = Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(1);
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.33333333");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"0.33333333");
     res = Rational(Number(1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(-10);
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"3.3333333");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"3.3333333");
     res = Rational(Number(-1, 0, { 1000 }), Number(1, 0, { 3 })) % Rational(-10);
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-3.3333333");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"-3.3333333");
     res = Rational(834345) % Rational(Number(1, 0, { 103 }), Number(1, 0, { 100 }));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.71");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"0.71");
     res = Rational(834345) % Rational(Number(-1, 0, { 103 }), Number(1, 0, { 100 }));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"0.71");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"0.71");
     res = Rational(-834345) % Rational(Number(1, 0, { 103 }), Number(1, 0, { 100 }));
-    VERIFY_ARE_EQUAL(res.ToString(10, FMT_FLOAT, 8), L"-0.71");
+    VERIFY_ARE_EQUAL(res.ToString(10, NumberFormat::Float, 8), L"-0.71");
 }
 }
 ;

--- a/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
@@ -510,19 +510,19 @@ namespace CalculatorUnitTests
         TEST_METHOD(ProgrammerModeButtonsDisable)
         {
             /* m_viewModel->IsProgrammer = true;
-            m_viewModel->SwitchProgrammerModeBase(OCT_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::OCT_RADIX);
             VERIFY_IS_TRUE(m_viewModel->AreOCTButtonsEnabled);
             VERIFY_IS_FALSE(m_viewModel->AreHEXButtonsEnabled);
             VERIFY_IS_FALSE(m_viewModel->AreDECButtonsEnabled);
-            m_viewModel->SwitchProgrammerModeBase(DEC_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::DEC_RADIX);
             VERIFY_IS_FALSE(m_viewModel->AreHEXButtonsEnabled);
             VERIFY_IS_TRUE(m_viewModel->AreDECButtonsEnabled);
             VERIFY_IS_TRUE(m_viewModel->AreOCTButtonsEnabled);
-            m_viewModel->SwitchProgrammerModeBase(HEX_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::HEX_RADIX);
             VERIFY_IS_TRUE(m_viewModel->AreHEXButtonsEnabled);
             VERIFY_IS_TRUE(m_viewModel->AreDECButtonsEnabled);
             VERIFY_IS_TRUE(m_viewModel->AreOCTButtonsEnabled);
-            m_viewModel->SwitchProgrammerModeBase(BIN_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::BIN_RADIX);
             VERIFY_IS_FALSE(m_viewModel->AreHEXButtonsEnabled);
             VERIFY_IS_FALSE(m_viewModel->AreDECButtonsEnabled);
             VERIFY_IS_FALSE(m_viewModel->AreOCTButtonsEnabled);*/

--- a/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
@@ -510,19 +510,19 @@ namespace CalculatorUnitTests
         TEST_METHOD(ProgrammerModeButtonsDisable)
         {
             /* m_viewModel->IsProgrammer = true;
-            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::OCT_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(RadixType::Octal);
             VERIFY_IS_TRUE(m_viewModel->AreOCTButtonsEnabled);
             VERIFY_IS_FALSE(m_viewModel->AreHEXButtonsEnabled);
             VERIFY_IS_FALSE(m_viewModel->AreDECButtonsEnabled);
-            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::DEC_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(RadixType::Decimal);
             VERIFY_IS_FALSE(m_viewModel->AreHEXButtonsEnabled);
             VERIFY_IS_TRUE(m_viewModel->AreDECButtonsEnabled);
             VERIFY_IS_TRUE(m_viewModel->AreOCTButtonsEnabled);
-            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::HEX_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(RadixType::Hex);
             VERIFY_IS_TRUE(m_viewModel->AreHEXButtonsEnabled);
             VERIFY_IS_TRUE(m_viewModel->AreDECButtonsEnabled);
             VERIFY_IS_TRUE(m_viewModel->AreOCTButtonsEnabled);
-            m_viewModel->SwitchProgrammerModeBase(RADIX_TYPE::BIN_RADIX);
+            m_viewModel->SwitchProgrammerModeBase(RadixType::Binary);
             VERIFY_IS_FALSE(m_viewModel->AreHEXButtonsEnabled);
             VERIFY_IS_FALSE(m_viewModel->AreDECButtonsEnabled);
             VERIFY_IS_FALSE(m_viewModel->AreOCTButtonsEnabled);*/


### PR DESCRIPTION
Contributes to #693. Trying to reduce the noise from code analysis warnings in the build.

This change is mostly just converting unscoped enums to "enum class".