### PR TITLE
Don't display the history button when the panel disappears

### DIFF
--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -659,8 +659,7 @@
                     Content="&#xe81c;"
                     ExitDisplayModeOnAccessKeyInvoked="False"
                     TabIndex="2"
-                    Visibility="{x:Bind local:Calculator.ShouldDisplayHistoryButton(Model.IsAlwaysOnTop, Model.IsProgrammer, DockPanel.Visibility), Mode=OneWay}"
-                    IsEnabled="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}">
+                    Visibility="{x:Bind local:Calculator.ShouldDisplayHistoryButton(Model.IsAlwaysOnTop, Model.IsProgrammer, DockPanel.Visibility), Mode=OneWay}">
                 <FlyoutBase.AttachedFlyout>
                     <Flyout x:Name="HistoryFlyout"
                             AutomationProperties.AutomationId="HistoryFlyout"

--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -659,7 +659,8 @@
                     Content="&#xe81c;"
                     ExitDisplayModeOnAccessKeyInvoked="False"
                     TabIndex="2"
-                    Visibility="{x:Bind local:Calculator.ShouldDisplayHistoryButton(Model.IsAlwaysOnTop, Model.IsProgrammer, DockPanel.Visibility), Mode=OneWay}">
+                    Visibility="{x:Bind local:Calculator.ShouldDisplayHistoryButton(Model.IsAlwaysOnTop, Model.IsProgrammer, DockPanel.Visibility), Mode=OneWay}"
+                    IsEnabled="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}">
                 <FlyoutBase.AttachedFlyout>
                     <Flyout x:Name="HistoryFlyout"
                             AutomationProperties.AutomationId="HistoryFlyout"

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -408,10 +408,6 @@ void Calculator::UpdateHistoryState()
     {
         // flyout view
         DockHistoryHolder->Child = nullptr;
-        if (!IsProgrammer)
-        {
-            HistoryButton->Visibility = ::Visibility::Visible;
-        }
     }
 }
 


### PR DESCRIPTION
## Fixes #1080 


### Description of the changes:
- Don't force the visibility of the History button when the history panel is closed


### How changes were validated:
- manually

