### PR TITLE
Updated EquationButton contrast fixed dark mode foreground color bugs

### DIFF
--- a/src/CalcViewModel/Common/Utils.cpp
+++ b/src/CalcViewModel/Common/Utils.cpp
@@ -324,8 +324,8 @@ SolidColorBrush ^ Utils::GetContrastColor(Color backgroundColor)
 
     if ((255 + 0.05) / (luminance + 0.05) >= 2.5)
     {
-        return ref new SolidColorBrush(Colors::White);
+        return static_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"WhiteBrush"));
     }
 
-    return ref new SolidColorBrush(Colors::Black);
+    return static_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"BlackBrush"));
 }

--- a/src/CalcViewModel/Common/Utils.cpp
+++ b/src/CalcViewModel/Common/Utils.cpp
@@ -24,6 +24,7 @@ using namespace Windows::UI;
 using namespace Windows::UI::Core;
 using namespace Windows::UI::ViewManagement;
 using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Media;
 using namespace Windows::Foundation;
 using namespace Windows::Storage;
 
@@ -312,4 +313,19 @@ bool operator==(const Color& color1, const Color& color2)
 bool operator!=(const Color& color1, const Color& color2)
 {
     return !(color1 == color2);
+}
+
+// This method calculates the luminance ratio between White and the given background color.
+// The luminance is calculate using the RGB values and does not use the A value.
+// White or Black is returned
+SolidColorBrush ^ Utils::GetContrastColor(Color backgroundColor)
+{
+    auto luminance = 0.2126 * backgroundColor.R + 0.7152 * backgroundColor.G + 0.0722 * backgroundColor.B;
+
+    if ((255 + 0.05) / (luminance + 0.05) >= 2.5)
+    {
+        return ref new SolidColorBrush(Colors::White);
+    }
+
+    return ref new SolidColorBrush(Colors::Black);
 }

--- a/src/CalcViewModel/Common/Utils.h
+++ b/src/CalcViewModel/Common/Utils.h
@@ -413,6 +413,7 @@ namespace Utils
 
     Platform::String ^ EscapeHtmlSpecialCharacters(Platform::String ^ originalString, std::shared_ptr<std::vector<wchar_t>> specialCharacters = nullptr);
 
+    Windows::UI::Xaml::Media::SolidColorBrush ^ GetContrastColor(Windows::UI::Color backgroundColor);
 }
 
 // This goes into the header to define the property, in the public: section of the class

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -249,6 +249,10 @@
             <x:Double x:Key="CalcOperatorCaptionSize">14</x:Double>
             <x:Double x:Key="CalcOperatorTextIconCaptionSize">16</x:Double>
 
+            <!-- White and black color brushes used for the Utils::GetContrastColor-->
+            <SolidColorBrush x:Key="WhiteBrush" Color="White"/>
+            <SolidColorBrush x:Key="BlackBrush" Color="Black"/>
+
             <!-- Base style for calc buttons -->
             <Style x:Key="CalcButtonStyle" TargetType="Controls:CalculatorButton">
                 <Setter Property="MinWidth" Value="24"/>

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -423,11 +423,6 @@ bool EquationTextBox::RichEditHasContent()
 
 void EquationTextBox::OnRichEditMenuOpened(Object ^ /*sender*/, Object ^ /*args*/)
 {
-    if (m_richEditBox != nullptr)
-    {
-        VisualStateManager::GoToState(m_richEditBox, "Focused", false);
-    }
-
     if (m_kgfEquationMenuItem != nullptr)
     {
         m_kgfEquationMenuItem->IsEnabled = m_HasFocus && !HasError && RichEditHasContent();

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -423,7 +423,10 @@ bool EquationTextBox::RichEditHasContent()
 
 void EquationTextBox::OnRichEditMenuOpened(Object ^ /*sender*/, Object ^ /*args*/)
 {
-    VisualStateManager::GoToState(m_richEditBox, "Focused", false);
+    if (m_richEditBox != nullptr)
+    {
+        VisualStateManager::GoToState(m_richEditBox, "Focused", false);
+    }
 
     if (m_kgfEquationMenuItem != nullptr)
     {

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -20,8 +20,10 @@ using namespace Windows::UI::Xaml::Automation;
 using namespace Windows::UI::Xaml::Controls;
 using namespace Windows::UI::Xaml::Input;
 using namespace Windows::UI::Xaml::Controls::Primitives;
+using namespace Windows::UI::Xaml::Media;
 
 DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, EquationColor);
+DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, EquationButtonForegroundColor);
 DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, ColorChooserFlyout);
 DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, EquationButtonContentIndex);
 DEPENDENCY_PROPERTY_INITIALIZATION(EquationTextBox, HasError);
