### PR TITLE
Change precision and variables regarding the number of digits to be unsigned instead of signed

### DIFF
--- a/src/CalcManager/NumberFormattingUtils.cpp
+++ b/src/CalcManager/NumberFormattingUtils.cpp
@@ -50,15 +50,15 @@ namespace CalcManager::NumberFormattingUtils
     /// <param name="value">the number</param>
     unsigned int GetNumberDigitsWholeNumberPart(double value)
     {
-        return value == 0 ? 1 : (1 + (int)log10(abs(value)));
+        return value == 0 ? 1 : (1 + static_cast<unsigned int>(log10(abs(value))));
     }
 
     /// <summary>
     /// Rounds the given double to the given number of significant digits
     /// </summary>
     /// <param name="num">input double</param>
-    /// <param name="numSignificant">int number of significant digits to round to</param>
-    wstring RoundSignificantDigits(double num, int numSignificant)
+    /// <param name="numSignificant">unsigned int number of significant digits to round to</param>
+    wstring RoundSignificantDigits(double num, unsigned int numSignificant)
     {
         wstringstream out(wstringstream::out);
         out << fixed;

--- a/src/CalcManager/NumberFormattingUtils.h
+++ b/src/CalcManager/NumberFormattingUtils.h
@@ -10,6 +10,6 @@ namespace CalcManager::NumberFormattingUtils
     void TrimTrailingZeros(_Inout_ std::wstring& input);
     unsigned int GetNumberDigits(std::wstring value);
     unsigned int GetNumberDigitsWholeNumberPart(double value);
-    std::wstring RoundSignificantDigits(double value, int numberSignificantDigits);
+    std::wstring RoundSignificantDigits(double value, unsigned int numberSignificantDigits);
     std::wstring ToScientificNumber(double number);
 }

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -13,19 +13,19 @@ using namespace std;
 using namespace UnitConversionManager;
 using namespace CalcManager::NumberFormattingUtils;
 
-static constexpr uint32_t EXPECTEDSERIALIZEDCATEGORYTOKENCOUNT = 3;
-static constexpr uint32_t EXPECTEDSERIALIZEDUNITTOKENCOUNT = 6;
-static constexpr uint32_t EXPECTEDSTATEDATATOKENCOUNT = 5;
-static constexpr uint32_t EXPECTEDMAPCOMPONENTTOKENCOUNT = 2;
+static constexpr uint32_t EXPECTEDSERIALIZEDCATEGORYTOKENCOUNT = 3U;
+static constexpr uint32_t EXPECTEDSERIALIZEDUNITTOKENCOUNT = 6U;
+static constexpr uint32_t EXPECTEDSTATEDATATOKENCOUNT = 5U;
+static constexpr uint32_t EXPECTEDMAPCOMPONENTTOKENCOUNT = 2U;
 
-static constexpr int32_t MAXIMUMDIGITSALLOWED = 15;
-static constexpr int32_t OPTIMALDIGITSALLOWED = 7;
+static constexpr uint32_t MAXIMUMDIGITSALLOWED = 15U;
+static constexpr uint32_t OPTIMALDIGITSALLOWED = 7U;
 
 static constexpr wchar_t LEFTESCAPECHAR = L'{';
 static constexpr wchar_t RIGHTESCAPECHAR = L'}';
 
-static const double OPTIMALDECIMALALLOWED = pow(10, -1 * (OPTIMALDIGITSALLOWED - 1));
-static const double MINIMUMDECIMALALLOWED = pow(10, -1 * (MAXIMUMDIGITSALLOWED - 1));
+static const double OPTIMALDECIMALALLOWED = 1e-6; // pow(10, -1 * (OPTIMALDIGITSALLOWED - 1));
+static const double MINIMUMDECIMALALLOWED = 1e-14; // pow(10, -1 * (MAXIMUMDIGITSALLOWED - 1));
 
 unordered_map<wchar_t, wstring> quoteConversions;
 unordered_map<wstring, wchar_t> unquoteConversions;
