### PR TITLE
Patch TitleBar to be correctly displayed on Windows 10X Preview

### DIFF
--- a/src/CalcViewModel/CalcViewModel.vcxproj
+++ b/src/CalcViewModel/CalcViewModel.vcxproj
@@ -335,6 +335,7 @@
     <ClInclude Include="StandardCalculatorViewModel.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="UnitConverterViewModel.h" />
+    <ClInclude Include="Utils\DeviceFamilyHelper.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ApplicationViewModel.cpp" />
@@ -375,6 +376,7 @@
     </ClCompile>
     <ClCompile Include="StandardCalculatorViewModel.cpp" />
     <ClCompile Include="UnitConverterViewModel.cpp" />
+    <ClCompile Include="Utils\DeviceFamilyHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CalcManager\CalcManager.vcxproj">

--- a/src/CalcViewModel/CalcViewModel.vcxproj.filters
+++ b/src/CalcViewModel/CalcViewModel.vcxproj.filters
@@ -13,6 +13,9 @@
     <Filter Include="GraphingCalculator">
       <UniqueIdentifier>{cf7dca32-9727-4f98-83c3-1c0ca7dd1e0c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Utils">
+      <UniqueIdentifier>{4514543a-a40c-4565-8e28-f93290679269}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -85,6 +88,9 @@
     </ClCompile>
     <ClCompile Include="GraphingCalculator\GraphingSettingsViewModel.cpp">
       <Filter>GraphingCalculator</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils\DeviceFamilyHelper.cpp">
+      <Filter>Utils</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -200,7 +206,10 @@
       <Filter>GraphingCalculator</Filter>
     </ClInclude>
     <ClInclude Include="Common\DelegateCommand.h">
-	    <Filter>Common</Filter>
+      <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\DeviceFamilyHelper.h">
+      <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/CalcViewModel/Utils/DeviceFamilyHelper.cpp
+++ b/src/CalcViewModel/Utils/DeviceFamilyHelper.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "DeviceFamilyHelper.h"
+
+using namespace CalculatorApp::ViewModel::Utils;
+using namespace Windows::System::Profile;
+
+bool DeviceFamilyHelper::m_isInit{ false };
+DeviceFamily DeviceFamilyHelper::m_deviceFamily{ DeviceFamily::Unknown };
+
+DeviceFamily DeviceFamilyHelper::GetDeviceFamily()
+{
+    if (!m_isInit)
+    {
+        InitDeviceFamily();
+        m_isInit = true;
+    }
+    return m_deviceFamily;
+}
+
+void DeviceFamilyHelper::InitDeviceFamily()
+{
+    auto deviceFamily = AnalyticsInfo::VersionInfo->DeviceFamily;
+    if (deviceFamily == L"Windows.Desktop")
+    {
+        m_deviceFamily = DeviceFamily::Desktop;
+    }
+    else if (deviceFamily == L"Windows.Core")
+    {
+        m_deviceFamily = DeviceFamily::WindowsCore;
+    }
+    else if (deviceFamily == L"Windows.Xbox")
+    {
+        m_deviceFamily = DeviceFamily::Xbox;
+    }
+    else if (deviceFamily == L"Windows.Team")
+    {
+        m_deviceFamily = DeviceFamily::SurfaceHub;
+    }
+    else if (deviceFamily == L"Windows.Holographic")
+    {
+        m_deviceFamily = DeviceFamily::HoloLens;
+    }
+    else if (deviceFamily == L"Windows.Mobile")
+    {
+        m_deviceFamily = DeviceFamily::Mobile;
+    }
+    else
+    {
+        m_deviceFamily = DeviceFamily::Unknown;
+    }
+}

--- a/src/CalcViewModel/Utils/DeviceFamilyHelper.h
+++ b/src/CalcViewModel/Utils/DeviceFamilyHelper.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace CalculatorApp::ViewModel::Utils
+{
+    public enum class DeviceFamily
+    {
+        Unknown,
+        Desktop,
+        Mobile,
+        Xbox,
+        SurfaceHub,
+        HoloLens,
+        WindowsCore,
+    };
+
+    public ref class DeviceFamilyHelper sealed
+    {
+    private:
+        DeviceFamilyHelper() {}
+    public:
+        static DeviceFamily GetDeviceFamily();
+    private:
+        static void InitDeviceFamily();
+    private:
+        static bool m_isInit;
+        static DeviceFamily m_deviceFamily;
+    };
+}

--- a/src/Calculator/Package.appxmanifest
+++ b/src/Calculator/Package.appxmanifest
@@ -8,7 +8,7 @@
         <Logo>Assets\CalculatorStoreLogo.png</Logo>
     </Properties>
     <Dependencies>
-        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17133.0" MaxVersionTested="10.0.18362.0" />
+        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17133.0" MaxVersionTested="10.0.19400.0" />
     </Dependencies>
     <Resources>
         <Resource Language="x-generate" />

--- a/src/Calculator/Views/TitleBar.xaml.h
+++ b/src/Calculator/Views/TitleBar.xaml.h
@@ -29,6 +29,7 @@ public
 
         void SetTitleBarText(Platform::String ^ text);
         void SetTitleBarVisibility();
+        void SetTitleBarHeight();
         void SetTitleBarPadding();
         void SetTitleBarControlColors();
         void ColorValuesChanged(_In_ Windows::UI::ViewManagement::UISettings ^ sender, _In_ Platform::Object ^ e);

--- a/src/Calculator/Views/TitleBar.xaml.h
+++ b/src/Calculator/Views/TitleBar.xaml.h
@@ -27,7 +27,6 @@ public
         void OnLoaded(_In_ Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void OnUnloaded(_In_ Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 
-        void SetTitleBarText(Platform::String ^ text);
         void SetTitleBarVisibility();
         void SetTitleBarHeight();
         void SetTitleBarPadding();


### PR DESCRIPTION
## Fixes #1077 

### Description of the changes:
- Force the visibility (visible) and the height (32px) of the Titlebar when running on Windows 10X
- Update `MaxVersionTested` to get access to the real DeviceFamily

### How changes were validated:
- Tested with 10X Emulators

