### PR TITLE
No need to invoke the compare method when we have an overloaded == operator.

### DIFF
--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -244,9 +244,9 @@ Unit UnitConverter::StringToUnit(wstring_view w)
     serializedUnit.name = Unquote(tokenList[1]);
     serializedUnit.accessibleName = serializedUnit.name;
     serializedUnit.abbreviation = Unquote(tokenList[2]);
-    serializedUnit.isConversionSource = (tokenList[3].compare(L"1") == 0);
-    serializedUnit.isConversionTarget = (tokenList[4].compare(L"1") == 0);
-    serializedUnit.isWhimsical = (tokenList[5].compare(L"1") == 0);
+    serializedUnit.isConversionSource = (tokenList[3] == L"1");
+    serializedUnit.isConversionTarget = (tokenList[4] == L"1");
+    serializedUnit.isWhimsical = (tokenList[5] == L"1");
     return serializedUnit;
 }
 
@@ -256,7 +256,7 @@ Category UnitConverter::StringToCategory(wstring_view w)
     assert(tokenList.size() == EXPECTEDSERIALIZEDCATEGORYTOKENCOUNT);
     Category serializedCategory;
     serializedCategory.id = wcstol(Unquote(tokenList[0]).c_str(), nullptr, 10);
-    serializedCategory.supportsNegative = (tokenList[1].compare(L"1") == 0);
+    serializedCategory.supportsNegative = (tokenList[1] == L"1");
     serializedCategory.name = Unquote(tokenList[2]);
     return serializedCategory;
 }
@@ -896,7 +896,7 @@ void UnitConverter::Calculate()
             else
             {
                 int currentNumberSignificantDigits = GetNumberDigits(m_currentDisplay);
-                int precision = 0;
+                int precision;
                 if (abs(returnValue) < OPTIMALDECIMALALLOWED)
                 {
                     precision = MAXIMUMDIGITSALLOWED;

--- a/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
+++ b/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
@@ -47,7 +47,7 @@ namespace CalculatorApp
             {
                 unsigned int get()
                 {
-                    return 128u
+                    return 128u;
                 }
             }
 

--- a/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
+++ b/src/CalculatorUnitTests/Mocks/CurrencyHttpClient.h
@@ -47,7 +47,7 @@ namespace CalculatorApp
             {
                 unsigned int get()
                 {
-                    return 128u;
+                    return 128u
                 }
             }
 


### PR DESCRIPTION
### Description of the changes:
- Changed the compare method calls in UnitConverter to use the overloaded == operator.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual
- Compiler fixes
- Automated