@@ -643,15 +643,15 @@ vector<tuple<wstring, Unit>> UnitConverter::CalculateSuggested()
         wstring roundedString;
         if (abs(entry.value) < 100)
         {
-            roundedString = RoundSignificantDigits(entry.value, 2);
+            roundedString = RoundSignificantDigits(entry.value, 2U);
         }
         else if (abs(entry.value) < 1000)
         {
-            roundedString = RoundSignificantDigits(entry.value, 1);
+            roundedString = RoundSignificantDigits(entry.value, 1U);
         }
         else
         {
-            roundedString = RoundSignificantDigits(entry.value, 0);
+            roundedString = RoundSignificantDigits(entry.value, 0U);
         }
         if (stod(roundedString) != 0.0 || m_currentCategory.supportsNegative)
         {
@@ -681,15 +681,15 @@ vector<tuple<wstring, Unit>> UnitConverter::CalculateSuggested()
         wstring roundedString;
         if (abs(entry.value) < 100)
         {
-            roundedString = RoundSignificantDigits(entry.value, 2);
+            roundedString = RoundSignificantDigits(entry.value, 2U);
         }
         else if (abs(entry.value) < 1000)
         {
-            roundedString = RoundSignificantDigits(entry.value, 1);
+            roundedString = RoundSignificantDigits(entry.value, 1U);
         }
         else
         {
-            roundedString = RoundSignificantDigits(entry.value, 0);
+            roundedString = RoundSignificantDigits(entry.value, 0U);
         }
 
         // How to work out which is the best whimsical value to add to the vector?
@@ -888,15 +888,15 @@ void UnitConverter::Calculate()
         }
         else
         {
-            int numPreDecimal = GetNumberDigitsWholeNumberPart(returnValue);
+            const unsigned int numPreDecimal = GetNumberDigitsWholeNumberPart(returnValue);
             if (numPreDecimal > MAXIMUMDIGITSALLOWED || (returnValue != 0 && abs(returnValue) < MINIMUMDECIMALALLOWED))
             {
                 m_returnDisplay = ToScientificNumber(returnValue);
             }
             else
             {
-                int currentNumberSignificantDigits = GetNumberDigits(m_currentDisplay);
-                int precision;
+                const unsigned int currentNumberSignificantDigits = GetNumberDigits(m_currentDisplay);
+                unsigned int precision;
                 if (abs(returnValue) < OPTIMALDECIMALALLOWED)
                 {
                     precision = MAXIMUMDIGITSALLOWED;
@@ -905,7 +905,7 @@ void UnitConverter::Calculate()
                 {
                     // Fewer digits are needed following the decimal if the number is large,
                     // we calculate the number of decimals necessary based on the number of digits in the integer part.
-                    precision = max(0, max(OPTIMALDIGITSALLOWED, min(MAXIMUMDIGITSALLOWED, currentNumberSignificantDigits)) - numPreDecimal);
+                    precision = max(0U, max(OPTIMALDIGITSALLOWED, min(MAXIMUMDIGITSALLOWED, currentNumberSignificantDigits)) - numPreDecimal);
                 }
 
                 m_returnDisplay = RoundSignificantDigits(returnValue, precision);

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -800,8 +800,8 @@ void UnitConverter::InitializeSelectedUnits()
     {
         // Units may already have been initialized through UnitConverter::RestoreUserPreferences().
         // Check if they have been, and if so, do not override restored units.
-        bool isFromUnitValid = m_fromType != EMPTY_UNIT && find(curUnits.begin(), curUnits.end(), m_fromType) != curUnits.end();
-        bool isToUnitValid = m_toType != EMPTY_UNIT && find(curUnits.begin(), curUnits.end(), m_toType) != curUnits.end();
+        const bool isFromUnitValid = m_fromType != EMPTY_UNIT && find(curUnits.begin(), curUnits.end(), m_fromType) != curUnits.end();
+        const bool isToUnitValid = m_toType != EMPTY_UNIT && find(curUnits.begin(), curUnits.end(), m_toType) != curUnits.end();
 
         if (isFromUnitValid && isToUnitValid)
         {

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -877,9 +877,9 @@ void UnitConverter::Calculate()
     else
     {
         double currentValue = stod(m_currentDisplay);
-        double returnValue = Convert(currentValue, conversionTable[m_toType]);
+        const double returnValue = Convert(currentValue, conversionTable[m_toType]);
 
-        auto isCurrencyConverter = m_currencyDataLoader != nullptr && m_currencyDataLoader->SupportsCategory(this->m_currentCategory);
+        const auto isCurrencyConverter = m_currencyDataLoader != nullptr && m_currencyDataLoader->SupportsCategory(this->m_currentCategory);
         if (isCurrencyConverter)
         {
             // We don't need to trim the value when it's a currency.


### PR DESCRIPTION
### Description of the changes:
- For number formatting and the UnitConverter, the prevision is important, and its results are based on functions that return a counted number, which is an unsigned integer. However, some functions were assigned the result to a signed variable, and so I changed them to be unsigned without any consequence.
- Changed the C style int cast into a static unsigned int cast

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Ad-Hoc
- Compiler refactorings
- Automated testing

