### PR TITLE
Change service URL to expression body instead of property

### DIFF
--- a/src/CalculatorUITestFramework/WindowsDriverLocalService.cs
+++ b/src/CalculatorUITestFramework/WindowsDriverLocalService.cs
@@ -119,11 +119,8 @@ namespace CalculatorUITestFramework
             GC.SuppressFinalize(this);
         }
 
-        public Uri ServiceUrl
-        {
-            // Note: append /wd/hub to the URL if you're directing the test at Appium
-            get { return new Uri($"http://{this.IP.ToString()}:{Convert.ToString(this.Port)}"); }
-        }
+        // Note: append /wd/hub to the URL if you're directing the test at Appium
+        public Uri ServiceUrl => new Uri($"http://{this.IP.ToString()}:{Convert.ToString(this.Port)}");
 
         private void DestroyProcess()
         {

--- a/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
+++ b/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
@@ -47,7 +47,7 @@ namespace CalculatorApp
             {
                 unsigned int get()
                 {
-                    return 128u
+                    return 128u;
                 }
             }
 

--- a/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
+++ b/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
@@ -47,7 +47,7 @@ namespace CalculatorApp
             {
                 unsigned int get()
                 {
-                    return 128u;
+                    return 128u
                 }
             }
 


### PR DESCRIPTION
### Description of the changes:
- The change to an expression body best shows the ServiceURL as being an expression, instead of an object with no get but a set.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Automated tests
- Manual Tests
- Compiler refactor