@@ -421,6 +423,8 @@ bool EquationTextBox::RichEditHasContent()
 
 void EquationTextBox::OnRichEditMenuOpened(Object ^ /*sender*/, Object ^ /*args*/)
 {
+    VisualStateManager::GoToState(m_richEditBox, "Focused", false);
+
     if (m_kgfEquationMenuItem != nullptr)
     {
         m_kgfEquationMenuItem->IsEnabled = m_HasFocus && !HasError && RichEditHasContent();

--- a/src/Calculator/Controls/EquationTextBox.h
+++ b/src/Calculator/Controls/EquationTextBox.h
@@ -20,6 +20,7 @@ namespace CalculatorApp
 
             DEPENDENCY_PROPERTY_OWNER(EquationTextBox);
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Media::SolidColorBrush ^, EquationColor);
+            DEPENDENCY_PROPERTY(Windows::UI::Xaml::Media::SolidColorBrush ^, EquationButtonForegroundColor);
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Controls::Flyout ^, ColorChooserFlyout);
             DEPENDENCY_PROPERTY(Platform::String ^, EquationButtonContentIndex);
             DEPENDENCY_PROPERTY(Platform::String ^, MathEquation);

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -365,6 +365,7 @@
                                             <VisualState.Setters>
                                                 <Setter Target="EquationBoxBorder.BorderBrush" Value="{ThemeResource EquationTextBoxBorderBrushFocused}"/>
                                                 <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource TextBoxBackgroundThemeBrush}"/>
+                                                <Setter Target="MathRichEditBox.Foreground" Value="{ThemeResource TextControlForegroundFocused}"/>
                                             </VisualState.Setters>
                                         </VisualState>
                                         <VisualState x:Name="FocusedError">
@@ -425,12 +426,12 @@
                                                     <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="White"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBackground" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBorderBrush" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                    <SolidColorBrush x:Key="ToggleButtonForeground" Color="White"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForeground" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationButtonForegroundColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBackgroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPointerOver" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationButtonForegroundColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBorderBrushPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationButtonForegroundColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBorderBrushPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                     <StaticResource x:Key="ToggleButtonBackgroundChecked" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
                                                     <StaticResource x:Key="ToggleButtonBorderBrushChecked" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
@@ -448,12 +449,12 @@
                                                     <SolidColorBrush x:Key="EquationButtonOverlayBackgroundBrush" Color="Black"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBackground" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBorderBrush" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                    <SolidColorBrush x:Key="ToggleButtonForeground" Color="White"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForeground" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationButtonForegroundColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBackgroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPointerOver" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationButtonForegroundColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBorderBrushPointerOver" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBackgroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
-                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPressed" Color="{ThemeResource SystemChromeWhiteColor}"/>
+                                                    <SolidColorBrush x:Key="ToggleButtonForegroundPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationButtonForegroundColor.Color}"/>
                                                     <SolidColorBrush x:Key="ToggleButtonBorderBrushPressed" Color="{Binding RelativeSource={RelativeSource TemplatedParent}, Path=EquationColor.Color}"/>
                                                     <StaticResource x:Key="ToggleButtonBackgroundChecked" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
                                                     <StaticResource x:Key="ToggleButtonBorderBrushChecked" ResourceKey="EquationButtonHideLineBackgroundBrush"/>
