### PR TITLE
Use static_cast instead of C-style cast in UnitConverter.cpp

### DIFF
--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -209,7 +209,7 @@ vector<wstring> UnitConverter::StringToVector(wstring_view w, wstring_view delim
     while (delimiterIndex != wstring_view::npos)
     {
         serializedTokens.emplace_back(w.substr(startIndex, delimiterIndex - startIndex));
-        startIndex = delimiterIndex + (int)delimiter.size();
+        startIndex = delimiterIndex + static_cast<int>(delimiter.size());
         delimiterIndex = w.find(delimiter, startIndex);
     }
     if (addRemainder)

--- a/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
+++ b/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
@@ -47,7 +47,7 @@ namespace CalculatorApp
             {
                 unsigned int get()
                 {
-                    return 128u
+                    return 128u;
                 }
             }
 

--- a/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
+++ b/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
@@ -47,7 +47,7 @@ namespace CalculatorApp
             {
                 unsigned int get()
                 {
-                    return 128u;
+                    return 128u
                 }
             }
 


### PR DESCRIPTION
# Description of the changes:
- In UnitConverter, for the conversion to vector, the delimiter size is cast to an int using the C style casting, so this was changed to the c++ style.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- ad hoc testing
- automated

On a side note, I have to ask why even cast at all, considering the variables in the equation are all size_t anyway. Nevertheless, this is the only case in the entire solution in which a c style case is used, and it is in a cpp file, so I changed it to that. Please let me know if the cast is even necessary should I be able to improve this code further by removing the case.

Thank you!
