### PR TITLE
Fixed Divider Line Between Equations and Variables Not Being Theme Aware

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -833,9 +833,24 @@
                 </ListView.ItemTemplate>
             </ListView>
             <StackPanel x:Name="VariableStackPanel" x:Load="{x:Bind local:EquationInputArea.ManageEditVariablesButtonLoaded(Variables.Size), Mode=OneWay}">
+                <StackPanel.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Light">
+                                <SolidColorBrush x:Key="DividerBrush" Color="#33000000" />
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Dark">
+                                <SolidColorBrush x:Key="DividerBrush" Color="#60FFFFFF"/>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <SolidColorBrush x:Key="DividerBrush" Color="Transparent" />
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
+                    </ResourceDictionary>
+                </StackPanel.Resources>
                 <Rectangle Height="1"
                            Margin="12"
-                           Fill="#33000000"/>
+                           Fill="{ThemeResource DividerBrush}"/>
                 <ListView IsItemClickEnabled="False"
                           ItemTemplate="{StaticResource VariableDataTemplate}"
                           ItemsSource="{x:Bind Variables, Mode=OneWay}"


### PR DESCRIPTION
## Fixes #994.


### Description of the changes:
- Added a resource dictionary to the StackPanel that contains the divider rectangle.
- Updated the divider rectangle to be bound to the resource dictionary brush.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually validated the color changes appropriately.

