### PR TITLE
Fix trace value not appearing after touch input

### DIFF
--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -616,7 +616,6 @@ namespace GraphControl
         if (m_renderMain)
         {
             OnPointerMoved(e);
-            m_renderMain->DrawNearestPoint = true;
 
             e->Handled = true;
         }
@@ -639,6 +638,7 @@ namespace GraphControl
     {
         if (m_renderMain)
         {
+            m_renderMain->DrawNearestPoint = true;
             Point currPosition = e->GetCurrentPoint(/* relativeTo */ this)->Position;
 
             if (m_renderMain->ActiveTracing)

--- a/src/GraphControl/DirectX/RenderMain.cpp
+++ b/src/GraphControl/DirectX/RenderMain.cpp
@@ -86,12 +86,6 @@ namespace GraphControl::DX
             {
                 m_Tracing = false;
             }
-
-            bool wasPointRendered = m_Tracing;
-            if (CanRenderPoint() || wasPointRendered)
-            {
-                RunRenderPassAsync();
-            }
         }
     }
 


### PR DESCRIPTION
## Fixes #1072


### Description of the changes:
DrawNearestPoint gets set to false on PointerExited, which fires on touch input, this caused the bug as another PointerEntered is not fired until the mouse actually leave the graph area and comes back. To fix this we remove the unneeded render in the DrawNearestPoint setter, and set it to true when PointerMoved is fired.

### How changes were validated:
Manual tests
