### PR TITLE
Unresolve call to virtual function in constructor by using the namespace.

### DIFF
--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -66,7 +66,7 @@ UnitConverter::UnitConverter(_In_ const shared_ptr<IConverterDataLoader>& dataLo
     unquoteConversions[L"{lb}"] = LEFTESCAPECHAR;
     unquoteConversions[L"{rb}"] = RIGHTESCAPECHAR;
     ClearValues();
-    ResetCategoriesAndRatios();
+    UnitConverter::ResetCategoriesAndRatios();
 }
 
 void UnitConverter::Initialize()

--- a/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
+++ b/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
@@ -47,7 +47,7 @@ namespace CalculatorApp
             {
                 unsigned int get()
                 {
-                    return 128u
+                    return 128u;
                 }
             }
 

--- a/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
+++ b/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
@@ -47,7 +47,7 @@ namespace CalculatorApp
             {
                 unsigned int get()
                 {
-                    return 128u;
+                    return 128u
                 }
             }
 


### PR DESCRIPTION
### Description of the changes:
- There is a call to a virtual function in the constructor, which will be resolved statically. Because we do not want that, I put the namespace name so the compiler does not do that.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual
- Automated