@@ -841,6 +842,7 @@
                                                   EquationButtonClicked="EquationTextBox_EquationButtonClicked"
                                                   EquationButtonContentIndex="{x:Bind FunctionLabelIndex, Mode=OneWay}"
                                                   EquationColor="{x:Bind local:EquationInputArea.ToSolidColorBrush(LineColor), Mode=OneWay}"
+                                                  EquationButtonForegroundColor ="{x:Bind local:EquationInputArea.GetForegroundColor(LineColor), Mode=OneWay}"
                                                   EquationFormatRequested="EquationTextBox_EquationFormatRequested"
                                                   EquationSubmitted="EquationTextBox_Submitted"
                                                   ErrorText="{x:Bind vm:EquationViewModel.EquationErrorText(GraphEquation.GraphErrorType, GraphEquation.GraphErrorCode), Mode=OneWay}"

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -540,7 +540,7 @@ EquationViewModel ^ EquationInputArea::GetViewModelFromEquationTextBox(Object ^ 
 
      auto whiteLum = 0.2126 * Colors::White.R + 0.7152 * Colors::White.G + 0.0722 * Colors::White.B;
 
-     if ((whiteLum + 0.05) / (luminance + 0.05) >= 2)
+     if ((whiteLum + 0.05) / (luminance + 0.05) >= 2.5)
      {
          return ref new SolidColorBrush(Colors::White);
      }

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -536,14 +536,5 @@ EquationViewModel ^ EquationInputArea::GetViewModelFromEquationTextBox(Object ^ 
 
  SolidColorBrush ^ EquationInputArea::GetForegroundColor(Color lineColor)
  {
-     auto luminance = 0.2126 * lineColor.R + 0.7152 * lineColor.G + 0.0722 * lineColor.B;  
-
-     auto whiteLum = 0.2126 * Colors::White.R + 0.7152 * Colors::White.G + 0.0722 * Colors::White.B;
-
-     if ((whiteLum + 0.05) / (luminance + 0.05) >= 2.5)
-     {
-         return ref new SolidColorBrush(Colors::White);
-     }
-
-     return ref new SolidColorBrush(Colors::Black);
+     return Utils::GetContrastColor(lineColor);
  }

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -533,3 +533,17 @@ EquationViewModel ^ EquationInputArea::GetViewModelFromEquationTextBox(Object ^ 
 
     return eq;
 }
+
+ SolidColorBrush ^ EquationInputArea::GetForegroundColor(Color lineColor)
+ {
+     auto luminance = 0.2126 * lineColor.R + 0.7152 * lineColor.G + 0.0722 * lineColor.B;  
+
+     auto whiteLum = 0.2126 * Colors::White.R + 0.7152 * Colors::White.G + 0.0722 * Colors::White.B;
+
+     if ((whiteLum + 0.05) / (luminance + 0.05) >= 2)
+     {
+         return ref new SolidColorBrush(Colors::White);
+     }
+
+     return ref new SolidColorBrush(Colors::Black);
+ }

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
@@ -40,6 +40,8 @@ public
         static Windows::UI::Xaml::Media::SolidColorBrush
             ^ ToSolidColorBrush(Windows::UI::Color color) { return ref new Windows::UI::Xaml::Media::SolidColorBrush(color); }
 
+        static Windows::UI::Xaml::Media::SolidColorBrush ^ GetForegroundColor(Windows::UI::Color lineColor);
+
         void FocusEquationTextBox(ViewModel::EquationViewModel ^ equation);
     private:
         void OnPropertyChanged(Platform::String ^ propertyName);


### PR DESCRIPTION
## Fixes #1132

### Description of the changes:
- Updates the foreground color on the equation button using a luminosity algorithm to create the correct contrast

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manually
