### PR TITLE
Add Automation Names to the GraphNumPad

### DIFF
--- a/src/Calculator/Common/KeyboardShortcutManager.cpp
+++ b/src/Calculator/Common/KeyboardShortcutManager.cpp
@@ -56,6 +56,8 @@ static map<int, Flyout ^> s_AboutFlyout;
 
 static reader_writer_lock s_keyboardShortcutMapLock;
 
+static bool s_shortcutsDisabled = false;
+
 namespace CalculatorApp
 {
     namespace Common
@@ -735,6 +737,11 @@ void KeyboardShortcutManager::UpdateDropDownState(Flyout ^ aboutPageFlyout)
 
 void KeyboardShortcutManager::HonorShortcuts(bool allow)
 {
+    if (s_shortcutsDisabled)
+    {
+        return;
+    }
+
     // Writer lock for the static maps
     reader_writer_lock::scoped_lock lock(s_keyboardShortcutMapLock);
 
@@ -827,4 +834,10 @@ void KeyboardShortcutManager::OnWindowClosed(int viewId)
     s_keepIgnoringEscape.erase(viewId);
     s_fHonorShortcuts.erase(viewId);
     s_AboutFlyout.erase(viewId);
+}
+
+void KeyboardShortcutManager::DisableShortcuts(bool disable)
+{
+    s_shortcutsDisabled = disable;
+    HonorShortcuts(!disable);
 }

--- a/src/Calculator/Common/KeyboardShortcutManager.h
+++ b/src/Calculator/Common/KeyboardShortcutManager.h
@@ -43,6 +43,7 @@ namespace CalculatorApp
             static void IgnoreEscape(bool onlyOnce);
             static void HonorEscape();
             static void HonorShortcuts(bool allow);
+            static void DisableShortcuts(bool disable);
             static void UpdateDropDownState(bool);
             static void ShiftButtonChecked(bool checked);
             static void UpdateDropDownState(Windows::UI::Xaml::Controls::Flyout ^ aboutPageFlyout);

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3539,6 +3539,10 @@
     <value>Inequalities</value>
     <comment>Displayed on the button that contains a flyout for the inequality functions.</comment>
   </data>
+  <data name="inequalityButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Inequalities</value>
+    <comment>Screen reader prompt for the Inequalities button</comment>
+  </data>
   <data name="bitwiseButton.Text" xml:space="preserve">
     <value>Bitwise</value>
     <comment>Displayed on the button that contains a flyout for the bitwise functions in programmer mode.</comment>
@@ -3842,14 +3846,6 @@
   <data name="GraphingCalculatorModeText" xml:space="preserve">
     <value>Graphing</value>
     <comment>Name of the Graphing mode of the Calculator app. Displayed in the navigation menu.</comment>
-  </data>
-  <data name="graphingEqualButton.[using:CalculatorApp.Common]KeyboardShortcutManager.Character" xml:space="preserve">
-    <value>=</value>
-    <comment>{Locked}This is the character that should trigger this button. Note that it is a character and not a key, so it does not come from the Windows::System::VirtualKey enum.</comment>
-  </data>
-  <data name="graphingEqualButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Equals</value>
-    <comment>Screen reader prompt for the equal button on the graphing calculator operator keypad</comment>
   </data>
   <data name="plotButton.[using:CalculatorApp.Common]KeyboardShortcutManager.VirtualKey" xml:space="preserve">
     <value>Enter</value>
@@ -4613,5 +4609,41 @@
   <data name="KGFEquationTextBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Function Analysis Equation Box</value>
     <comment>This is the automation name text for the equation box in the function analsis panel</comment>
+  </data>
+  <data name="lessThanFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Less than</value>
+    <comment>Screen reader prompt for the Less than button</comment>
+  </data>
+  <data name="lessThanOrEqualFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Less than or equal</value>
+    <comment>Screen reader prompt for the Less than or equal button</comment>
+  </data>
+  <data name="equalsFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Equal</value>
+    <comment>Screen reader prompt for the Equal button</comment>
+  </data>
+  <data name="greaterThanOrEqualFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Greater than or equal</value>
+    <comment>Screen reader prompt for the Greater than or equal button</comment>
+  </data>
+  <data name="greaterThanFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Greater than</value>
+    <comment>Screen reader prompt for the Greater than button</comment>
+  </data>
+  <data name="graphingEqualButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Equals</value>
+    <comment>Screen reader prompt for the equal button on the graphing calculator operator keypad</comment>
+  </data>
+    <data name="xButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>X</value>
+    <comment>Screen reader prompt for the X button on the graphing calculator operator keypad</comment>
+  </data>
+    <data name="yButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Y</value>
+    <comment>Screen reader prompt for the Y button on the graphing calculator operator keypad</comment>
+  </data>
+  <data name="submitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Submit</value>
+    <comment>Screen reader prompt for the submit button on the graphing calculator operator keypad</comment>
   </data>
 </root>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4630,11 +4630,7 @@
     <value>Greater than</value>
     <comment>Screen reader prompt for the Greater than button</comment>
   </data>
-  <data name="graphingEqualButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Equals</value>
-    <comment>Screen reader prompt for the equal button on the graphing calculator operator keypad</comment>
-  </data>
-    <data name="xButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+  <data name="xButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>X</value>
     <comment>Screen reader prompt for the X button on the graphing calculator operator keypad</comment>
   </data>

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -111,8 +111,6 @@ void EquationInputArea::AddNewEquation()
 
 void EquationInputArea::EquationTextBox_GotFocus(Object ^ sender, RoutedEventArgs ^ e)
 {
-    KeyboardShortcutManager::HonorShortcuts(false);
-
     auto eq = GetViewModelFromEquationTextBox(sender);
     if (eq != nullptr)
     {
@@ -122,8 +120,6 @@ void EquationInputArea::EquationTextBox_GotFocus(Object ^ sender, RoutedEventArg
 
 void EquationInputArea::EquationTextBox_LostFocus(Object ^ sender, RoutedEventArgs ^ e)
 {
-    KeyboardShortcutManager::HonorShortcuts(true);
-
     auto eq = GetViewModelFromEquationTextBox(sender);
     if (eq != nullptr)
     {

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
@@ -393,6 +393,7 @@
                                     causing the shortcut keys to be used when the control would normally be disabled.
                                 -->
                                 <ToggleButton x:Name="TrigShiftButton"
+                                              x:Uid="trigShiftButton"
                                               Style="{StaticResource CaptionToggleEmphasizedButtonStyle}"
                                               FontFamily="{StaticResource CalculatorFontFamily}"
                                               AutomationProperties.AutomationId="trigShiftButton"
@@ -403,6 +404,7 @@
                                               IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                 <ToggleButton x:Name="HypButton"
+                                              x:Uid="hypButton"
                                               Grid.Row="1"
                                               Style="{StaticResource CaptionToggleEmphasizedButtonStyle}"
                                               AutomationProperties.AutomationId="hypShiftButton"
@@ -429,6 +431,7 @@
                                     </Grid.ColumnDefinitions>
 
                                     <controls:CalculatorButton x:Name="SinButton"
+                                                               x:Uid="sinButton"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="sinButton"
                                                                ButtonId="Sin"
@@ -437,6 +440,7 @@
                                                                IsTabStop="false"/>
 
                                     <controls:CalculatorButton x:Name="CosButton"
+                                                               x:Uid="cosButton"
                                                                Grid.Column="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="cosButton"
@@ -447,6 +451,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="TanButton"
+                                                               x:Uid="tanButton"
                                                                Grid.Column="2"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="tanButton"
@@ -457,6 +462,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="SecButton"
+                                                               x:Uid="secButton"
                                                                Grid.Row="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="secButton"
@@ -467,6 +473,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="CscButton"
+                                                               x:Uid="cscButton"
                                                                Grid.Row="1"
                                                                Grid.Column="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
@@ -478,6 +485,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="CotButton"
+                                                               x:Uid="cotButton"
                                                                Grid.Row="1"
                                                                Grid.Column="2"
                                                                Style="{StaticResource OperatorButtonStyle}"
@@ -505,6 +513,7 @@
                                     </Grid.ColumnDefinitions>
 
                                     <controls:CalculatorButton x:Name="InvsinButton"
+                                                               x:Uid="invsinButton"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="invsinButton"
                                                                ButtonId="InvSin"
@@ -514,6 +523,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvcosButton"
+                                                               x:Uid="invcosButton"
                                                                Grid.Column="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="invcosButton"
@@ -524,6 +534,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvtanButton"
+                                                               x:Uid="invtanButton"
                                                                Grid.Column="2"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="invtanButton"
@@ -534,6 +545,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvsecButton"
+                                                               x:Uid="invsecButton"
                                                                Grid.Row="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="invsecButton"
@@ -544,6 +556,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvcscButton"
+                                                               x:Uid="invcscButton"
                                                                Grid.Row="1"
                                                                Grid.Column="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
@@ -555,6 +568,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvcotButton"
+                                                               x:Uid="invcotButton"
                                                                Grid.Row="1"
                                                                Grid.Column="2"
                                                                Style="{StaticResource OperatorButtonStyle}"
@@ -582,6 +596,7 @@
                                     </Grid.ColumnDefinitions>
 
                                     <controls:CalculatorButton x:Name="SinhButton"
+                                                               x:Uid="sinhButton"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="sinhButton"
                                                                ButtonId="Sinh"
@@ -591,6 +606,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="CoshButton"
+                                                               x:Uid="coshButton"
                                                                Grid.Column="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="coshButton"
@@ -601,6 +617,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="TanhButton"
+                                                               x:Uid="tanhButton"
                                                                Grid.Column="2"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="tanhButton"
@@ -611,6 +628,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="SechButton"
+                                                               x:Uid="sechButton"
                                                                Grid.Row="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="sechButton"
@@ -621,6 +639,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="CschButton"
+                                                               x:Uid="cschButton"
                                                                Grid.Row="1"
                                                                Grid.Column="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
@@ -632,6 +651,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="CothButton"
+                                                               x:Uid="cothButton"
                                                                Grid.Row="1"
                                                                Grid.Column="2"
                                                                Style="{StaticResource OperatorButtonStyle}"
@@ -658,6 +678,7 @@
                                         <ColumnDefinition Width="1*"/>
                                     </Grid.ColumnDefinitions>
                                     <controls:CalculatorButton x:Name="InvsinhButton"
+                                                               x:Uid="invsinhButton"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="invsinhButton"
                                                                ButtonId="InvSinh"
@@ -667,6 +688,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvcoshButton"
+                                                               x:Uid="invcoshButton"
                                                                Grid.Column="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="invcoshButton"
@@ -677,6 +699,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvtanhButton"
+                                                               x:Uid="invtanhButton"
                                                                Grid.Column="2"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="invtanhButton"
@@ -687,6 +710,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvsechButton"
+                                                               x:Uid="invsechButton"
                                                                Grid.Row="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
                                                                AutomationProperties.AutomationId="invsechButton"
@@ -697,6 +721,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvcschButton"
+                                                               x:Uid="invcschButton"
                                                                Grid.Row="1"
                                                                Grid.Column="1"
                                                                Style="{StaticResource OperatorButtonStyle}"
@@ -708,6 +733,7 @@
                                                                IsEnabled="{x:Bind TrigButton.IsEnabled, Mode=OneWay}"/>
 
                                     <controls:CalculatorButton x:Name="InvcothButton"
+                                                               x:Uid="invcothButton"
                                                                Grid.Row="1"
                                                                Grid.Column="2"
                                                                Style="{StaticResource OperatorButtonStyle}"
@@ -753,6 +779,7 @@
                                 </Grid.ColumnDefinitions>
 
                                 <controls:CalculatorButton x:Name="LessThanFlyoutButton"
+                                                           x:Uid="lessThanFlyoutButton"
                                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                                            AutomationProperties.AutomationId="lessThanFlyoutButton"
                                                            ButtonId="LessThan"
@@ -762,6 +789,7 @@
                                                            IsEnabled="{x:Bind InequalityButton.IsEnabled, Mode=OneWay}"/>
 
                                 <controls:CalculatorButton x:Name="LessThanOrEqualFlyoutButton"
+                                                           x:Uid="lessThanOrEqualFlyoutButton"
                                                            Grid.Column="1"
                                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                                            AutomationProperties.AutomationId="lessThanOrEqualFlyoutButton"
@@ -772,6 +800,7 @@
                                                            IsEnabled="{x:Bind InequalityButton.IsEnabled, Mode=OneWay}"/>
 
                                 <controls:CalculatorButton x:Name="EqualsFlyoutButton"
+                                                           x:Uid="equalsFlyoutButton"
                                                            Grid.Column="2"
                                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                                            AutomationProperties.AutomationId="equalsFlyoutButton"
@@ -782,6 +811,7 @@
                                                            IsEnabled="{x:Bind InequalityButton.IsEnabled, Mode=OneWay}"/>
 
                                 <controls:CalculatorButton x:Name="GreaterThanOrEqualFlyoutButton"
+                                                           x:Uid="greaterThanOrEqualFlyoutButton"
                                                            Grid.Column="3"
                                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                                            AutomationProperties.AutomationId="greaterThanOrEqualFlyoutButton"
@@ -792,6 +822,7 @@
                                                            IsEnabled="{x:Bind InequalityButton.IsEnabled, Mode=OneWay}"/>
 
                                 <controls:CalculatorButton x:Name="GreaterThanFlyoutButton"
+                                                           x:Uid="greaterThanFlyoutButton"
                                                            Grid.Column="4"
                                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                                            AutomationProperties.AutomationId="greaterThanFlyoutButton"
@@ -834,6 +865,7 @@
                                     <ColumnDefinition Width="1*"/>
                                 </Grid.ColumnDefinitions>
                                 <controls:CalculatorButton x:Name="AbsFlyoutButton"
+                                                           x:Uid="absButton"
                                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                                            AutomationProperties.AutomationId="absButton"
                                                            ButtonId="Abs"
@@ -843,6 +875,7 @@
                                                            IsEnabled="{x:Bind FuncButton.IsEnabled, Mode=OneWay}"/>
 
                                 <controls:CalculatorButton x:Name="FloorButton"
+                                                           x:Uid="floorButton"
                                                            Grid.Column="1"
                                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                                            AutomationProperties.AutomationId="floorButton"
@@ -853,6 +886,7 @@
                                                            IsEnabled="{x:Bind FuncButton.IsEnabled, Mode=OneWay}"/>
 
                                 <controls:CalculatorButton x:Name="CeilButton"
+                                                           x:Uid="ceilButton"
                                                            Grid.Column="2"
                                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                                            AutomationProperties.AutomationId="ceilButton"
@@ -868,6 +902,7 @@
             </controls:OperatorPanelListView>
 
             <ToggleButton x:Name="ShiftButton"
+                          x:Uid="shiftButton"
                           Grid.Row="1"
                           Style="{StaticResource CaptionToggleEmphasizedButtonStyle}"
                           FontFamily="{StaticResource CalculatorFontFamily}"
@@ -881,6 +916,7 @@
                           IsEnabled="{x:Bind FuncButton.IsEnabled, Mode=OneWay}"/>
 
             <controls:CalculatorButton x:Name="PiButton"
+                                       x:Uid="piButton"
                                        Grid.Row="1"
                                        Grid.Column="1"
                                        Style="{StaticResource SymbolOperatorButtonStyle}"
@@ -892,6 +928,7 @@
                                        IsTabStop="false"/>
 
             <controls:CalculatorButton x:Name="EulerButton"
+                                       x:Uid="eulerButton"
                                        Grid.Row="1"
                                        Grid.Column="2"
                                        Style="{StaticResource OperatorButtonStyle}"
@@ -914,6 +951,7 @@
                 </Grid.ColumnDefinitions>
 
                 <controls:CalculatorButton x:Name="ClearButton"
+                                           x:Uid="clearButton"
                                            Grid.Column="1"
                                            Style="{StaticResource OperatorButtonStyle}"
                                            FontSize="16"
@@ -924,6 +962,7 @@
                                            IsTabStop="false"/>
 
                 <controls:CalculatorButton x:Name="BackSpaceButton"
+                                           x:Uid="backSpaceButton"
                                            Grid.Column="2"
                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                            FontFamily="{StaticResource CalculatorFontFamily}"
@@ -951,6 +990,7 @@
                     </Grid.RowDefinitions>
 
                     <controls:CalculatorButton x:Name="XPower2Button"
+                                               x:Uid="xpower2Button"
                                                Style="{StaticResource SymbolOperatorButtonStyle}"
                                                AutomationProperties.AutomationId="xpower2Button"
                                                ButtonId="XPower2"
@@ -959,6 +999,7 @@
                                                IsTabStop="false"/>
 
                     <controls:CalculatorButton x:Name="XPower3Button"
+                                               x:Uid="xpower3Button"
                                                Grid.Row="1"
                                                Style="{StaticResource SymbolOperatorButtonStyle}"
                                                AutomationProperties.AutomationId="xpower3Button"
@@ -968,6 +1009,7 @@
                                                IsTabStop="false"/>
 
                     <controls:CalculatorButton x:Name="PowerButton"
+                                               x:Uid="powerButton"
                                                Grid.Row="2"
                                                Style="{StaticResource SymbolOperatorButtonStyle}"
                                                AutomationProperties.AutomationId="powerButton"
@@ -977,6 +1019,7 @@
                                                IsTabStop="false"/>
 
                     <controls:CalculatorButton x:Name="PowerOf10Button"
+                                               x:Uid="powerOf10Button"
                                                Grid.Row="3"
                                                Style="{StaticResource SymbolOperatorButtonStyle}"
                                                AutomationProperties.AutomationId="powerOf10Button"
@@ -986,6 +1029,7 @@
                                                IsTabStop="false"/>
 
                     <controls:CalculatorButton x:Name="LogBase10Button"
+                                               x:Uid="logBase10Button"
                                                Grid.Row="4"
                                                Style="{StaticResource OperatorButtonStyle}"
                                                AutomationProperties.AutomationId="logBase10Button"
@@ -995,6 +1039,7 @@
                                                IsTabStop="false"/>
 
                     <controls:CalculatorButton x:Name="LogBaseEButton"
+                                               x:Uid="logBaseEButton"
                                                Grid.Row="5"
                                                Style="{StaticResource OperatorButtonStyle}"
                                                AutomationProperties.AutomationId="logBaseEButton"
@@ -1015,6 +1060,7 @@
                         <RowDefinition/>
                     </Grid.RowDefinitions>
                     <controls:CalculatorButton x:Name="SquareRootButton"
+                                               x:Uid="squareRootButton"
                                                Style="{StaticResource EmphasizedCalcButtonStyle}"
                                                AutomationProperties.AutomationId="squareRootButton"
                                                ButtonId="Sqrt"
@@ -1023,6 +1069,7 @@
                                                IsTabStop="false"/>
 
                     <controls:CalculatorButton x:Name="CubeRootButton"
+                                               x:Uid="cubeRootButton"
                                                Grid.Row="1"
                                                Style="{StaticResource EmphasizedCalcButtonStyle}"
                                                AutomationProperties.AutomationId="cubeRootButton"
@@ -1032,6 +1079,7 @@
                                                IsTabStop="false"/>
 
                     <controls:CalculatorButton x:Name="YSquareRootButton"
+                                               x:Uid="ySquareRootButton"
                                                Grid.Row="2"
                                                Style="{StaticResource EmphasizedCalcButtonStyle}"
                                                AutomationProperties.AutomationId="ySquareRootButton"
@@ -1041,6 +1089,7 @@
                                                IsTabStop="false"/>
 
                     <controls:CalculatorButton x:Name="TwoPowerXButton"
+                                               x:Uid="twoPowerXButton"
                                                Grid.Row="3"
                                                Style="{StaticResource EmphasizedCalcButtonStyle}"
                                                AutomationProperties.AutomationId="twoPowerXButton"
@@ -1060,6 +1109,7 @@
                                                IsTabStop="false"/>
 
                     <controls:CalculatorButton x:Name="PowerOfEButton"
+                                               x:Uid="powerOfEButton"
                                                Grid.Row="5"
                                                Style="{StaticResource EmphasizedCalcButtonStyle}"
                                                AutomationProperties.AutomationId="powerOfEButton"
@@ -1082,6 +1132,7 @@
                 </Grid.ColumnDefinitions>
 
                 <controls:CalculatorButton x:Name="InvertButton"
+                                           x:Uid="invertButton"
                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                            AutomationProperties.AutomationId="invertButton"
                                            ButtonId="Invert"
@@ -1090,6 +1141,7 @@
                                            IsTabStop="false"/>
 
                 <controls:CalculatorButton x:Name="AbsButton"
+                                           x:Uid="absButton"
                                            Grid.Column="1"
                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                            AutomationProperties.AutomationId="absButton"
@@ -1099,6 +1151,7 @@
                                            IsTabStop="false"/>
 
                 <controls:CalculatorButton x:Name="XButton"
+                                           x:Uid="xButton"
                                            Grid.Column="2"
                                            Style="{StaticResource OperatorButtonStyle}"
                                            FontSize="16"
@@ -1109,6 +1162,7 @@
                                            IsTabStop="false"/>
 
                 <controls:CalculatorButton x:Name="YButton"
+                                           x:Uid="yButton"
                                            Grid.Column="3"
                                            Style="{StaticResource OperatorButtonStyle}"
                                            FontSize="16"
@@ -1120,6 +1174,7 @@
             </Grid>
 
             <controls:CalculatorButton x:Name="OpenParenthesisButton"
+                                       x:Uid="openParenthesisButton"
                                        Grid.Row="3"
                                        Grid.Column="1"
                                        Style="{StaticResource ParenthesisCalcButtonStyle}"
@@ -1131,6 +1186,7 @@
                                        IsTabStop="false"/>
 
             <controls:CalculatorButton x:Name="CloseParenthesisButton"
+                                       x:Uid="closeParenthesisButton"
                                        Grid.Row="3"
                                        Grid.Column="2"
                                        Style="{StaticResource OperatorButtonStyle}"
@@ -1142,6 +1198,7 @@
                                        IsTabStop="false"/>
 
             <controls:CalculatorButton x:Name="EqualButton"
+                                       x:Uid="graphingEqualButton"
                                        Grid.Row="3"
                                        Grid.Column="3"
                                        Style="{StaticResource SymbolOperatorButtonStyle}"
@@ -1165,6 +1222,7 @@
                     <RowDefinition/>
                 </Grid.RowDefinitions>
                 <controls:CalculatorButton x:Name="DivideButton"
+                                           x:Uid="divideButton"
                                            Grid.Row="0"
                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                            AutomationProperties.AutomationId="divideButton"
@@ -1174,6 +1232,7 @@
                                            IsTabStop="false"/>
 
                 <controls:CalculatorButton x:Name="MultiplyButton"
+                                           x:Uid="multiplyButton"
                                            Grid.Row="1"
                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                            AutomationProperties.AutomationId="multiplyButton"
@@ -1183,6 +1242,7 @@
                                            IsTabStop="false"/>
 
                 <controls:CalculatorButton x:Name="MinusButton"
+                                           x:Uid="minusButton"
                                            Grid.Row="2"
                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                            AutomationProperties.AutomationId="minusButton"
@@ -1192,6 +1252,7 @@
                                            IsTabStop="false"/>
 
                 <controls:CalculatorButton x:Name="PlusButton"
+                                           x:Uid="plusButton"
                                            Grid.Row="3"
                                            Style="{StaticResource SymbolOperatorButtonStyle}"
                                            AutomationProperties.AutomationId="plusButton"
@@ -1201,6 +1262,7 @@
                                            IsTabStop="false"/>
 
                 <controls:CalculatorButton x:Name="SubmitButton"
+                                           x:Uid="submitButton"
                                            Grid.Row="4"
                                            Style="{StaticResource AccentEmphasizedCalcButtonStyle}"
                                            FontFamily="{StaticResource SymbolThemeFontFamily}"
@@ -1211,6 +1273,7 @@
             </Grid>
 
             <controls:CalculatorButton x:Name="NegateButton"
+                                       x:Uid="negateButton"
                                        Grid.Row="7"
                                        Grid.Column="1"
                                        Style="{StaticResource SymbolOperatorKeypadButtonStyle}"
@@ -1223,6 +1286,7 @@
                                        IsTabStop="false"/>
 
             <controls:CalculatorButton x:Name="Num0Button"
+                                       x:Uid="num0Button"
                                        Grid.Row="7"
                                        Grid.Column="2"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1231,6 +1295,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="Num1Button"
+                                       x:Uid="num1Button"
                                        Grid.Row="6"
                                        Grid.Column="1"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1239,6 +1304,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="Num2Button"
+                                       x:Uid="num2Button"
                                        Grid.Row="6"
                                        Grid.Column="2"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1247,6 +1313,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="Num3Button"
+                                       x:Uid="num3Button"
                                        Grid.Row="6"
                                        Grid.Column="3"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1255,6 +1322,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="Num4Button"
+                                       x:Uid="num4Button"
                                        Grid.Row="5"
                                        Grid.Column="1"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1263,6 +1331,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="Num5Button"
+                                       x:Uid="num5Button"
                                        Grid.Row="5"
                                        Grid.Column="2"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1271,6 +1340,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="Num6Button"
+                                       x:Uid="num6Button"
                                        Grid.Row="5"
                                        Grid.Column="3"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1279,6 +1349,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="Num7Button"
+                                       x:Uid="num7Button"
                                        Grid.Row="4"
                                        Grid.Column="1"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1287,6 +1358,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="Num8Button"
+                                       x:Uid="num8Button"
                                        Grid.Row="4"
                                        Grid.Column="2"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1295,6 +1367,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="Num9Button"
+                                       x:Uid="num9Button"
                                        Grid.Row="4"
                                        Grid.Column="3"
                                        Style="{StaticResource NumericButtonStyle24}"
@@ -1303,6 +1376,7 @@
                                        Click="Button_Clicked"
                                        IsTabStop="false"/>
             <controls:CalculatorButton x:Name="DecimalSeparatorButton"
+                                       x:Uid="decimalSeparatorButton"
                                        Grid.Row="7"
                                        Grid.Column="3"
                                        Style="{StaticResource NumericButtonStyle24}"

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
@@ -1198,7 +1198,7 @@
                                        IsTabStop="false"/>
 
             <controls:CalculatorButton x:Name="EqualButton"
-                                       x:Uid="graphingEqualButton"
+                                       x:Uid="equalButton"
                                        Grid.Row="3"
                                        Grid.Column="3"
                                        Style="{StaticResource SymbolOperatorButtonStyle}"

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -129,7 +129,7 @@ void MainPage::OnAppPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows
         ViewMode newValue = m_model->Mode;
         ViewMode previousMode = m_model->PreviousMode;
 
-        KeyboardShortcutManager::HonorShortcuts(true);
+        KeyboardShortcutManager::DisableShortcuts(false);
 
         if (newValue == ViewMode::Standard)
         {
@@ -173,7 +173,7 @@ void MainPage::OnAppPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows
         else if (newValue == ViewMode::Graphing)
         {
             EnsureGraphingCalculator();
-            KeyboardShortcutManager::HonorShortcuts(false);
+            KeyboardShortcutManager::DisableShortcuts(true);
         }
         else if (NavCategory::IsConverterViewMode(newValue))
         {

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -427,7 +427,11 @@ void MainPage::OnNavPaneOpened(_In_ MUXC::NavigationView ^ sender, _In_ Object ^
 
 void MainPage::OnNavPaneClosed(_In_ MUXC::NavigationView ^ sender, _In_ Object ^ args)
 {
-    KeyboardShortcutManager::HonorShortcuts(true);
+    if (Model->Mode != ViewMode::Graphing)
+    {
+        KeyboardShortcutManager::HonorShortcuts(true);
+    }
+
     this->SetDefaultFocus();
 }
 

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -129,6 +129,8 @@ void MainPage::OnAppPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows
         ViewMode newValue = m_model->Mode;
         ViewMode previousMode = m_model->PreviousMode;
 
+        KeyboardShortcutManager::HonorShortcuts(true);
+
         if (newValue == ViewMode::Standard)
         {
             EnsureCalculator();
@@ -171,6 +173,7 @@ void MainPage::OnAppPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows
         else if (newValue == ViewMode::Graphing)
         {
             EnsureGraphingCalculator();
+            KeyboardShortcutManager::HonorShortcuts(false);
         }
         else if (NavCategory::IsConverterViewMode(newValue))
         {


### PR DESCRIPTION
## Fixes #1127, Fixes #1129.


### Description of the changes:
- Adds automation names to all of the buttons in the GraphNumPad
- Disables KeyboardShortCuts when entering graphing mode

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manually testing the shortcuts are active on non-graphing modes
- manually using accessibility insights
