### PR TITLE
Remove unused "this" in async lamba expression

### DIFF
--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -559,7 +559,7 @@ future<pair<bool, wstring>> UnitConverter::RefreshCurrencyRatios()
     }
 
     shared_future<bool> sharedLoadResult = loadDataResult.share();
-    return async([this, currencyDataLoader, sharedLoadResult]() {
+    return async([currencyDataLoader, sharedLoadResult]() {
         sharedLoadResult.wait();
         bool didLoad = sharedLoadResult.get();
         wstring timestamp;


### PR DESCRIPTION
### Description of the changes:
- The qualifier "this" serves no purpose in the async lambda expression, so we should just remove it for simplicity's sake.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Compiler refactoring
- Automated Testing
- Manual Testing