### PR TITLE
Add dual-screen support to all views

### DIFF
--- a/src/CalcViewModel/CalcViewModel.vcxproj
+++ b/src/CalcViewModel/CalcViewModel.vcxproj
@@ -334,6 +334,7 @@
     <ClInclude Include="StandardCalculatorViewModel.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="UnitConverterViewModel.h" />
+    <ClInclude Include="Utils\DeviceFamilyHelper.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ApplicationViewModel.cpp" />
@@ -374,6 +375,7 @@
     </ClCompile>
     <ClCompile Include="StandardCalculatorViewModel.cpp" />
     <ClCompile Include="UnitConverterViewModel.cpp" />
+    <ClCompile Include="Utils\DeviceFamilyHelper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CalcManager\CalcManager.vcxproj">

--- a/src/CalcViewModel/CalcViewModel.vcxproj.filters
+++ b/src/CalcViewModel/CalcViewModel.vcxproj.filters
@@ -13,6 +13,9 @@
     <Filter Include="GraphingCalculator">
       <UniqueIdentifier>{cf7dca32-9727-4f98-83c3-1c0ca7dd1e0c}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Utils">
+      <UniqueIdentifier>{68bb415f-fcb1-4759-b0a7-c5caf9d72396}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="pch.cpp" />
@@ -85,6 +88,9 @@
     </ClCompile>
     <ClCompile Include="GraphingCalculator\GraphingSettingsViewModel.cpp">
       <Filter>GraphingCalculator</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils\DeviceFamilyHelper.cpp">
+      <Filter>Utils</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -198,6 +204,9 @@
     </ClInclude>
     <ClInclude Include="Common\DelegateCommand.h">
       <Filter>Common</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils\DeviceFamilyHelper.h">
+      <Filter>Utils</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/src/CalcViewModel/Utils/DeviceFamilyHelper.cpp
+++ b/src/CalcViewModel/Utils/DeviceFamilyHelper.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "DeviceFamilyHelper.h"
+
+using namespace CalculatorApp::ViewModel::Utils;
+using namespace Windows::System::Profile;
+
+bool DeviceFamilyHelper::m_isInit{ false };
+DeviceFamily DeviceFamilyHelper::m_deviceFamily{ DeviceFamily::Unknown };
+
+DeviceFamily DeviceFamilyHelper::GetDeviceFamily()
+{
+    if (!m_isInit)
+    {
+        InitDeviceFamily();
+        m_isInit = true;
+    }
+    return m_deviceFamily;
+}
+
+void DeviceFamilyHelper::InitDeviceFamily()
+{
+    auto deviceFamily = AnalyticsInfo::VersionInfo->DeviceFamily;
+    if (deviceFamily == L"Windows.Desktop")
+    {
+        m_deviceFamily = DeviceFamily::Desktop;
+    }
+    else if (deviceFamily == L"Windows.Core")
+    {
+        m_deviceFamily = DeviceFamily::WindowsCore;
+    }
+    else if (deviceFamily == L"Windows.Xbox")
+    {
+        m_deviceFamily = DeviceFamily::Xbox;
+    }
+    else if (deviceFamily == L"Windows.Team")
+    {
+        m_deviceFamily = DeviceFamily::SurfaceHub;
+    }
+    else if (deviceFamily == L"Windows.Holographic")
+    {
+        m_deviceFamily = DeviceFamily::HoloLens;
+    }
+    else if (deviceFamily == L"Windows.Mobile")
+    {
+        m_deviceFamily = DeviceFamily::Mobile;
+    }
+    else
+    {
+        m_deviceFamily = DeviceFamily::Unknown;
+    }
+}

--- a/src/CalcViewModel/Utils/DeviceFamilyHelper.h
+++ b/src/CalcViewModel/Utils/DeviceFamilyHelper.h
@@ -1,0 +1,31 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+namespace CalculatorApp::ViewModel::Utils
+{
+    public enum class DeviceFamily
+    {
+        Unknown,
+        Desktop,
+        Mobile,
+        Xbox,
+        SurfaceHub,
+        HoloLens,
+        WindowsCore,
+    };
+
+    public ref class DeviceFamilyHelper sealed
+    {
+    private:
+        DeviceFamilyHelper() {}
+    public:
+        static DeviceFamily GetDeviceFamily();
+    private:
+        static void InitDeviceFamily();
+    private:
+        static bool m_isInit;
+        static DeviceFamily m_deviceFamily;
+    };
+}

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -1819,6 +1819,7 @@
                 <Setter Property="MinWideModeWidth" Value="641"/>
                 <Setter Property="MinTallModeHeight" Value="641"/>
                 <Setter Property="IsTabStop" Value="False"/>
+                <Setter Property="AutomationProperties.AccessibilityView" Value="Raw"/>
                 <Setter Property="Template">
                     <Setter.Value>
                         <ControlTemplate TargetType="Controls:TwoPaneViewCX">

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -3,6 +3,8 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:Controls="using:CalculatorApp.Controls"
              xmlns:common="using:CalculatorApp.Common"
+             xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
+             xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
              xmlns:local="using:CalculatorApp">
 
     <Application.Resources>
@@ -1805,6 +1807,125 @@
                                                   AutomationProperties.AccessibilityView="Raw"
                                                   Content="{TemplateBinding Description}"
                                                   x:Load="False"/>
+                            </Grid>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <Style TargetType="Controls:TwoPaneViewCX">
+                <Setter Property="HorizontalAlignment" Value="Stretch"/>
+                <Setter Property="VerticalAlignment" Value="Stretch"/>
+                <Setter Property="MinWideModeWidth" Value="641"/>
+                <Setter Property="MinTallModeHeight" Value="641"/>
+                <Setter Property="IsTabStop" Value="False"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Controls:TwoPaneViewCX">
+                            <Grid x:Name="RootGrid"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Stretch"
+                                  Background="{TemplateBinding Background}">
+
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition x:Name="PART_ColumnLeft" Width="Auto"/>
+                                    <ColumnDefinition x:Name="PART_ColumnMiddle" Width="0"/>
+                                    <ColumnDefinition x:Name="PART_ColumnRight" Width="*"/>
+                                </Grid.ColumnDefinitions>
+
+                                <Grid.RowDefinitions>
+                                    <RowDefinition x:Name="PART_RowTop" Height="*"/>
+                                    <RowDefinition x:Name="PART_RowMiddle" Height="0"/>
+                                    <RowDefinition x:Name="PART_RowBottom" Height="0"/>
+                                </Grid.RowDefinitions>
+                                <VisualStateManager.VisualStateGroups>
+                                    <VisualStateGroup x:Name="ModeStates">
+                                        <VisualState x:Name="ViewMode_LeftRight"/>
+
+                                        <VisualState x:Name="ViewMode_RightLeft">
+                                            <VisualState.Setters>
+                                                <contract7NotPresent:Setter Target="PART_Pane1.(Grid.Column)" Value="2"/>
+                                                <contract7NotPresent:Setter Target="PART_Pane2.(Grid.Column)" Value="0"/>
+
+                                                <contract7Present:Setter Target="PART_Pane1ScrollViewer.(Grid.Column)" Value="2"/>
+                                                <contract7Present:Setter Target="PART_Pane2ScrollViewer.(Grid.Column)" Value="0"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+
+                                        <VisualState x:Name="ViewMode_TopBottom">
+                                            <VisualState.Setters>
+                                                <contract7NotPresent:Setter Target="PART_Pane1.(Grid.Column)" Value="0"/>
+                                                <contract7NotPresent:Setter Target="PART_Pane1.(Grid.Row)" Value="0"/>
+
+                                                <contract7NotPresent:Setter Target="PART_Pane2.(Grid.Column)" Value="0"/>
+                                                <contract7NotPresent:Setter Target="PART_Pane2.(Grid.Row)" Value="2"/>
+
+                                                <contract7Present:Setter Target="PART_Pane1ScrollViewer.(Grid.Column)" Value="0"/>
+                                                <contract7Present:Setter Target="PART_Pane1ScrollViewer.(Grid.Row)" Value="0"/>
+
+                                                <contract7Present:Setter Target="PART_Pane2ScrollViewer.(Grid.Column)" Value="0"/>
+                                                <contract7Present:Setter Target="PART_Pane2ScrollViewer.(Grid.Row)" Value="2"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+
+                                        <VisualState x:Name="ViewMode_BottomTop">
+                                            <VisualState.Setters>
+                                                <contract7NotPresent:Setter Target="PART_Pane1.(Grid.Column)" Value="0"/>
+                                                <contract7NotPresent:Setter Target="PART_Pane1.(Grid.Row)" Value="2"/>
+
+                                                <contract7NotPresent:Setter Target="PART_Pane2.(Grid.Column)" Value="0"/>
+                                                <contract7NotPresent:Setter Target="PART_Pane2.(Grid.Row)" Value="0"/>
+
+                                                <contract7Present:Setter Target="PART_Pane1ScrollViewer.(Grid.Column)" Value="0"/>
+                                                <contract7Present:Setter Target="PART_Pane1ScrollViewer.(Grid.Row)" Value="2"/>
+
+                                                <contract7Present:Setter Target="PART_Pane2ScrollViewer.(Grid.Column)" Value="0"/>
+                                                <contract7Present:Setter Target="PART_Pane2ScrollViewer.(Grid.Row)" Value="0"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+
+                                        <VisualState x:Name="ViewMode_OneOnly">
+                                            <VisualState.Setters>
+                                                <contract7NotPresent:Setter Target="PART_Pane2.Visibility" Value="Collapsed"/>
+
+                                                <contract7Present:Setter Target="PART_Pane2ScrollViewer.Visibility" Value="Collapsed"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+
+                                        <VisualState x:Name="ViewMode_TwoOnly">
+                                            <VisualState.Setters>
+                                                <contract7NotPresent:Setter Target="PART_Pane1.Visibility" Value="Collapsed"/>
+                                                <contract7NotPresent:Setter Target="PART_Pane2.(Grid.Column)" Value="0"/>
+
+                                                <contract7Present:Setter Target="PART_Pane1ScrollViewer.Visibility" Value="Collapsed"/>
+                                                <contract7Present:Setter Target="PART_Pane2ScrollViewer.(Grid.Column)" Value="0"/>
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateManager.VisualStateGroups>
+
+                                <contract7Present:ScrollViewer x:Name="PART_Pane1ScrollViewer"
+                                                               Grid.Column="0"
+                                                               IsTabStop="False"
+                                                               VerticalScrollBarVisibility="Auto">
+                                    <Border Child="{TemplateBinding Pane1}"/>
+                                </contract7Present:ScrollViewer>
+
+                                <contract7Present:ScrollViewer x:Name="PART_Pane2ScrollViewer"
+                                                               Grid.Column="2"
+                                                               IsTabStop="False"
+                                                               VerticalScrollBarVisibility="Auto">
+                                    <Border Child="{TemplateBinding Pane2}"/>
+                                </contract7Present:ScrollViewer>
+
+                                <contract7NotPresent:Border x:Name="PART_Pane1"
+                                                            Grid.Column="0"
+                                                            Child="{TemplateBinding Pane1}"/>
+
+                                <contract7NotPresent:Border x:Name="PART_Pane2"
+                                                            Grid.Column="2"
+                                                            Child="{TemplateBinding Pane2}"/>
+
                             </Grid>
                         </ControlTemplate>
                     </Setter.Value>

--- a/src/Calculator/Calculator.vcxproj
+++ b/src/Calculator/Calculator.vcxproj
@@ -252,6 +252,7 @@
     </ClInclude>
     <ClInclude Include="Controls\RadixButton.h" />
     <ClInclude Include="Controls\SupplementaryItemsControl.h" />
+    <ClInclude Include="Controls\TwoPaneViewCX.h" />
     <ClInclude Include="Converters\BooleanNegationConverter.h" />
     <ClInclude Include="Converters\BooleanToVisibilityConverter.h" />
     <ClInclude Include="Converters\ExpressionItemTemplateSelector.h" />
@@ -329,6 +330,7 @@
     <ClInclude Include="Views\OperatorsPanel.xaml.h">
       <DependentUpon>Views\OperatorsPanel.xaml</DependentUpon>
     </ClInclude>
+    <ClInclude Include="Views\StateTriggers\ApplicationViewModeTrigger.h" />
     <ClInclude Include="Views\StateTriggers\AspectRatioTrigger.h" />
     <ClInclude Include="Views\StateTriggers\ControlSizeTrigger.h" />
     <ClInclude Include="Views\SupplementaryResults.xaml.h">
@@ -422,6 +424,7 @@
     </ClCompile>
     <ClCompile Include="Controls\RadixButton.cpp" />
     <ClCompile Include="Controls\SupplementaryItemsControl.cpp" />
+    <ClCompile Include="Controls\TwoPaneViewCX.cpp" />
     <ClCompile Include="Converters\BooleanNegationConverter.cpp" />
     <ClCompile Include="Converters\BooleanToVisibilityConverter.cpp" />
     <ClCompile Include="Converters\ExpressionItemTemplateSelector.cpp" />
@@ -505,6 +508,7 @@
     <ClCompile Include="Views\OperatorsPanel.xaml.cpp">
       <DependentUpon>Views\OperatorsPanel.xaml</DependentUpon>
     </ClCompile>
+    <ClCompile Include="Views\StateTriggers\ApplicationViewModeTrigger.cpp" />
     <ClCompile Include="Views\StateTriggers\AspectRatioTrigger.cpp" />
     <ClCompile Include="Views\StateTriggers\ControlSizeTrigger.cpp" />
     <ClCompile Include="Views\SupplementaryResults.xaml.cpp">

--- a/src/Calculator/Calculator.vcxproj.filters
+++ b/src/Calculator/Calculator.vcxproj.filters
@@ -329,6 +329,12 @@
     </ClCompile>
     <ClCompile Include="Common\ViewState.cpp" />
     <ClCompile Include="Utils\DispatcherTimerDelayer.cpp" />
+    <ClCompile Include="Controls\TwoPaneViewCX.cpp">
+      <Filter>Controls</Filter>
+    </ClCompile>
+    <ClCompile Include="Views\StateTriggers\ApplicationViewModeTrigger.cpp">
+      <Filter>Views\StateTriggers</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="pch.h" />
@@ -437,6 +443,12 @@
     </ClInclude>
     <ClInclude Include="Common\ViewState.h" />
     <ClInclude Include="Utils\DispatcherTimerDelayer.h" />
+    <ClInclude Include="Controls\TwoPaneViewCX.h">
+      <Filter>Controls</Filter>
+    </ClInclude>
+    <ClInclude Include="Views\StateTriggers\ApplicationViewModeTrigger.h">
+      <Filter>Views\StateTriggers</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <AppxManifest Include="Package.appxmanifest" />

--- a/src/Calculator/Controls/TwoPaneViewCX.cpp
+++ b/src/Calculator/Controls/TwoPaneViewCX.cpp
@@ -42,7 +42,7 @@ DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, MinTallModeHeight);
 
 TwoPaneViewCX::TwoPaneViewCX()
 {
-    this->DefaultStyleKey = L"CalculatorApp.Controls.TwoPaneViewCX";
+    this->DefaultStyleKey = TwoPaneViewCX::typeid->FullName;
     this->SizeChanged += ref new Windows::UI::Xaml::SizeChangedEventHandler(this, &TwoPaneViewCX::OnSizeChanged);
     m_windowSizeChangedToken = Window::Current->SizeChanged +=
         ref new Windows::UI::Xaml::WindowSizeChangedEventHandler(this, &TwoPaneViewCX::OnWindowSizeChanged);

--- a/src/Calculator/Controls/TwoPaneViewCX.cpp
+++ b/src/Calculator/Controls/TwoPaneViewCX.cpp
@@ -50,7 +50,10 @@ TwoPaneViewCX::TwoPaneViewCX()
 
 TwoPaneViewCX::~TwoPaneViewCX()
 {
-    Window::Current->SizeChanged -= m_windowSizeChangedToken;
+    if (Window::Current != nullptr)
+    {
+        Window::Current->SizeChanged -= m_windowSizeChangedToken;
+    }
 }
 
 void TwoPaneViewCX::OnApplyTemplate()

--- a/src/Calculator/Controls/TwoPaneViewCX.cpp
+++ b/src/Calculator/Controls/TwoPaneViewCX.cpp
@@ -1,0 +1,487 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#include "pch.h"
+#include "TwoPaneViewCX.h"
+#include "Utils/VisualTree.h"
+#include <math.h>
+
+using namespace std;
+using namespace Platform;
+using namespace CalculatorApp::Controls;
+using namespace Calculator::Utils;
+using namespace Windows::Foundation;
+using namespace Windows::UI::ViewManagement;
+using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Controls;
+using Windows::Foundation::Metadata::ApiInformation;
+namespace MUXC = Microsoft::UI::Xaml::Controls;
+
+StringReference c_pane1ScrollViewerName(L"PART_Pane1ScrollViewer");
+StringReference c_pane2ScrollViewerName(L"PART_Pane2ScrollViewer");
+StringReference c_columnLeftName(L"PART_ColumnLeft");
+StringReference c_columnMiddleName(L"PART_ColumnMiddle");
+StringReference c_columnRightName(L"PART_ColumnRight");
+StringReference c_rowTopName(L"PART_RowTop");
+StringReference c_rowMiddleName(L"PART_RowMiddle");
+StringReference c_rowBottomName(L"PART_RowBottom");
+
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, Pane1);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, Pane2);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, Pane1Length);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, Pane2Length);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, Pane1MinLength);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, Pane2MinLength);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, Pane1MaxLength);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, Pane2MaxLength);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, PanePriority);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, Mode);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, WideModeConfiguration);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, TallModeConfiguration);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, MinWideModeWidth);
+DEPENDENCY_PROPERTY_INITIALIZATION(TwoPaneViewCX, MinTallModeHeight);
+
+TwoPaneViewCX::TwoPaneViewCX()
+{
+    this->DefaultStyleKey = L"CalculatorApp.Controls.TwoPaneViewCX";
+    this->SizeChanged += ref new Windows::UI::Xaml::SizeChangedEventHandler(this, &TwoPaneViewCX::OnSizeChanged);
+    m_windowSizeChangedToken = Window::Current->SizeChanged +=
+        ref new Windows::UI::Xaml::WindowSizeChangedEventHandler(this, &TwoPaneViewCX::OnWindowSizeChanged);
+}
+
+TwoPaneViewCX::~TwoPaneViewCX()
+{
+    Window::Current->SizeChanged -= m_windowSizeChangedToken;
+}
+
+void TwoPaneViewCX::OnApplyTemplate()
+{
+    m_loaded = true;
+    this->SetScrollViewerProperties(c_pane1ScrollViewerName);
+    this->SetScrollViewerProperties(c_pane2ScrollViewerName);
+
+    if (auto column = dynamic_cast<ColumnDefinition ^>(this->GetTemplateChild(c_columnLeftName)))
+    {
+        m_columnLeft = column;
+    }
+    if (auto column = dynamic_cast<ColumnDefinition ^>(this->GetTemplateChild(c_columnMiddleName)))
+    {
+        m_columnMiddle = column;
+    }
+    if (auto column = dynamic_cast<ColumnDefinition ^>(this->GetTemplateChild(c_columnRightName)))
+    {
+        m_columnRight = column;
+    }
+    if (auto row = dynamic_cast<RowDefinition ^>(this->GetTemplateChild(c_rowTopName)))
+    {
+        m_rowTop = row;
+    }
+    if (auto row = dynamic_cast<RowDefinition ^>(this->GetTemplateChild(c_rowMiddleName)))
+    {
+        m_rowMiddle = row;
+    }
+    if (auto row = dynamic_cast<RowDefinition ^>(this->GetTemplateChild(c_rowBottomName)))
+    {
+        m_rowBottom = row;
+    }
+}
+
+void TwoPaneViewCX::UpdateMode()
+{
+    // Don't bother running this logic until after we hit OnApplyTemplate.
+    if (!m_loaded)
+        return;
+
+    double controlWidth = this->ActualWidth;
+    double controlHeight = this->ActualHeight;
+
+    ViewMode newMode = (this->PanePriority == MUXC::TwoPaneViewPriority::Pane1) ? ViewMode::Pane1Only : ViewMode::Pane2Only;
+
+    // Calculate new mode
+    Rect rcControl = GetControlRect();
+    auto info = this->GetDisplayRegionHelperInfo();
+    bool isInMultipleRegions = IsInMultipleRegions(info, rcControl);
+
+    if (isInMultipleRegions)
+    {
+        if (info.Mode == MUXC::TwoPaneViewMode::Wide)
+        {
+            // Regions are laid out horizontally
+            if (this->WideModeConfiguration != MUXC::TwoPaneViewWideModeConfiguration::SinglePane)
+            {
+                newMode = (this->WideModeConfiguration == MUXC::TwoPaneViewWideModeConfiguration::LeftRight) ? ViewMode::LeftRight : ViewMode::RightLeft;
+            }
+        }
+        else if (info.Mode == MUXC::TwoPaneViewMode::Tall)
+        {
+            // Regions are laid out vertically
+            if (this->TallModeConfiguration != MUXC::TwoPaneViewTallModeConfiguration::SinglePane)
+            {
+                newMode = (this->TallModeConfiguration == MUXC::TwoPaneViewTallModeConfiguration::TopBottom) ? ViewMode::TopBottom : ViewMode::BottomTop;
+            }
+        }
+    }
+    else
+    {
+        // One region
+        if (controlWidth > this->MinWideModeWidth && this->WideModeConfiguration != MUXC::TwoPaneViewWideModeConfiguration::SinglePane)
+        {
+            // Split horizontally
+            newMode = (this->WideModeConfiguration == MUXC::TwoPaneViewWideModeConfiguration::LeftRight) ? ViewMode::LeftRight : ViewMode::RightLeft;
+        }
+        else if (controlHeight > this->MinTallModeHeight && this->TallModeConfiguration != MUXC::TwoPaneViewTallModeConfiguration::SinglePane)
+        {
+            // Split vertically
+            newMode = (this->TallModeConfiguration == MUXC::TwoPaneViewTallModeConfiguration::TopBottom) ? ViewMode::TopBottom : ViewMode::BottomTop;
+        }
+    }
+
+    // Update row/column sizes (this may need to happen even if the mode doesn't change)
+    UpdateRowsColumns(newMode, info, rcControl);
+
+    // Update mode if necessary
+    if (newMode != m_currentMode)
+    {
+        m_currentMode = newMode;
+
+        auto newViewMode = MUXC::TwoPaneViewMode::SinglePane;
+
+        switch (m_currentMode)
+        {
+        case ViewMode::Pane1Only:
+            VisualStateManager::GoToState(this, L"ViewMode_OneOnly", true);
+            break;
+        case ViewMode::Pane2Only:
+            VisualStateManager::GoToState(this, L"ViewMode_TwoOnly", true);
+            break;
+        case ViewMode::LeftRight:
+            VisualStateManager::GoToState(this, L"ViewMode_LeftRight", true);
+            newViewMode = MUXC::TwoPaneViewMode::Wide;
+            break;
+        case ViewMode::RightLeft:
+            VisualStateManager::GoToState(this, L"ViewMode_RightLeft", true);
+            newViewMode = MUXC::TwoPaneViewMode::Wide;
+            break;
+        case ViewMode::TopBottom:
+            VisualStateManager::GoToState(this, L"ViewMode_TopBottom", true);
+            newViewMode = MUXC::TwoPaneViewMode::Tall;
+            break;
+        case ViewMode::BottomTop:
+            VisualStateManager::GoToState(this, L"ViewMode_BottomTop", true);
+            newViewMode = MUXC::TwoPaneViewMode::Tall;
+            break;
+        }
+
+        if (newViewMode != this->Mode)
+        {
+            SetValue(s_ModeProperty, newViewMode);
+            this->ModeChanged(this, this);
+        }
+    }
+}
+
+void TwoPaneViewCX::UpdateRowsColumns(ViewMode newMode, DisplayRegionHelperInfo info, Rect rcControl)
+{
+    if (m_columnLeft && m_columnMiddle && m_columnRight && m_rowTop && m_rowMiddle && m_rowBottom)
+    {
+        // Reset split lengths
+        this->m_columnMiddle->Width = GridLengthHelper::FromPixels(0);
+        this->m_rowMiddle->Height = GridLengthHelper::FromPixels(0);
+
+        // Set columns lengths
+        if (newMode == ViewMode::LeftRight || newMode == ViewMode::RightLeft)
+        {
+            if (newMode == ViewMode::LeftRight)
+            {
+                this->m_columnLeft->MinWidth = this->Pane1MinLength;
+                this->m_columnLeft->MaxWidth = this->Pane1MaxLength;
+                this->m_columnLeft->Width = this->Pane1Length;
+                this->m_columnRight->MinWidth = this->Pane2MinLength;
+                this->m_columnRight->MaxWidth = this->Pane2MaxLength;
+                this->m_columnRight->Width = this->Pane2Length;
+            }
+            else
+            {
+                this->m_columnLeft->MinWidth = this->Pane2MinLength;
+                this->m_columnLeft->MaxWidth = this->Pane2MaxLength;
+                this->m_columnLeft->Width = this->Pane2Length;
+                this->m_columnRight->MinWidth = this->Pane1MinLength;
+                this->m_columnRight->MaxWidth = this->Pane1MaxLength;
+                this->m_columnRight->Width = this->Pane1Length;
+            }
+        }
+        else
+        {
+            this->m_columnLeft->MinWidth = 0.0;
+            this->m_columnRight->MinWidth = 0.0; 
+            this->m_columnLeft->MaxWidth = std::numeric_limits<double>::max();
+            this->m_columnRight->MaxWidth = std::numeric_limits<double>::max();
+            this->m_columnLeft->Width = GridLengthHelper::FromValueAndType(1, GridUnitType::Star);
+            this->m_columnRight->Width = GridLengthHelper::FromPixels(0);
+        }
+
+        // Set row lengths
+        if (newMode == ViewMode::TopBottom || newMode == ViewMode::BottomTop)
+        {
+            if (newMode == ViewMode::TopBottom)
+            {
+                this->m_rowTop->MinHeight = this->Pane1MinLength;
+                this->m_rowTop->MaxHeight = this->Pane1MaxLength;
+                this->m_rowTop->Height = this->Pane1Length;
+                this->m_rowBottom->MinHeight = this->Pane2MinLength;
+                this->m_rowBottom->MaxHeight = this->Pane2MaxLength;
+                this->m_rowBottom->Height = this->Pane2Length;
+            }
+            else
+            {
+                this->m_rowTop->MinHeight = this->Pane2MinLength;
+                this->m_rowTop->MaxHeight = this->Pane2MaxLength;
+                this->m_rowTop->Height = this->Pane2Length;
+                this->m_rowBottom->MinHeight = this->Pane1MinLength;
+                this->m_rowBottom->MaxHeight = this->Pane1MaxLength;
+                this->m_rowBottom->Height = this->Pane1Length;
+            }
+        }
+        else
+        {
+            this->m_rowTop->MinHeight = 0.0;
+            this->m_rowBottom->MinHeight = 0.0;
+            this->m_rowTop->MaxHeight = std::numeric_limits<double>::max();
+            this->m_rowBottom->MaxHeight = std::numeric_limits<double>::max();
+            this->m_rowTop->Height = GridLengthHelper::FromValueAndType(1, GridUnitType::Star);
+            this->m_rowBottom->Height = GridLengthHelper::FromPixels(0);
+        }
+
+        // Handle regions
+        if (IsInMultipleRegions(info, rcControl) && newMode != ViewMode::Pane1Only && newMode != ViewMode::Pane2Only)
+        {
+            Rect rc1 = info.Regions[0];
+            Rect rc2 = info.Regions[1];
+            Rect rcWindow = Window::Current->Bounds;
+
+            if (info.Mode == MUXC::TwoPaneViewMode::Wide)
+            {
+                this->m_columnMiddle->Width = GridLengthHelper::FromPixels(rc2.X - rc1.Width);
+
+                this->m_columnLeft->MinWidth = 0.0;
+                this->m_columnRight->MinWidth = 0.0;
+                this->m_columnLeft->MaxWidth = std::numeric_limits<double>::max();
+                this->m_columnRight->MaxWidth = std::numeric_limits<double>::max();
+                this->m_columnLeft->Width = GridLengthHelper::FromPixels(rc1.Width - rcControl.X);
+                this->m_columnRight->Width = GridLengthHelper::FromPixels(rc2.Width - ((rcWindow.Width - rcControl.Width) - rcControl.X));
+            }
+            else
+            {
+                this->m_rowMiddle->Height = GridLengthHelper::FromPixels(rc2.Y - rc1.Height);
+
+                this->m_rowTop->MinHeight = 0.0;
+                this->m_rowBottom->MinHeight = 0.0;
+                this->m_rowTop->MaxHeight = std::numeric_limits<double>::max();
+                this->m_rowBottom->MaxHeight = std::numeric_limits<double>::max();
+                this->m_rowTop->Height = GridLengthHelper::FromPixels(rc1.Height - rcControl.Y);
+                this->m_rowBottom->Height = GridLengthHelper::FromPixels(rc2.Height - ((rcWindow.Height - rcControl.Height) - rcControl.Y));
+            }
+        }
+    }
+}
+
+Rect TwoPaneViewCX::GetControlRect()
+{
+    // Find out where this control is in the window
+    auto transform = TransformToVisual(Window::Current->Content);
+    return transform->TransformBounds(RectHelper::FromCoordinatesAndDimensions(0, 0, (float)this->ActualWidth, (float)this->ActualHeight));
+}
+
+bool TwoPaneViewCX::IsInMultipleRegions(DisplayRegionHelperInfo info, Rect rcControl)
+{
+    bool isInMultipleRegions = false;
+
+    if (info.Mode != MUXC::TwoPaneViewMode::SinglePane)
+    {
+        Rect rc1 = info.Regions[0];
+        Rect rc2 = info.Regions[1];
+
+        if (info.Mode == MUXC::TwoPaneViewMode::Wide)
+        {
+            // Check that the control is over the split
+            if (rcControl.X < rc1.Width && rcControl.X + rcControl.Width > rc2.X)
+            {
+                isInMultipleRegions = true;
+            }
+        }
+        else if (info.Mode == MUXC::TwoPaneViewMode::Tall)
+        {
+            // Check that the control is over the split
+            if (rcControl.Y < rc1.Height && rcControl.Y + rcControl.Height > rc2.Y)
+            {
+                isInMultipleRegions = true;
+            }
+        }
+    }
+
+    return isInMultipleRegions;
+}
+
+void TwoPaneViewCX::OnSizeChanged(Platform::Object ^ /*sender*/, Windows::UI::Xaml::SizeChangedEventArgs ^ /*e*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnWindowSizeChanged(Platform::Object ^ /*sender*/, Windows::UI::Core::WindowSizeChangedEventArgs ^ /*e*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnPane1LengthPropertyChanged(GridLength /*oldValue*/, GridLength /*newValue*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnPane2LengthPropertyChanged(GridLength /*oldValue*/, GridLength /*newValue*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnPane1MinLengthPropertyChanged(double /*oldValue*/, double /*newValue*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnPane2MinLengthPropertyChanged(double /*oldValue*/, double /*newValue*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnPane1MaxLengthPropertyChanged(double /*oldValue*/, double /*newValue*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnPane2MaxLengthPropertyChanged(double /*oldValue*/, double /*newValue*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnMinTallModeHeightPropertyChanged(double /*oldValue*/, double newValue)
+{
+    auto clampedValue = max(0.0, newValue);
+    if (clampedValue != newValue)
+    {
+        this->MinTallModeHeight = clampedValue;
+        return;
+    }
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnMinWideModeWidthPropertyChanged(double /*oldValue*/, double newValue)
+{
+    auto clampedValue = max(0.0, newValue);
+    if (clampedValue != newValue)
+    {
+        this->MinWideModeWidth = clampedValue;
+        return;
+    }
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnWideModeConfigurationPropertyChanged(
+    MUXC::TwoPaneViewWideModeConfiguration /*oldValue*/,
+    MUXC::TwoPaneViewWideModeConfiguration /*newValue*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnTallModeConfigurationPropertyChanged(
+    MUXC::TwoPaneViewTallModeConfiguration /*oldValue*/,
+    MUXC::TwoPaneViewTallModeConfiguration /*newValue*/)
+{
+    this->UpdateMode();
+}
+
+void TwoPaneViewCX::OnPanePriorityPropertyChanged(MUXC::TwoPaneViewPriority /*oldValue*/, MUXC::TwoPaneViewPriority /*newValue*/)
+{
+    this->UpdateMode();
+}
+
+TwoPaneViewCX::DisplayRegionHelperInfo TwoPaneViewCX::GetDisplayRegionHelperInfo()
+{
+    DisplayRegionHelperInfo info;
+    info.Mode = MUXC::TwoPaneViewMode::SinglePane;
+
+    if (!Windows::Foundation::Metadata::ApiInformation::IsMethodPresent(L"Windows.UI.ViewManagement.ApplicationView", L"GetDisplayRegions"))
+    {
+        return info;
+    }
+
+    // ApplicationView::GetForCurrentView throws on failure; in that case we just won't do anything.
+    ApplicationView ^ view;
+    try
+    {
+        view = ApplicationView::GetForCurrentView();
+    }
+    catch (...)
+    {
+    }
+
+    if (view && (int)view->ViewMode == 2 /*ApplicationViewMode::Spanning*/)
+    {
+        auto regions = view->GetDisplayRegions();
+        if (regions->Size == 2)
+        {
+            auto region1 = regions->GetAt(0);
+            auto region2 = regions->GetAt(1);
+            info.Regions = ref new Array<Rect>(2);
+            info.Regions[0] = RectHelper::FromCoordinatesAndDimensions(
+                region1->WorkAreaOffset.X, region1->WorkAreaOffset.Y, region1->WorkAreaSize.Width, region1->WorkAreaSize.Height);
+            info.Regions[1] = RectHelper::FromCoordinatesAndDimensions(
+                region2->WorkAreaOffset.X, region2->WorkAreaOffset.Y, region2->WorkAreaSize.Width, region2->WorkAreaSize.Height);
+
+            // Determine orientation. If neither of these are true, default to doing nothing.
+            if (info.Regions[0].X < info.Regions[1].X && info.Regions[0].Y == info.Regions[1].Y)
+            {
+                // Double portrait
+                info.Mode = MUXC::TwoPaneViewMode::Wide;
+            }
+            else if (info.Regions[0].X == info.Regions[1].X && info.Regions[0].Y < info.Regions[1].Y)
+            {
+                // Double landscape
+                info.Mode = MUXC::TwoPaneViewMode::Tall;
+            }
+        }
+    }
+    return info;
+}
+
+void TwoPaneViewCX::SetScrollViewerProperties(String ^ scrollViewerName)
+{
+    if (ApiInformation::IsApiContractPresent(L"Windows.Foundation.UniversalApiContract", 7))
+    {
+        if (auto scrollViewer = dynamic_cast<ScrollViewer ^>(this->GetTemplateChild(scrollViewerName)))
+        {
+            if (ApiInformation::IsPropertyPresent(L"Windows.UI.Xaml.Controls.ScrollContentPresenter", L"SizesContentToTemplatedParent"))
+            {
+                scrollViewer->Loaded += ref new RoutedEventHandler(this, &TwoPaneViewCX::OnScrollViewerLoaded);
+            }
+
+            if (ApiInformation::IsPropertyPresent(L"Windows.UI.Xaml.Controls.ScrollViewer", L"ReduceViewportForCoreInputViewOcclusions"))
+            {
+                scrollViewer->ReduceViewportForCoreInputViewOcclusions = true;
+            }
+        }
+    }
+}
+
+void TwoPaneViewCX::OnScrollViewerLoaded(Object ^ sender, RoutedEventArgs ^ e)
+{
+    if (auto scrollViewer = dynamic_cast<FrameworkElement ^>(sender))
+    {
+        auto scrollContentPresenterFE = VisualTree::FindDescendantByName(scrollViewer, L"ScrollContentPresenter");
+        if (scrollContentPresenterFE)
+        {
+            if (auto scrollContentPresenter = dynamic_cast<ScrollContentPresenter ^>(scrollContentPresenterFE))
+            {
+                scrollContentPresenter->SizesContentToTemplatedParent = true;
+            }
+        }
+    }
+}

--- a/src/Calculator/Controls/TwoPaneViewCX.cpp
+++ b/src/Calculator/Controls/TwoPaneViewCX.cpp
@@ -15,7 +15,6 @@ using namespace Windows::UI::ViewManagement;
 using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;
 using Windows::Foundation::Metadata::ApiInformation;
-namespace MUXC = Microsoft::UI::Xaml::Controls;
 
 StringReference c_pane1ScrollViewerName(L"PART_Pane1ScrollViewer");
 StringReference c_pane2ScrollViewerName(L"PART_Pane2ScrollViewer");
@@ -95,7 +94,7 @@ void TwoPaneViewCX::UpdateMode()
     double controlWidth = this->ActualWidth;
     double controlHeight = this->ActualHeight;
 
-    ViewMode newMode = (this->PanePriority == MUXC::TwoPaneViewPriority::Pane1) ? ViewMode::Pane1Only : ViewMode::Pane2Only;
+    ViewMode newMode = (this->PanePriority == TwoPaneViewCXPriority::Pane1) ? ViewMode::Pane1Only : ViewMode::Pane2Only;
 
     // Calculate new mode
     Rect rcControl = GetControlRect();
@@ -104,35 +103,35 @@ void TwoPaneViewCX::UpdateMode()
 
     if (isInMultipleRegions)
     {
-        if (info.Mode == MUXC::TwoPaneViewMode::Wide)
+        if (info.Mode == TwoPaneViewCXMode::Wide)
         {
             // Regions are laid out horizontally
-            if (this->WideModeConfiguration != MUXC::TwoPaneViewWideModeConfiguration::SinglePane)
+            if (this->WideModeConfiguration != TwoPaneViewCXWideModeConfiguration::SinglePane)
             {
-                newMode = (this->WideModeConfiguration == MUXC::TwoPaneViewWideModeConfiguration::LeftRight) ? ViewMode::LeftRight : ViewMode::RightLeft;
+                newMode = (this->WideModeConfiguration == TwoPaneViewCXWideModeConfiguration::LeftRight) ? ViewMode::LeftRight : ViewMode::RightLeft;
             }
         }
-        else if (info.Mode == MUXC::TwoPaneViewMode::Tall)
+        else if (info.Mode == TwoPaneViewCXMode::Tall)
         {
             // Regions are laid out vertically
-            if (this->TallModeConfiguration != MUXC::TwoPaneViewTallModeConfiguration::SinglePane)
+            if (this->TallModeConfiguration != TwoPaneViewCXTallModeConfiguration::SinglePane)
             {
-                newMode = (this->TallModeConfiguration == MUXC::TwoPaneViewTallModeConfiguration::TopBottom) ? ViewMode::TopBottom : ViewMode::BottomTop;
+                newMode = (this->TallModeConfiguration == TwoPaneViewCXTallModeConfiguration::TopBottom) ? ViewMode::TopBottom : ViewMode::BottomTop;
             }
         }
     }
     else
     {
         // One region
-        if (controlWidth > this->MinWideModeWidth && this->WideModeConfiguration != MUXC::TwoPaneViewWideModeConfiguration::SinglePane)
+        if (controlWidth > this->MinWideModeWidth && this->WideModeConfiguration != TwoPaneViewCXWideModeConfiguration::SinglePane)
         {
             // Split horizontally
-            newMode = (this->WideModeConfiguration == MUXC::TwoPaneViewWideModeConfiguration::LeftRight) ? ViewMode::LeftRight : ViewMode::RightLeft;
+            newMode = (this->WideModeConfiguration == TwoPaneViewCXWideModeConfiguration::LeftRight) ? ViewMode::LeftRight : ViewMode::RightLeft;
         }
-        else if (controlHeight > this->MinTallModeHeight && this->TallModeConfiguration != MUXC::TwoPaneViewTallModeConfiguration::SinglePane)
+        else if (controlHeight > this->MinTallModeHeight && this->TallModeConfiguration != TwoPaneViewCXTallModeConfiguration::SinglePane)
         {
             // Split vertically
-            newMode = (this->TallModeConfiguration == MUXC::TwoPaneViewTallModeConfiguration::TopBottom) ? ViewMode::TopBottom : ViewMode::BottomTop;
+            newMode = (this->TallModeConfiguration == TwoPaneViewCXTallModeConfiguration::TopBottom) ? ViewMode::TopBottom : ViewMode::BottomTop;
         }
     }
 
@@ -144,7 +143,7 @@ void TwoPaneViewCX::UpdateMode()
     {
         m_currentMode = newMode;
 
-        auto newViewMode = MUXC::TwoPaneViewMode::SinglePane;
+        auto newViewMode = TwoPaneViewCXMode::SinglePane;
 
         switch (m_currentMode)
         {
@@ -156,19 +155,19 @@ void TwoPaneViewCX::UpdateMode()
             break;
         case ViewMode::LeftRight:
             VisualStateManager::GoToState(this, L"ViewMode_LeftRight", true);
-            newViewMode = MUXC::TwoPaneViewMode::Wide;
+            newViewMode = TwoPaneViewCXMode::Wide;
             break;
         case ViewMode::RightLeft:
             VisualStateManager::GoToState(this, L"ViewMode_RightLeft", true);
-            newViewMode = MUXC::TwoPaneViewMode::Wide;
+            newViewMode = TwoPaneViewCXMode::Wide;
             break;
         case ViewMode::TopBottom:
             VisualStateManager::GoToState(this, L"ViewMode_TopBottom", true);
-            newViewMode = MUXC::TwoPaneViewMode::Tall;
+            newViewMode = TwoPaneViewCXMode::Tall;
             break;
         case ViewMode::BottomTop:
             VisualStateManager::GoToState(this, L"ViewMode_BottomTop", true);
-            newViewMode = MUXC::TwoPaneViewMode::Tall;
+            newViewMode = TwoPaneViewCXMode::Tall;
             break;
         }
 
@@ -259,7 +258,7 @@ void TwoPaneViewCX::UpdateRowsColumns(ViewMode newMode, DisplayRegionHelperInfo 
             Rect rc2 = info.Regions[1];
             Rect rcWindow = Window::Current->Bounds;
 
-            if (info.Mode == MUXC::TwoPaneViewMode::Wide)
+            if (info.Mode == TwoPaneViewCXMode::Wide)
             {
                 this->m_columnMiddle->Width = GridLengthHelper::FromPixels(rc2.X - rc1.Width);
 
@@ -296,12 +295,12 @@ bool TwoPaneViewCX::IsInMultipleRegions(DisplayRegionHelperInfo info, Rect rcCon
 {
     bool isInMultipleRegions = false;
 
-    if (info.Mode != MUXC::TwoPaneViewMode::SinglePane)
+    if (info.Mode != TwoPaneViewCXMode::SinglePane)
     {
         Rect rc1 = info.Regions[0];
         Rect rc2 = info.Regions[1];
 
-        if (info.Mode == MUXC::TwoPaneViewMode::Wide)
+        if (info.Mode == TwoPaneViewCXMode::Wide)
         {
             // Check that the control is over the split
             if (rcControl.X < rc1.Width && rcControl.X + rcControl.Width > rc2.X)
@@ -309,7 +308,7 @@ bool TwoPaneViewCX::IsInMultipleRegions(DisplayRegionHelperInfo info, Rect rcCon
                 isInMultipleRegions = true;
             }
         }
-        else if (info.Mode == MUXC::TwoPaneViewMode::Tall)
+        else if (info.Mode == TwoPaneViewCXMode::Tall)
         {
             // Check that the control is over the split
             if (rcControl.Y < rc1.Height && rcControl.Y + rcControl.Height > rc2.Y)
@@ -385,20 +384,20 @@ void TwoPaneViewCX::OnMinWideModeWidthPropertyChanged(double /*oldValue*/, doubl
 }
 
 void TwoPaneViewCX::OnWideModeConfigurationPropertyChanged(
-    MUXC::TwoPaneViewWideModeConfiguration /*oldValue*/,
-    MUXC::TwoPaneViewWideModeConfiguration /*newValue*/)
+    TwoPaneViewCXWideModeConfiguration /*oldValue*/,
+    TwoPaneViewCXWideModeConfiguration /*newValue*/)
 {
     this->UpdateMode();
 }
 
 void TwoPaneViewCX::OnTallModeConfigurationPropertyChanged(
-    MUXC::TwoPaneViewTallModeConfiguration /*oldValue*/,
-    MUXC::TwoPaneViewTallModeConfiguration /*newValue*/)
+    TwoPaneViewCXTallModeConfiguration /*oldValue*/,
+    TwoPaneViewCXTallModeConfiguration /*newValue*/)
 {
     this->UpdateMode();
 }
 
-void TwoPaneViewCX::OnPanePriorityPropertyChanged(MUXC::TwoPaneViewPriority /*oldValue*/, MUXC::TwoPaneViewPriority /*newValue*/)
+void TwoPaneViewCX::OnPanePriorityPropertyChanged(TwoPaneViewCXPriority /*oldValue*/, TwoPaneViewCXPriority /*newValue*/)
 {
     this->UpdateMode();
 }
@@ -406,7 +405,7 @@ void TwoPaneViewCX::OnPanePriorityPropertyChanged(MUXC::TwoPaneViewPriority /*ol
 TwoPaneViewCX::DisplayRegionHelperInfo TwoPaneViewCX::GetDisplayRegionHelperInfo()
 {
     DisplayRegionHelperInfo info;
-    info.Mode = MUXC::TwoPaneViewMode::SinglePane;
+    info.Mode = TwoPaneViewCXMode::SinglePane;
 
     if (!Windows::Foundation::Metadata::ApiInformation::IsMethodPresent(L"Windows.UI.ViewManagement.ApplicationView", L"GetDisplayRegions"))
     {
@@ -440,12 +439,12 @@ TwoPaneViewCX::DisplayRegionHelperInfo TwoPaneViewCX::GetDisplayRegionHelperInfo
             if (info.Regions[0].X < info.Regions[1].X && info.Regions[0].Y == info.Regions[1].Y)
             {
                 // Double portrait
-                info.Mode = MUXC::TwoPaneViewMode::Wide;
+                info.Mode = TwoPaneViewCXMode::Wide;
             }
             else if (info.Regions[0].X == info.Regions[1].X && info.Regions[0].Y < info.Regions[1].Y)
             {
                 // Double landscape
-                info.Mode = MUXC::TwoPaneViewMode::Tall;
+                info.Mode = TwoPaneViewCXMode::Tall;
             }
         }
     }

--- a/src/Calculator/Controls/TwoPaneViewCX.h
+++ b/src/Calculator/Controls/TwoPaneViewCX.h
@@ -1,0 +1,116 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See LICENSE in the project root for license information.
+
+#pragma once
+#include "CalcViewModel/Common/Utils.h"
+
+namespace CalculatorApp::Controls
+{
+    ref class TwoPaneViewCX;
+public
+    interface class ITwoPaneViewCX
+    {
+        event Windows::Foundation::TypedEventHandler<TwoPaneViewCX ^, Object ^> ^ ModeChanged;
+    };
+
+    // We can't use the TwoPaneView control from the SDK or from Microsoft.UI.Xaml because of a bug with C++ apps.
+    // (see this issue: https://github.com/microsoft/microsoft-ui-xaml/pull/2045)
+    // This class is a C++/CX port of the C++/WinRT version of Microsoft.UI.Xaml (commit b3a2e45) which include the patch to fix the crash.
+    // This fork adds also 4 new properties Pane1MinLength, Pane2MinLength, Pane1MaxLength, Pane2MaxLength
+public
+    ref class TwoPaneViewCX sealed : public Windows::UI::Xaml::Controls::Control, [Windows::Foundation::Metadata::Default] ITwoPaneViewCX
+    {
+        enum class ViewMode
+        {
+            Pane1Only,
+            Pane2Only,
+            LeftRight,
+            RightLeft,
+            TopBottom,
+            BottomTop,
+            None
+        };
+
+        struct DisplayRegionHelperInfo
+        {
+            Microsoft::UI::Xaml::Controls::TwoPaneViewMode Mode = Microsoft::UI::Xaml::Controls::TwoPaneViewMode::SinglePane;
+            Platform::Array<Windows::Foundation::Rect> ^ Regions;
+        };
+
+    public:
+        DEPENDENCY_PROPERTY_OWNER(TwoPaneViewCX);
+        DEPENDENCY_PROPERTY(Windows::UI::Xaml::UIElement ^, Pane1);
+        DEPENDENCY_PROPERTY(Windows::UI::Xaml::UIElement ^, Pane2);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(
+            Windows::UI::Xaml::GridLength,
+            Pane1Length,
+            Windows::UI::Xaml::GridLengthHelper::FromValueAndType(1, Windows::UI::Xaml::GridUnitType::Auto));
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(
+            Windows::UI::Xaml::GridLength,
+            Pane2Length,
+            Windows::UI::Xaml::GridLengthHelper::FromValueAndType(1, Windows::UI::Xaml::GridUnitType::Star));
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, Pane1MinLength, 0.0);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, Pane2MinLength, 0.0);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, Pane1MaxLength, std::numeric_limits<double>::max());
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, Pane2MaxLength, std::numeric_limits<double>::max());
+
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(Microsoft::UI::Xaml::Controls::TwoPaneViewPriority,
+            PanePriority,
+            Microsoft::UI::Xaml::Controls::TwoPaneViewPriority::Pane1);
+        DEPENDENCY_PROPERTY(Microsoft::UI::Xaml::Controls::TwoPaneViewMode, Mode);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(
+            Microsoft::UI::Xaml::Controls::TwoPaneViewWideModeConfiguration,
+            WideModeConfiguration,
+            Microsoft::UI::Xaml::Controls::TwoPaneViewWideModeConfiguration::LeftRight);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(
+            Microsoft::UI::Xaml::Controls::TwoPaneViewTallModeConfiguration,
+            TallModeConfiguration,
+            Microsoft::UI::Xaml::Controls::TwoPaneViewTallModeConfiguration::TopBottom);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, MinWideModeWidth, 641);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, MinTallModeHeight, 641);
+
+        TwoPaneViewCX();
+        virtual ~TwoPaneViewCX();
+        void OnApplyTemplate() override;
+        virtual event Windows::Foundation::TypedEventHandler<TwoPaneViewCX ^, Object ^> ^ ModeChanged;
+
+    private:
+        void UpdateRowsColumns(ViewMode newMode, DisplayRegionHelperInfo info, Windows::Foundation::Rect rcControl);
+        void UpdateMode();
+        bool IsInMultipleRegions(DisplayRegionHelperInfo info, Windows::Foundation::Rect rcControl);
+        void SetScrollViewerProperties(Platform::String ^ scrollViewerName);
+        Windows::Foundation::Rect GetControlRect();
+        DisplayRegionHelperInfo GetDisplayRegionHelperInfo();
+
+        void OnSizeChanged(Platform::Object ^ sender, Windows::UI::Xaml::SizeChangedEventArgs ^ e);
+        void OnWindowSizeChanged(Platform::Object ^ sender, Windows::UI::Core::WindowSizeChangedEventArgs ^ e);
+        void OnPane1LengthPropertyChanged(Windows::UI::Xaml::GridLength oldValue, Windows::UI::Xaml::GridLength newValue);
+        void OnPane2LengthPropertyChanged(Windows::UI::Xaml::GridLength oldValue, Windows::UI::Xaml::GridLength newValue);
+        void OnPane1MinLengthPropertyChanged(double oldValue, double newValue);
+        void OnPane2MinLengthPropertyChanged(double oldValue, double newValue);
+        void OnPane1MaxLengthPropertyChanged(double oldValue, double newValue);
+        void OnPane2MaxLengthPropertyChanged(double oldValue, double newValue);
+        void
+        OnPanePriorityPropertyChanged(Microsoft::UI::Xaml::Controls::TwoPaneViewPriority oldValue, Microsoft::UI::Xaml::Controls::TwoPaneViewPriority newValue);
+        void OnMinTallModeHeightPropertyChanged(double oldValue, double newValue);
+        void OnMinWideModeWidthPropertyChanged(double oldValue, double newValue);
+        void OnWideModeConfigurationPropertyChanged(
+            Microsoft::UI::Xaml::Controls::TwoPaneViewWideModeConfiguration oldValue,
+            Microsoft::UI::Xaml::Controls::TwoPaneViewWideModeConfiguration newValue);
+        void OnTallModeConfigurationPropertyChanged(
+            Microsoft::UI::Xaml::Controls::TwoPaneViewTallModeConfiguration oldValue,
+            Microsoft::UI::Xaml::Controls::TwoPaneViewTallModeConfiguration newValue);
+        void OnScrollViewerLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+
+    private:
+        Windows::UI::Xaml::Controls::ColumnDefinition ^ m_columnLeft;
+        Windows::UI::Xaml::Controls::ColumnDefinition ^ m_columnMiddle;
+        Windows::UI::Xaml::Controls::ColumnDefinition ^ m_columnRight;
+        Windows::UI::Xaml::Controls::RowDefinition ^ m_rowTop;
+        Windows::UI::Xaml::Controls::RowDefinition ^ m_rowMiddle;
+        Windows::UI::Xaml::Controls::RowDefinition ^ m_rowBottom;
+        Windows::Foundation::EventRegistrationToken m_windowSizeChangedToken;
+        ViewMode m_currentMode{ ViewMode::None };
+        bool m_loaded{ false };
+    };
+}

--- a/src/Calculator/Controls/TwoPaneViewCX.h
+++ b/src/Calculator/Controls/TwoPaneViewCX.h
@@ -13,6 +13,38 @@ public
         event Windows::Foundation::TypedEventHandler<TwoPaneViewCX ^, Object ^> ^ ModeChanged;
     };
 
+public
+    enum class TwoPaneViewCXWideModeConfiguration : int
+    {
+        SinglePane = 0,
+        LeftRight = 1,
+        RightLeft = 2,
+    };
+
+public
+    enum class TwoPaneViewCXTallModeConfiguration : int
+    {
+        SinglePane = 0,
+        TopBottom = 1,
+        BottomTop = 2,
+    };
+
+public
+    enum class TwoPaneViewCXPriority : int
+    {
+        Pane1 = 0,
+        Pane2 = 1,
+    };
+
+public
+    enum class TwoPaneViewCXMode: int
+    {
+        SinglePane = 0,
+        Wide = 1,
+        Tall = 2,
+    };
+
+
     // We can't use the TwoPaneView control from the SDK or from Microsoft.UI.Xaml because of a bug with C++ apps.
     // (see this issue: https://github.com/microsoft/microsoft-ui-xaml/pull/2045)
     // This class is a C++/CX port of the C++/WinRT version of Microsoft.UI.Xaml (commit b3a2e45) which include the patch to fix the crash.
@@ -33,7 +65,7 @@ public
 
         struct DisplayRegionHelperInfo
         {
-            Microsoft::UI::Xaml::Controls::TwoPaneViewMode Mode = Microsoft::UI::Xaml::Controls::TwoPaneViewMode::SinglePane;
+            TwoPaneViewCXMode Mode = TwoPaneViewCXMode::SinglePane;
             Platform::Array<Windows::Foundation::Rect> ^ Regions;
         };
 
@@ -54,18 +86,11 @@ public
         DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, Pane1MaxLength, std::numeric_limits<double>::max());
         DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, Pane2MaxLength, std::numeric_limits<double>::max());
 
-        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(Microsoft::UI::Xaml::Controls::TwoPaneViewPriority,
-            PanePriority,
-            Microsoft::UI::Xaml::Controls::TwoPaneViewPriority::Pane1);
-        DEPENDENCY_PROPERTY(Microsoft::UI::Xaml::Controls::TwoPaneViewMode, Mode);
-        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(
-            Microsoft::UI::Xaml::Controls::TwoPaneViewWideModeConfiguration,
-            WideModeConfiguration,
-            Microsoft::UI::Xaml::Controls::TwoPaneViewWideModeConfiguration::LeftRight);
-        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(
-            Microsoft::UI::Xaml::Controls::TwoPaneViewTallModeConfiguration,
-            TallModeConfiguration,
-            Microsoft::UI::Xaml::Controls::TwoPaneViewTallModeConfiguration::TopBottom);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(TwoPaneViewCXPriority,
+            PanePriority, TwoPaneViewCXPriority::Pane1);
+        DEPENDENCY_PROPERTY(TwoPaneViewCXMode, Mode);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(TwoPaneViewCXWideModeConfiguration, WideModeConfiguration, TwoPaneViewCXWideModeConfiguration::LeftRight);
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(TwoPaneViewCXTallModeConfiguration, TallModeConfiguration, TwoPaneViewCXTallModeConfiguration::TopBottom);
         DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, MinWideModeWidth, 641);
         DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, MinTallModeHeight, 641);
 
@@ -91,15 +116,11 @@ public
         void OnPane1MaxLengthPropertyChanged(double oldValue, double newValue);
         void OnPane2MaxLengthPropertyChanged(double oldValue, double newValue);
         void
-        OnPanePriorityPropertyChanged(Microsoft::UI::Xaml::Controls::TwoPaneViewPriority oldValue, Microsoft::UI::Xaml::Controls::TwoPaneViewPriority newValue);
+        OnPanePriorityPropertyChanged(TwoPaneViewCXPriority oldValue, TwoPaneViewCXPriority newValue);
         void OnMinTallModeHeightPropertyChanged(double oldValue, double newValue);
         void OnMinWideModeWidthPropertyChanged(double oldValue, double newValue);
-        void OnWideModeConfigurationPropertyChanged(
-            Microsoft::UI::Xaml::Controls::TwoPaneViewWideModeConfiguration oldValue,
-            Microsoft::UI::Xaml::Controls::TwoPaneViewWideModeConfiguration newValue);
-        void OnTallModeConfigurationPropertyChanged(
-            Microsoft::UI::Xaml::Controls::TwoPaneViewTallModeConfiguration oldValue,
-            Microsoft::UI::Xaml::Controls::TwoPaneViewTallModeConfiguration newValue);
+        void OnWideModeConfigurationPropertyChanged(TwoPaneViewCXWideModeConfiguration oldValue, TwoPaneViewCXWideModeConfiguration newValue);
+        void OnTallModeConfigurationPropertyChanged(TwoPaneViewCXTallModeConfiguration oldValue, TwoPaneViewCXTallModeConfiguration newValue);
         void OnScrollViewerLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 
     private:

--- a/src/Calculator/Package.appxmanifest
+++ b/src/Calculator/Package.appxmanifest
@@ -8,7 +8,7 @@
         <Logo>Assets\CalculatorStoreLogo.png</Logo>
     </Properties>
     <Dependencies>
-        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17133.0" MaxVersionTested="10.0.18362.0" />
+        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17133.0" MaxVersionTested="10.0.19400.0" />
     </Dependencies>
     <Resources>
         <Resource Language="x-generate" />

--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -8,6 +8,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="using:CalculatorApp"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:triggers="using:CalculatorApp.Views.StateTriggers"
              Loaded="OnLoaded"
              mc:Ignorable="d">
 
@@ -378,15 +379,7 @@
                             Icon="Paste"/>
         </MenuFlyout>
     </UserControl.Resources>
-
     <Grid AutomationProperties.LandmarkType="Main">
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="ColumnMain"/>
-            <ColumnDefinition x:Name="ColumnHistory"
-                              Width="0"
-                              MaxWidth="320"/>
-        </Grid.ColumnDefinitions>
-
         <VisualStateManager.VisualStateGroups>
             <!-- Error Layout specific -->
             <VisualStateGroup x:Name="ErrorVisualStates">
@@ -411,18 +404,13 @@
                         <Setter Target="MemPlus.IsEnabled" Value="False"/>
                         <Setter Target="MemMinus.IsEnabled" Value="False"/>
                         <Setter Target="MemButton.IsEnabled" Value="False"/>
-                        <Setter Target="RowExpression.Height" Value="0*"/>
+                        <Setter Target="RowExpression.Height" Value="0"/>
                         <Setter Target="RowHamburger.Height" Value="0"/>
-                        <Setter Target="RowMemoryControls.Height" Value="0*"/>
+                        <Setter Target="RowMemoryControls.Height" Value="0"/>
                     </VisualState.Setters>
                     <Storyboard Completed="OnDisplayVisualStateCompleted"/>
                 </VisualState>
                 <VisualState x:Name="DisplayModeNormal">
-                    <VisualState.Setters>
-                        <Setter Target="RowExpression.Height" Value="20*"/>
-                        <Setter Target="RowHamburger.Height" Value="{StaticResource HamburgerHeightGridLength}"/>
-                        <Setter Target="RowMemoryControls.Height" Value="32*"/>
-                    </VisualState.Setters>
                     <Storyboard Completed="OnDisplayVisualStateCompleted"/>
                 </VisualState>
             </VisualStateGroup>
@@ -456,12 +444,44 @@
             </VisualStateGroup>
             <!-- Layout specific -->
             <VisualStateGroup x:Name="LayoutVisualStates" CurrentStateChanged="OnVisualStateChanged">
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <triggers:ApplicationViewModeTrigger ViewMode="DoubleLandscape"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="DockPanel.Visibility" Value="Visible"/>
+                        <Setter Target="M6.Width" Value="0"/>
+                        <Setter Target="ExpressionText.Visibility" Value="Collapsed"/>
+                        <Setter Target="Results.Visibility" Value="Collapsed"/>
+                        <Setter Target="RowExpression.Height" Value="0"/>
+                        <Setter Target="RowMemoryControls.Height" Value="64"/>
+                        <Setter Target="RowHamburger.Height" Value="0"/>
+                        <Setter Target="RowDisplayControls.Height" Value="0"/>
+                        <Setter Target="DualScreenResultPanel.Visibility" Value="Visible"/>
+                        <Setter Target="DockPanel.BorderThickness" Value="1,0,0,0"/>
+                        <Setter Target="DockPanel.(Grid.ColumnSpan)" Value="1"/>
+                        <Setter Target="DockPanel.(Grid.Column)" Value="1"/>
+                        <Setter Target="Pane1Panel.Margin" Value="12,0,12,12"/>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <triggers:ApplicationViewModeTrigger ViewMode="DoublePortrait"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Pane1Panel.Margin" Value="12"/>
+                        <Setter Target="Pane2Panel.Margin" Value="12"/>
+                        <Setter Target="DockPanel.Visibility" Value="Visible"/>
+                        <Setter Target="M6.Width" Value="0"/>
+                    </VisualState.Setters>
+                    <Storyboard Completed="OnLayoutVisualStateCompleted"/>
+                </VisualState>
                 <VisualState x:Name="Portrait768x1366">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowHeight="1366" MinWindowWidth="768"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="ColumnHistory.Width" Value="320"/>
+                        <Setter Target="PaneView.Pane2Length" Value="320"/>
                         <Setter Target="DockPanel.Visibility" Value="Visible"/>
                         <Setter Target="M6.Width" Value="0"/>
                     </VisualState.Setters>
@@ -472,7 +492,7 @@
                         <AdaptiveTrigger MinWindowHeight="768" MinWindowWidth="1024"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="ColumnHistory.Width" Value="320"/>
+                        <Setter Target="PaneView.Pane2Length" Value="320"/>
                         <Setter Target="DockPanel.Visibility" Value="Visible"/>
                         <Setter Target="M6.Width" Value="0"/>
                     </VisualState.Setters>
@@ -483,8 +503,8 @@
                         <AdaptiveTrigger MinWindowHeight="0" MinWindowWidth="560"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="ColumnMain.Width" Value="320*"/>
-                        <Setter Target="ColumnHistory.Width" Value="240*"/>
+                        <Setter Target="PaneView.Pane1Length" Value="320*"/>
+                        <Setter Target="PaneView.Pane2Length" Value="240*"/>
                         <Setter Target="DockPanel.Visibility" Value="Visible"/>
                         <Setter Target="M6.Width" Value="0"/>
                     </VisualState.Setters>
@@ -512,11 +532,18 @@
                     <Storyboard Completed="OnLayoutVisualStateCompleted"/>
                 </VisualState>
             </VisualStateGroup>
-            <!-- Results display specific -->
             <VisualStateGroup>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <triggers:ApplicationViewModeTrigger ViewMode="DoubleLandscape"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="RowResult.Height" Value="0"/>
+                    </VisualState.Setters>
+                </VisualState>
                 <VisualState x:Name="RegularAlwaysOnTop">
                     <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowHeight="260"/>
+                        <triggers:ApplicationViewModeTrigger MinWindowHeight="260" ViewMode="CompactOverlay"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="RowResult.MinHeight" Value="54"/>
@@ -525,7 +552,7 @@
                 </VisualState>
                 <VisualState x:Name="MinAlwaysOnTop">
                     <VisualState.StateTriggers>
-                        <AdaptiveTrigger MinWindowHeight="0"/>
+                        <triggers:ApplicationViewModeTrigger MinWindowHeight="0" ViewMode="CompactOverlay"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="RowResult.MinHeight" Value="20"/>
@@ -535,8 +562,6 @@
                         <Setter Target="AlwaysOnTopResults.ScrollButtonsFontSize" Value="12"/>
                     </VisualState.Setters>
                 </VisualState>
-            </VisualStateGroup>
-            <VisualStateGroup>
                 <VisualState x:Name="ResultsL">
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowHeight="800"/>
@@ -570,704 +595,751 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
-        <Grid FlowDirection="LeftToRight">
-            <Grid.RowDefinitions>
-                <RowDefinition x:Name="RowHamburger" Height="{StaticResource HamburgerHeightGridLength}"/>
-                <RowDefinition x:Name="RowExpression"
-                               Height="20*"
-                               MinHeight="0"/>
-                <RowDefinition x:Name="RowResult"
-                               Height="72*"
-                               MinHeight="20"/>
-                <RowDefinition x:Name="RowDisplayControls" Height="0"/>
-                <RowDefinition x:Name="RowMemoryControls"
-                               Height="32*"
-                               MinHeight="0"/>
-                <RowDefinition x:Name="RowNumPad"
-                               Height="308*"
-                               MinHeight="0"/>
-            </Grid.RowDefinitions>
+        <controls:TwoPaneViewCX x:Name="PaneView"
+                                Grid.RowSpan="2"
+                                MinTallModeHeight="Infinity"
+                                MinWideModeWidth="0"
+                                Pane1Length="*"
+                                Pane2Length="0"
+                                Pane2MaxLength="320"
+                                TallModeConfiguration="BottomTop">
+            <controls:TwoPaneViewCX.Pane1>
+                <Grid x:Name="Pane1Panel" FlowDirection="LeftToRight">
+                    <Grid.RowDefinitions>
+                        <RowDefinition x:Name="RowHamburger" Height="{StaticResource HamburgerHeightGridLength}"/>
+                        <RowDefinition x:Name="RowExpression"
+                                       Height="20*"
+                                       MinHeight="0"/>
+                        <RowDefinition x:Name="RowResult"
+                                       Height="72*"
+                                       MinHeight="20"/>
+                        <RowDefinition x:Name="RowDisplayControls" Height="0"/>
+                        <RowDefinition x:Name="RowMemoryControls"
+                                       Height="32*"
+                                       MinHeight="0"/>
+                        <RowDefinition x:Name="RowNumPad"
+                                       Height="308*"
+                                       MinHeight="0"/>
+                    </Grid.RowDefinitions>
 
-            <controls:OverflowTextBlock x:Name="ExpressionText"
-                                        Grid.Row="1"
-                                        Margin="6,0,6,0"
-                                        VerticalAlignment="Bottom"
-                                        Style="{StaticResource NormalStyle}"
-                                        AutomationProperties.AutomationId="CalculatorExpression"
-                                        AutomationProperties.Name="{x:Bind Model.CalculationExpressionAutomationName, Mode=OneWay}"
-                                        IsTabStop="False"
-                                        TokensUpdated="{x:Bind Model.AreTokensUpdated, Mode=OneWay}"
-                                        Visibility="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
-            <controls:CalculationResult x:Name="Results"
-                                        x:Uid="CalculatorResults"
-                                        Grid.Row="2"
-                                        Margin="0,0,0,0"
-                                        Style="{StaticResource ResultsStyle}"
-                                        AutomationProperties.AutomationId="CalculatorResults"
-                                        AutomationProperties.HeadingLevel="Level1"
-                                        AutomationProperties.Name="{x:Bind Model.CalculationResultAutomationName, Mode=OneWay}"
-                                        ContextCanceled="OnContextCanceled"
-                                        ContextRequested="OnContextRequested"
-                                        DisplayValue="{x:Bind Model.DisplayValue, Mode=OneWay}"
-                                        IsInError="{x:Bind Model.IsInError, Mode=OneWay}"
-                                        IsOperatorCommand="{x:Bind Model.IsOperatorCommand, Mode=OneWay}"
-                                        TabIndex="1"
-                                        Visibility="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
-            <controls:OverflowTextBlock x:Name="AlwaysOnTopResults"
-                                        x:Uid="CalculatorAlwaysOnTopResults"
-                                        Grid.Row="2"
-                                        Margin="6,0,6,0"
-                                        HorizontalContentAlignment="Right"
-                                        Style="{StaticResource AOTResultsStyle}"
-                                        FontSize="40"
-                                        AutomationProperties.AutomationId="CalculatorAlwaysOnTopResults"
-                                        AutomationProperties.HeadingLevel="Level1"
-                                        AutomationProperties.Name="{x:Bind Model.CalculationResultAutomationName, Mode=OneWay}"
-                                        IsActive="True"
-                                        ScrollButtonsFontSize="28"
-                                        ScrollButtonsPlacement="Above"
-                                        ScrollButtonsWidth="28"
-                                        TokensUpdated="{x:Bind Model.AreAlwaysOnTopResultsUpdated, Mode=OneWay}"
-                                        UseSystemFocusVisuals="True"
-                                        Visibility="{x:Bind Model.IsAlwaysOnTop, Mode=OneWay}"/>
-
-            <!-- Programmer display panel controls -->
-            <local:CalculatorProgrammerOperators x:Name="ProgrammerOperators"
-                                                 Grid.Row="3"
-                                                 TabIndex="6"
-                                                 Visibility="{x:Bind Model.IsProgrammer, Mode=OneWay}"
-                                                 IsEnabled="{x:Bind Model.IsProgrammer, Mode=OneWay}"
-                                                 x:Load="False"/>
-
-            <local:CalculatorProgrammerDisplayPanel x:Name="ProgrammerDisplayPanel"
-                                                    Grid.Row="4"
-                                                    TabIndex="7"
-                                                    Visibility="{x:Bind Model.IsProgrammer, Mode=OneWay}"
-                                                    IsEnabled="{x:Bind Model.IsProgrammer, Mode=OneWay}"
-                                                    x:Load="False"/>
-
-            <Button x:Name="HistoryButton"
-                    x:Uid="HistoryButton"
-                    Grid.Row="0"
-                    Style="{StaticResource HistoryButtonStyle}"
-                    AutomationProperties.AutomationId="HistoryButton"
-                    Command="{x:Bind HistoryButtonPressed, Mode=OneTime}"
-                    Content="&#xe81c;"
-                    ExitDisplayModeOnAccessKeyInvoked="False"
-                    TabIndex="2"
-                    Visibility="{x:Bind local:Calculator.ShouldDisplayHistoryButton(Model.IsAlwaysOnTop, Model.IsProgrammer, DockPanel.Visibility), Mode=OneWay}"
-                    IsEnabled="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}">
-                <FlyoutBase.AttachedFlyout>
-                    <Flyout x:Name="HistoryFlyout"
-                            AutomationProperties.AutomationId="HistoryFlyout"
-                            Closed="HistoryFlyout_Closed"
-                            FlyoutPresenterStyle="{StaticResource HistoryFlyoutStyle}"
-                            Opened="HistoryFlyout_Opened"
-                            Placement="Full"/>
-                </FlyoutBase.AttachedFlyout>
-            </Button>
-
-            <!-- Scientific angle buttons -->
-            <local:CalculatorScientificAngleButtons x:Name="ScientificAngleButtons"
-                                                    Grid.Row="3"
-                                                    TabIndex="6"
-                                                    Visibility="{x:Bind Model.IsScientific, Mode=OneWay}"
-                                                    IsEnabled="{x:Bind Model.IsScientific, Mode=OneWay}"
-                                                    x:Load="False"/>
-
-            <!-- Memory panel controls -->
-            <Grid x:Name="MemoryPanel"
-                  x:Uid="MemoryPanel"
-                  Grid.Row="4"
-                  Margin="3,0,3,0"
-                  AutomationProperties.HeadingLevel="Level1"
-                  Visibility="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="1*" MaxWidth="80"/>
-                    <ColumnDefinition Width="1*" MaxWidth="80"/>
-                    <ColumnDefinition Width="1*" MaxWidth="80"/>
-                    <ColumnDefinition Width="1*" MaxWidth="80"/>
-                    <ColumnDefinition x:Name="M4"
-                                      Width="1*"
-                                      MaxWidth="80"/>
-                    <ColumnDefinition x:Name="M5" Width="0.01*"/>
-                    <ColumnDefinition x:Name="M6"
-                                      Width="1*"
-                                      MaxWidth="80"/>
-                </Grid.ColumnDefinitions>
-
-                <controls:CalculatorButton x:Name="ClearMemoryButton"
-                                           x:Uid="ClearMemoryButton"
-                                           Style="{StaticResource CaptionButtonStyle}"
-                                           AutomationProperties.AutomationId="ClearMemoryButton"
-                                           Command="{x:Bind Model.ClearMemoryCommand}"
-                                           Content="MC"
-                                           TabIndex="10"
-                                           Visibility="{Binding IsProgrammer, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
-                <controls:CalculatorButton x:Name="MemRecall"
-                                           x:Uid="MemRecall"
-                                           Grid.Column="1"
-                                           Style="{StaticResource CaptionButtonStyle}"
-                                           AutomationProperties.AutomationId="MemRecall"
-                                           Command="{x:Bind Model.MemoryItemPressed}"
-                                           CommandParameter="{StaticResource Zero}"
-                                           Content="MR"
-                                           TabIndex="11"
-                                           Visibility="{Binding IsProgrammer, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
-                <controls:CalculatorButton x:Name="MemPlus"
-                                           x:Uid="MemPlus"
-                                           Grid.Column="2"
-                                           Style="{StaticResource CaptionButtonStyle}"
-                                           AutomationProperties.AutomationId="MemPlus"
-                                           Command="{x:Bind Model.MemoryAdd}"
-                                           CommandParameter="{StaticResource Zero}"
-                                           Content="M+"
-                                           TabIndex="12"
-                                           Visibility="{Binding IsProgrammer, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
-                <controls:CalculatorButton x:Name="MemMinus"
-                                           x:Uid="MemMinus"
-                                           Grid.Column="3"
-                                           Style="{StaticResource CaptionButtonStyle}"
-                                           AutomationProperties.AutomationId="MemMinus"
-                                           Command="{x:Bind Model.MemorySubtract}"
-                                           CommandParameter="{StaticResource Zero}"
-                                           Content="M-"
-                                           TabIndex="13"
-                                           Visibility="{Binding IsProgrammer, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
-                <controls:CalculatorButton x:Name="MemButton"
-                                           x:Uid="memButton"
-                                           Grid.Column="4"
-                                           Style="{StaticResource CaptionButtonStyle}"
-                                           AutomationProperties.AutomationId="memButton"
-                                           ButtonId="Memory"
-                                           Content="MS"
-                                           TabIndex="14"/>
-                <Button x:Name="MemoryButton"
-                        x:Uid="MemoryButton"
-                        Grid.Column="6"
-                        MinWidth="15.5"
-                        MinHeight="8.402"
-                        Style="{StaticResource PathFakeButtonStyle}"
-                        AutomationProperties.AutomationId="MemoryButton"
-                        Click="ToggleMemoryFlyout"
-                        Content="M0,9.46968e-006L1.96199,9.46968e-006L4.17099,5.59502C4.33899,6.02501 4.44899,6.34502 4.5,6.55602L4.52899,6.55602C4.67299,6.11501 4.791,5.78701 4.87999,5.57201L7.12999,9.46968e-006L9.023,9.46968e-006L9.023,8.402L7.64,8.402L7.64,2.96501C7.64,2.519 7.668,1.97401 7.722,1.33L7.69899,1.33C7.613,1.697 7.53699,1.96101 7.46999,2.12102L4.96199,8.402L4.002,8.402L1.48799,2.16801C1.418,1.98399 1.34299,1.705 1.265,1.33L1.24199,1.33C1.273,1.666 1.28899,2.21501 1.28899,2.976L1.28899,8.402L0,8.402zM10.5,0L15.5,0L12.99,2.5z"
-                        ExitDisplayModeOnAccessKeyInvoked="False"
-                        TabIndex="15"
-                        IsEnabled="{x:Bind Model.IsMemoryEmpty, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}">
-                    <FlyoutBase.AttachedFlyout>
-                        <Flyout x:Name="MemoryFlyout"
-                                x:Uid="MemoryFlyout"
-                                AutomationProperties.AutomationId="MemoryFlyout"
-                                Closed="OnMemoryFlyoutClosed"
-                                FlyoutPresenterStyle="{StaticResource MemoryFlyoutStyle}"
-                                Opened="OnMemoryFlyoutOpened"
-                                Placement="Full"/>
-                    </FlyoutBase.AttachedFlyout>
-                </Button>
-            </Grid>
-
-            <Grid x:Name="NumpadPanel"
-                  Grid.Row="5"
-                  Margin="3,0,3,3"
-                  RenderTransformOrigin="0.5,0.5">
-                <Grid.RenderTransform>
-                    <CompositeTransform/>
-                </Grid.RenderTransform>
-
-                <local:OperatorsPanel x:Name="OpsPanel" IsBitFlipChecked="{x:Bind Model.IsBitFlipChecked, Mode=OneWay}"/>
-            </Grid>
-        </Grid>
-
-        <!-- Docked Pivot panel for history/memory -->
-        <Border x:Name="DockPanel"
-                x:Uid="DockPanel"
-                Grid.Row="1"
-                Grid.Column="1"
-                AutomationProperties.HeadingLevel="Level1"
-                Visibility="Collapsed">
-            <Border.Resources>
-                <!--
-                    This is a copy/paste of the Pivot template. The only change is setting the PivotPanel's ManipulationMode=None
-                    to disable swipe navigation between History and Memory to enable the SwipeControl
-                -->
-                <ControlTemplate x:Key="DockPanelTemplate" TargetType="Pivot">
-                    <Grid x:Name="RootElement"
-                          HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
-                          VerticalAlignment="{TemplateBinding VerticalAlignment}"
-                          Background="{TemplateBinding Background}">
-                        <Grid.Resources>
-                            <Style x:Key="BaseContentControlStyle" TargetType="ContentControl">
-                                <Setter Property="FontFamily" Value="XamlAutoFontFamily"/>
-                                <Setter Property="FontWeight" Value="SemiBold"/>
-                                <Setter Property="FontSize" Value="15"/>
-                                <Setter Property="Template">
-                                    <Setter.Value>
-                                        <ControlTemplate TargetType="ContentControl">
-                                            <ContentPresenter Margin="{TemplateBinding Padding}"
-                                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                              Content="{TemplateBinding Content}"
-                                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                              ContentTransitions="{TemplateBinding ContentTransitions}"
-                                                              OpticalMarginAlignment="TrimSideBearings"/>
-                                        </ControlTemplate>
-                                    </Setter.Value>
-                                </Setter>
-                            </Style>
-                            <Style x:Key="TitleContentControlStyle"
-                                   BasedOn="{StaticResource BaseContentControlStyle}"
-                                   TargetType="ContentControl">
-                                <Setter Property="FontFamily" Value="{ThemeResource PivotTitleFontFamily}"/>
-                                <Setter Property="FontWeight" Value="{ThemeResource PivotTitleThemeFontWeight}"/>
-                                <Setter Property="FontSize" Value="{ThemeResource PivotTitleFontSize}"/>
-                            </Style>
-                        </Grid.Resources>
-
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto"/>
-                            <RowDefinition Height="*"/>
-                        </Grid.RowDefinitions>
-
-                        <VisualStateManager.VisualStateGroups>
-                            <VisualStateGroup x:Name="Orientation">
-                                <VisualState x:Name="Portrait">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TitleContentControl" Storyboard.TargetProperty="Margin">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPortraitThemePadding}"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="Landscape">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TitleContentControl" Storyboard.TargetProperty="Margin">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotLandscapeThemePadding}"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="NavigationButtonsVisibility">
-                                <VisualState x:Name="NavigationButtonsHidden"/>
-                                <VisualState x:Name="NavigationButtonsVisible">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NextButton" Storyboard.TargetProperty="Opacity">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NextButton" Storyboard.TargetProperty="IsEnabled">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="True"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PreviousButton" Storyboard.TargetProperty="Opacity">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PreviousButton" Storyboard.TargetProperty="IsEnabled">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="True"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="PreviousButtonVisible">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PreviousButton" Storyboard.TargetProperty="Opacity">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PreviousButton" Storyboard.TargetProperty="IsEnabled">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="True"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                                <VisualState x:Name="NextButtonVisible">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NextButton" Storyboard.TargetProperty="Opacity">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NextButton" Storyboard.TargetProperty="IsEnabled">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="True"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
-                            <VisualStateGroup x:Name="HeaderStates">
-                                <VisualState x:Name="HeaderDynamic"/>
-                                <VisualState x:Name="HeaderStatic">
-                                    <Storyboard>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Header" Storyboard.TargetProperty="Visibility">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="StaticHeader" Storyboard.TargetProperty="Visibility">
-                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
-                                        </ObjectAnimationUsingKeyFrames>
-                                    </Storyboard>
-                                </VisualState>
-                            </VisualStateGroup>
-
-                        </VisualStateManager.VisualStateGroups>
-
-                        <ContentControl x:Name="TitleContentControl"
-                                        Margin="{StaticResource PivotPortraitThemePadding}"
-                                        Style="{StaticResource TitleContentControlStyle}"
-                                        Content="{TemplateBinding Title}"
-                                        ContentTemplate="{TemplateBinding TitleTemplate}"
-                                        IsTabStop="False"
-                                        Visibility="Collapsed"/>
-
-                        <Grid Grid.Row="1">
-                            <Grid.Resources>
-                                <ControlTemplate x:Key="NextTemplate" TargetType="Button">
-                                    <Border x:Name="Root"
-                                            Background="{ThemeResource PivotNextButtonBackground}"
-                                            BorderBrush="{ThemeResource PivotNextButtonBorderBrush}"
-                                            BorderThickness="{ThemeResource PivotNavButtonBorderThemeThickness}">
-                                        <VisualStateManager.VisualStateGroups>
-                                            <VisualStateGroup x:Name="CommonStates">
-                                                <VisualState x:Name="Normal"/>
-                                                <VisualState x:Name="PointerOver">
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonBackgroundPointerOver}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonBorderBrushPointerOver}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonForegroundPointerOver}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="Pressed">
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonBackgroundPressed}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonBorderBrushPressed}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonForegroundPressed}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                            </VisualStateGroup>
-                                        </VisualStateManager.VisualStateGroups>
-                                        <FontIcon x:Name="Arrow"
-                                                  HorizontalAlignment="Center"
-                                                  VerticalAlignment="Center"
-                                                  Foreground="{ThemeResource PivotNextButtonForeground}"
-                                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                                  FontSize="12"
-                                                  Glyph="&#xE0E3;"
-                                                  MirroredWhenRightToLeft="True"
-                                                  UseLayoutRounding="False"/>
-                                    </Border>
-                                </ControlTemplate>
-
-                                <ControlTemplate x:Key="PreviousTemplate" TargetType="Button">
-                                    <Border x:Name="Root"
-                                            Background="{ThemeResource PivotPreviousButtonBackground}"
-                                            BorderBrush="{ThemeResource PivotPreviousButtonBorderBrush}"
-                                            BorderThickness="{ThemeResource PivotNavButtonBorderThemeThickness}">
-                                        <VisualStateManager.VisualStateGroups>
-                                            <VisualStateGroup x:Name="CommonStates">
-                                                <VisualState x:Name="Normal"/>
-                                                <VisualState x:Name="PointerOver">
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonBackgroundPointerOver}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonBorderBrushPointerOver}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonForegroundPointerOver}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="Pressed">
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonBackgroundPressed}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonBorderBrushPressed}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonForegroundPressed}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                            </VisualStateGroup>
-                                        </VisualStateManager.VisualStateGroups>
-                                        <FontIcon x:Name="Arrow"
-                                                  HorizontalAlignment="Center"
-                                                  VerticalAlignment="Center"
-                                                  Foreground="{ThemeResource PivotPreviousButtonForeground}"
-                                                  FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                                  FontSize="12"
-                                                  Glyph="&#xE0E2;"
-                                                  MirroredWhenRightToLeft="True"
-                                                  UseLayoutRounding="False"/>
-                                    </Border>
-                                </ControlTemplate>
-                            </Grid.Resources>
-
-                            <ScrollViewer x:Name="ScrollViewer"
-                                          Margin="{TemplateBinding Padding}"
-                                          VerticalContentAlignment="Stretch"
-                                          BringIntoViewOnFocusChange="False"
-                                          HorizontalScrollBarVisibility="Hidden"
-                                          HorizontalSnapPointsAlignment="Center"
-                                          HorizontalSnapPointsType="MandatorySingle"
-                                          Template="{StaticResource ScrollViewerScrollBarlessTemplate}"
-                                          VerticalScrollBarVisibility="Disabled"
-                                          VerticalScrollMode="Disabled"
-                                          VerticalSnapPointsType="None"
-                                          ZoomMode="Disabled">
-                                <PivotPanel x:Name="Panel"
-                                            VerticalAlignment="Stretch"
-                                            ManipulationMode="None">
-                                    <Grid x:Name="PivotLayoutElement">
-                                        <Grid.RowDefinitions>
-                                            <RowDefinition Height="Auto"/>
-                                            <RowDefinition Height="*"/>
-                                        </Grid.RowDefinitions>
-                                        <Grid.ColumnDefinitions>
-                                            <ColumnDefinition Width="Auto"/>
-                                            <ColumnDefinition Width="*"/>
-                                            <ColumnDefinition Width="Auto"/>
-                                        </Grid.ColumnDefinitions>
-                                        <Grid.RenderTransform>
-                                            <CompositeTransform x:Name="PivotLayoutElementTranslateTransform"/>
-                                        </Grid.RenderTransform>
-                                        <ContentPresenter x:Name="LeftHeaderPresenter"
-                                                          HorizontalAlignment="Stretch"
-                                                          VerticalAlignment="Stretch"
-                                                          Content="{TemplateBinding LeftHeader}"
-                                                          ContentTemplate="{TemplateBinding LeftHeaderTemplate}"/>
-                                        <ContentControl x:Name="HeaderClipper"
-                                                        Grid.Column="1"
-                                                        HorizontalContentAlignment="Stretch"
-                                                        UseSystemFocusVisuals="{StaticResource UseSystemFocusVisuals}">
-                                            <ContentControl.Clip>
-                                                <RectangleGeometry x:Name="HeaderClipperGeometry"/>
-                                            </ContentControl.Clip>
-                                            <Grid Background="{ThemeResource PivotHeaderBackground}">
-                                                <Grid.RenderTransform>
-                                                    <CompositeTransform x:Name="HeaderOffsetTranslateTransform"/>
-                                                </Grid.RenderTransform>
-                                                <PivotHeaderPanel x:Name="StaticHeader" Visibility="Collapsed">
-                                                    <PivotHeaderPanel.RenderTransform>
-                                                        <CompositeTransform x:Name="StaticHeaderTranslateTransform"/>
-                                                    </PivotHeaderPanel.RenderTransform>
-                                                </PivotHeaderPanel>
-                                                <PivotHeaderPanel x:Name="Header">
-                                                    <PivotHeaderPanel.RenderTransform>
-                                                        <CompositeTransform x:Name="HeaderTranslateTransform"/>
-                                                    </PivotHeaderPanel.RenderTransform>
-                                                </PivotHeaderPanel>
-                                                <Rectangle x:Name="FocusFollower"
-                                                           HorizontalAlignment="Stretch"
-                                                           VerticalAlignment="Stretch"
-                                                           Fill="Transparent"
-                                                           Control.IsTemplateFocusTarget="True"
-                                                           IsHitTestVisible="False"/>
-                                            </Grid>
-                                        </ContentControl>
-                                        <Button x:Name="PreviousButton"
-                                                Grid.Column="1"
-                                                Width="20"
-                                                Height="36"
-                                                Margin="{ThemeResource PivotNavButtonMargin}"
-                                                HorizontalAlignment="Left"
-                                                VerticalAlignment="Top"
-                                                Background="Transparent"
-                                                Opacity="0"
+                    <controls:OverflowTextBlock x:Name="ExpressionText"
+                                                Grid.Row="1"
+                                                Margin="6,0,6,0"
+                                                VerticalAlignment="Bottom"
+                                                Style="{StaticResource NormalStyle}"
+                                                AutomationProperties.AutomationId="CalculatorExpression"
+                                                AutomationProperties.Name="{x:Bind Model.CalculationExpressionAutomationName, Mode=OneWay}"
                                                 IsTabStop="False"
-                                                Template="{StaticResource PreviousTemplate}"
-                                                UseSystemFocusVisuals="False"
-                                                IsEnabled="False"/>
-                                        <Button x:Name="NextButton"
-                                                Grid.Column="1"
-                                                Width="20"
-                                                Height="36"
-                                                Margin="{ThemeResource PivotNavButtonMargin}"
-                                                HorizontalAlignment="Right"
-                                                VerticalAlignment="Top"
-                                                Background="Transparent"
-                                                Opacity="0"
-                                                IsTabStop="False"
-                                                Template="{StaticResource NextTemplate}"
-                                                UseSystemFocusVisuals="False"
-                                                IsEnabled="False"/>
-                                        <ContentPresenter x:Name="RightHeaderPresenter"
-                                                          Grid.Column="2"
-                                                          HorizontalAlignment="Stretch"
-                                                          VerticalAlignment="Stretch"
-                                                          Content="{TemplateBinding RightHeader}"
-                                                          ContentTemplate="{TemplateBinding RightHeaderTemplate}"/>
-                                        <ItemsPresenter x:Name="PivotItemPresenter"
-                                                        Grid.Row="1"
-                                                        Grid.ColumnSpan="3">
-                                            <ItemsPresenter.RenderTransform>
-                                                <TransformGroup>
-                                                    <TranslateTransform x:Name="ItemsPresenterTranslateTransform"/>
-                                                    <CompositeTransform x:Name="ItemsPresenterCompositeTransform"/>
-                                                </TransformGroup>
-                                            </ItemsPresenter.RenderTransform>
-                                        </ItemsPresenter>
-                                    </Grid>
-                                </PivotPanel>
-                            </ScrollViewer>
-                        </Grid>
+                                                TokensUpdated="{x:Bind Model.AreTokensUpdated, Mode=OneWay}"
+                                                Visibility="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
+                    <controls:CalculationResult x:Name="Results"
+                                                x:Uid="CalculatorResults"
+                                                Grid.Row="2"
+                                                Margin="0,0,0,0"
+                                                Style="{StaticResource ResultsStyle}"
+                                                AutomationProperties.AutomationId="CalculatorResults"
+                                                AutomationProperties.HeadingLevel="Level1"
+                                                AutomationProperties.Name="{x:Bind Model.CalculationResultAutomationName, Mode=OneWay}"
+                                                ContextCanceled="OnContextCanceled"
+                                                ContextRequested="OnContextRequested"
+                                                DisplayValue="{x:Bind Model.DisplayValue, Mode=OneWay}"
+                                                IsInError="{x:Bind Model.IsInError, Mode=OneWay}"
+                                                IsOperatorCommand="{x:Bind Model.IsOperatorCommand, Mode=OneWay}"
+                                                TabIndex="1"
+                                                Visibility="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
+                    <controls:OverflowTextBlock x:Name="AlwaysOnTopResults"
+                                                x:Uid="CalculatorAlwaysOnTopResults"
+                                                Grid.Row="2"
+                                                Margin="6,0,6,0"
+                                                HorizontalContentAlignment="Right"
+                                                Style="{StaticResource AOTResultsStyle}"
+                                                FontSize="40"
+                                                AutomationProperties.AutomationId="CalculatorAlwaysOnTopResults"
+                                                AutomationProperties.HeadingLevel="Level1"
+                                                AutomationProperties.Name="{x:Bind Model.CalculationResultAutomationName, Mode=OneWay}"
+                                                IsActive="True"
+                                                ScrollButtonsFontSize="28"
+                                                ScrollButtonsPlacement="Above"
+                                                ScrollButtonsWidth="28"
+                                                TokensUpdated="{x:Bind Model.AreAlwaysOnTopResultsUpdated, Mode=OneWay}"
+                                                UseSystemFocusVisuals="True"
+                                                Visibility="{x:Bind Model.IsAlwaysOnTop, Mode=OneWay}"/>
+
+                    <!-- Programmer display panel controls -->
+                    <local:CalculatorProgrammerOperators x:Name="ProgrammerOperators"
+                                                         Grid.Row="3"
+                                                         TabIndex="6"
+                                                         Visibility="{x:Bind Model.IsProgrammer, Mode=OneWay}"
+                                                         IsEnabled="{x:Bind Model.IsProgrammer, Mode=OneWay}"
+                                                         x:Load="False"/>
+
+                    <local:CalculatorProgrammerDisplayPanel x:Name="ProgrammerDisplayPanel"
+                                                            Grid.Row="4"
+                                                            TabIndex="7"
+                                                            Visibility="{x:Bind Model.IsProgrammer, Mode=OneWay}"
+                                                            IsEnabled="{x:Bind Model.IsProgrammer, Mode=OneWay}"
+                                                            x:Load="False"/>
+
+                    <Button x:Name="HistoryButton"
+                            x:Uid="HistoryButton"
+                            Grid.Row="0"
+                            Style="{StaticResource HistoryButtonStyle}"
+                            AutomationProperties.AutomationId="HistoryButton"
+                            Command="{x:Bind HistoryButtonPressed, Mode=OneTime}"
+                            Content="&#xe81c;"
+                            ExitDisplayModeOnAccessKeyInvoked="False"
+                            TabIndex="2"
+                            Visibility="{x:Bind local:Calculator.ShouldDisplayHistoryButton(Model.IsAlwaysOnTop, Model.IsProgrammer, DockPanel.Visibility), Mode=OneWay}"
+                            IsEnabled="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}">
+                        <FlyoutBase.AttachedFlyout>
+                            <Flyout x:Name="HistoryFlyout"
+                                    AutomationProperties.AutomationId="HistoryFlyout"
+                                    Closed="HistoryFlyout_Closed"
+                                    FlyoutPresenterStyle="{StaticResource HistoryFlyoutStyle}"
+                                    Opened="HistoryFlyout_Opened"
+                                    Placement="Full"/>
+                        </FlyoutBase.AttachedFlyout>
+                    </Button>
+
+                    <!-- Scientific angle buttons -->
+                    <local:CalculatorScientificAngleButtons x:Name="ScientificAngleButtons"
+                                                            Grid.Row="3"
+                                                            TabIndex="6"
+                                                            Visibility="{x:Bind Model.IsScientific, Mode=OneWay}"
+                                                            IsEnabled="{x:Bind Model.IsScientific, Mode=OneWay}"
+                                                            x:Load="False"/>
+
+                    <!-- Memory panel controls -->
+                    <Grid x:Name="MemoryPanel"
+                          x:Uid="MemoryPanel"
+                          Grid.Row="4"
+                          Margin="3,0,3,0"
+                          AutomationProperties.HeadingLevel="Level1"
+                          Visibility="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1*" MaxWidth="80"/>
+                            <ColumnDefinition Width="1*" MaxWidth="80"/>
+                            <ColumnDefinition Width="1*" MaxWidth="80"/>
+                            <ColumnDefinition Width="1*" MaxWidth="80"/>
+                            <ColumnDefinition x:Name="M4"
+                                              Width="1*"
+                                              MaxWidth="80"/>
+                            <ColumnDefinition x:Name="M5" Width="0.01*"/>
+                            <ColumnDefinition x:Name="M6"
+                                              Width="1*"
+                                              MaxWidth="80"/>
+                        </Grid.ColumnDefinitions>
+
+                        <controls:CalculatorButton x:Name="ClearMemoryButton"
+                                                   x:Uid="ClearMemoryButton"
+                                                   Style="{StaticResource CaptionButtonStyle}"
+                                                   AutomationProperties.AutomationId="ClearMemoryButton"
+                                                   Command="{x:Bind Model.ClearMemoryCommand}"
+                                                   Content="MC"
+                                                   TabIndex="10"
+                                                   Visibility="{Binding IsProgrammer, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
+                        <controls:CalculatorButton x:Name="MemRecall"
+                                                   x:Uid="MemRecall"
+                                                   Grid.Column="1"
+                                                   Style="{StaticResource CaptionButtonStyle}"
+                                                   AutomationProperties.AutomationId="MemRecall"
+                                                   Command="{x:Bind Model.MemoryItemPressed}"
+                                                   CommandParameter="{StaticResource Zero}"
+                                                   Content="MR"
+                                                   TabIndex="11"
+                                                   Visibility="{Binding IsProgrammer, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
+                        <controls:CalculatorButton x:Name="MemPlus"
+                                                   x:Uid="MemPlus"
+                                                   Grid.Column="2"
+                                                   Style="{StaticResource CaptionButtonStyle}"
+                                                   AutomationProperties.AutomationId="MemPlus"
+                                                   Command="{x:Bind Model.MemoryAdd}"
+                                                   CommandParameter="{StaticResource Zero}"
+                                                   Content="M+"
+                                                   TabIndex="12"
+                                                   Visibility="{Binding IsProgrammer, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
+                        <controls:CalculatorButton x:Name="MemMinus"
+                                                   x:Uid="MemMinus"
+                                                   Grid.Column="3"
+                                                   Style="{StaticResource CaptionButtonStyle}"
+                                                   AutomationProperties.AutomationId="MemMinus"
+                                                   Command="{x:Bind Model.MemorySubtract}"
+                                                   CommandParameter="{StaticResource Zero}"
+                                                   Content="M-"
+                                                   TabIndex="13"
+                                                   Visibility="{Binding IsProgrammer, Converter={StaticResource BooleanToVisibilityNegationConverter}}"/>
+                        <controls:CalculatorButton x:Name="MemButton"
+                                                   x:Uid="memButton"
+                                                   Grid.Column="4"
+                                                   Style="{StaticResource CaptionButtonStyle}"
+                                                   AutomationProperties.AutomationId="memButton"
+                                                   ButtonId="Memory"
+                                                   Content="MS"
+                                                   TabIndex="14"/>
+                        <Button x:Name="MemoryButton"
+                                x:Uid="MemoryButton"
+                                Grid.Column="6"
+                                MinWidth="15.5"
+                                MinHeight="8.402"
+                                Style="{StaticResource PathFakeButtonStyle}"
+                                AutomationProperties.AutomationId="MemoryButton"
+                                Click="ToggleMemoryFlyout"
+                                Content="M0,9.46968e-006L1.96199,9.46968e-006L4.17099,5.59502C4.33899,6.02501 4.44899,6.34502 4.5,6.55602L4.52899,6.55602C4.67299,6.11501 4.791,5.78701 4.87999,5.57201L7.12999,9.46968e-006L9.023,9.46968e-006L9.023,8.402L7.64,8.402L7.64,2.96501C7.64,2.519 7.668,1.97401 7.722,1.33L7.69899,1.33C7.613,1.697 7.53699,1.96101 7.46999,2.12102L4.96199,8.402L4.002,8.402L1.48799,2.16801C1.418,1.98399 1.34299,1.705 1.265,1.33L1.24199,1.33C1.273,1.666 1.28899,2.21501 1.28899,2.976L1.28899,8.402L0,8.402zM10.5,0L15.5,0L12.99,2.5z"
+                                ExitDisplayModeOnAccessKeyInvoked="False"
+                                TabIndex="15"
+                                IsEnabled="{x:Bind Model.IsMemoryEmpty, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}">
+                            <FlyoutBase.AttachedFlyout>
+                                <Flyout x:Name="MemoryFlyout"
+                                        x:Uid="MemoryFlyout"
+                                        AutomationProperties.AutomationId="MemoryFlyout"
+                                        Closed="OnMemoryFlyoutClosed"
+                                        FlyoutPresenterStyle="{StaticResource MemoryFlyoutStyle}"
+                                        Opened="OnMemoryFlyoutOpened"
+                                        Placement="Full"/>
+                            </FlyoutBase.AttachedFlyout>
+                        </Button>
                     </Grid>
-                </ControlTemplate>
-            </Border.Resources>
 
-            <Pivot x:Name="DockPivot"
-                   TabIndex="5"
-                   Tapped="DockPanelTapped"
-                   Template="{StaticResource DockPanelTemplate}">
-                <Pivot.Resources>
-                    <Style TargetType="PivotHeaderItem">
-                        <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
-                        <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundTransparentBrush}"/>
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="PivotHeaderItem">
-                                    <Grid x:Name="Grid"
-                                          Padding="{TemplateBinding Padding}"
-                                          Background="{TemplateBinding Background}">
-                                        <Grid.RenderTransform>
-                                            <TranslateTransform x:Name="ContentPresenterTranslateTransform"/>
-                                        </Grid.RenderTransform>
-                                        <VisualStateManager.VisualStateGroups>
-                                            <VisualStateGroup x:Name="SelectionStates">
-                                                <VisualStateGroup.Transitions>
-                                                    <VisualTransition From="Unselected"
-                                                                      GeneratedDuration="0:0:0.33"
-                                                                      To="UnselectedLocked"/>
-                                                    <VisualTransition From="UnselectedLocked"
-                                                                      GeneratedDuration="0:0:0.33"
-                                                                      To="Unselected"/>
-                                                </VisualStateGroup.Transitions>
-                                                <VisualState x:Name="Disabled">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
-                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundDisabled}"/>
-                                                        <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundDisabled}"/>
-                                                    </VisualState.Setters>
-                                                </VisualState>
-                                                <VisualState x:Name="Unselected"/>
-                                                <VisualState x:Name="UnselectedLocked">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
-                                                        <Setter Target="ContentPresenter.(UIElement.Opacity)" Value="0"/>
-                                                    </VisualState.Setters>
-                                                    <Storyboard>
-                                                        <DoubleAnimation Duration="0"
-                                                                         Storyboard.TargetName="ContentPresenterTranslateTransform"
-                                                                         Storyboard.TargetProperty="X"
-                                                                         To="{ThemeResource PivotHeaderItemLockedTranslation}"/>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="Selected">
-                                                    <!--
-                                                        TODO: MSFT 13767760: Need to use storyboards here because
-                                                        visualstate setters are bugged
-                                                    -->
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SelectedPipe" Storyboard.TargetProperty="Visibility">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemForegroundSelected}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundSelected}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="UnselectedPointerOver">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
-                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundUnselectedPointerOver}"/>
-                                                        <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundUnselectedPointerOver}"/>
-                                                    </VisualState.Setters>
-                                                </VisualState>
-                                                <VisualState x:Name="SelectedPointerOver">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Visible"/>
-                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundSelectedPointerOver}"/>
-                                                        <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundSelectedPointerOver}"/>
-                                                    </VisualState.Setters>
-                                                </VisualState>
-                                                <VisualState x:Name="UnselectedPressed">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
-                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundUnselectedPressed}"/>
-                                                        <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundUnselectedPressed}"/>
-                                                    </VisualState.Setters>
-                                                </VisualState>
-                                                <VisualState x:Name="SelectedPressed">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Visible"/>
-                                                        <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundSelectedPressed}"/>
-                                                        <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundSelectedPressed}"/>
-                                                    </VisualState.Setters>
-                                                </VisualState>
-                                            </VisualStateGroup>
-                                            <VisualStateGroup x:Name="FocusStates">
-                                                <VisualState x:Name="Focused">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="FocusPipe.Visibility" Value="Visible"/>
-                                                    </VisualState.Setters>
-                                                </VisualState>
-                                                <VisualState x:Name="Unfocused"/>
-                                            </VisualStateGroup>
-                                        </VisualStateManager.VisualStateGroups>
-                                        <Rectangle x:Name="FocusPipe"
-                                                   Stroke="{ThemeResource SystemControlFocusVisualPrimaryBrush}"
-                                                   StrokeThickness="2"
-                                                   Visibility="Collapsed"/>
-                                        <Grid Margin="4,0,4,0">
-                                            <ContentPresenter x:Name="ContentPresenter"
-                                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                              FontFamily="{TemplateBinding FontFamily}"
-                                                              FontSize="{TemplateBinding FontSize}"
-                                                              FontWeight="{TemplateBinding FontWeight}"
-                                                              Content="{TemplateBinding Content}"
-                                                              ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                              OpticalMarginAlignment="TrimSideBearings"/>
-                                            <Rectangle x:Name="SelectedPipe"
-                                                       Height="3"
-                                                       Margin="0,0,0,6"
-                                                       HorizontalAlignment="Stretch"
-                                                       VerticalAlignment="Bottom"
-                                                       Fill="{ThemeResource AppControlTransparentAccentColorBrush}"
-                                                       Visibility="Collapsed"/>
-                                        </Grid>
+                    <Grid x:Name="NumpadPanel"
+                          Grid.Row="5"
+                          Margin="3,0,3,3"
+                          RenderTransformOrigin="0.5,0.5">
+                        <Grid.RenderTransform>
+                            <CompositeTransform/>
+                        </Grid.RenderTransform>
+
+                        <local:OperatorsPanel x:Name="OpsPanel" IsBitFlipChecked="{x:Bind Model.IsBitFlipChecked, Mode=OneWay}"/>
+                    </Grid>
+                </Grid>
+            </controls:TwoPaneViewCX.Pane1>
+
+            <controls:TwoPaneViewCX.Pane2>
+                <Grid x:Name="Pane2Panel">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="248"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel x:Name="DualScreenResultPanel"
+                                Padding="0,0,12,0"
+                                VerticalAlignment="Center"
+                                Visibility="Collapsed"
+                                x:Load="False">
+                        <controls:OverflowTextBlock x:Name="DualScreenExpressionText"
+                                                    Margin="6,0,6,0"
+                                                    VerticalAlignment="Bottom"
+                                                    Style="{StaticResource NormalStyle}"
+                                                    AutomationProperties.AutomationId="CalculatorExpression"
+                                                    AutomationProperties.Name="{x:Bind Model.CalculationExpressionAutomationName, Mode=OneWay}"
+                                                    IsTabStop="False"
+                                                    TokensUpdated="{x:Bind Model.AreTokensUpdated, Mode=OneWay}"/>
+
+                        <controls:CalculationResult x:Uid="CalculatorResults"
+                                                    Style="{StaticResource ResultsStyle}"
+                                                    AutomationProperties.AutomationId="CalculatorResults"
+                                                    AutomationProperties.HeadingLevel="Level1"
+                                                    AutomationProperties.Name="{x:Bind Model.CalculationResultAutomationName, Mode=OneWay}"
+                                                    ContextCanceled="OnContextCanceled"
+                                                    ContextRequested="OnContextRequested"
+                                                    DisplayValue="{x:Bind Model.DisplayValue, Mode=OneWay}"
+                                                    IsInError="{x:Bind Model.IsInError, Mode=OneWay}"
+                                                    IsOperatorCommand="{x:Bind Model.IsOperatorCommand, Mode=OneWay}"
+                                                    MaxFontSize="72"/>
+
+                    </StackPanel>
+                    <!-- Docked Pivot panel for history/memory -->
+                    <Border x:Name="DockPanel"
+                            x:Uid="DockPanel"
+                            Grid.ColumnSpan="2"
+                            BorderBrush="{ThemeResource DividerBrush}"
+                            BorderThickness="0"
+                            AutomationProperties.HeadingLevel="Level1"
+                            Visibility="Collapsed">
+                        <Border.Resources>
+                            <!--
+                                This is a copy/paste of the Pivot template. The only change is setting the PivotPanel's ManipulationMode=None
+                                to disable swipe navigation between History and Memory to enable the SwipeControl
+                            -->
+                            <ControlTemplate x:Key="DockPanelTemplate" TargetType="Pivot">
+                                <Grid x:Name="RootElement"
+                                      HorizontalAlignment="{TemplateBinding HorizontalAlignment}"
+                                      VerticalAlignment="{TemplateBinding VerticalAlignment}"
+                                      Background="{TemplateBinding Background}">
+                                    <Grid.Resources>
+                                        <Style x:Key="BaseContentControlStyle" TargetType="ContentControl">
+                                            <Setter Property="FontFamily" Value="XamlAutoFontFamily"/>
+                                            <Setter Property="FontWeight" Value="SemiBold"/>
+                                            <Setter Property="FontSize" Value="15"/>
+                                            <Setter Property="Template">
+                                                <Setter.Value>
+                                                    <ControlTemplate TargetType="ContentControl">
+                                                        <ContentPresenter Margin="{TemplateBinding Padding}"
+                                                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                                          Content="{TemplateBinding Content}"
+                                                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                                          ContentTransitions="{TemplateBinding ContentTransitions}"
+                                                                          OpticalMarginAlignment="TrimSideBearings"/>
+                                                    </ControlTemplate>
+                                                </Setter.Value>
+                                            </Setter>
+                                        </Style>
+                                        <Style x:Key="TitleContentControlStyle"
+                                               BasedOn="{StaticResource BaseContentControlStyle}"
+                                               TargetType="ContentControl">
+                                            <Setter Property="FontFamily" Value="{ThemeResource PivotTitleFontFamily}"/>
+                                            <Setter Property="FontWeight" Value="{ThemeResource PivotTitleThemeFontWeight}"/>
+                                            <Setter Property="FontSize" Value="{ThemeResource PivotTitleFontSize}"/>
+                                        </Style>
+                                    </Grid.Resources>
+
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto"/>
+                                        <RowDefinition Height="*"/>
+                                    </Grid.RowDefinitions>
+
+                                    <VisualStateManager.VisualStateGroups>
+                                        <VisualStateGroup x:Name="Orientation">
+                                            <VisualState x:Name="Portrait">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TitleContentControl" Storyboard.TargetProperty="Margin">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPortraitThemePadding}"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                            <VisualState x:Name="Landscape">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="TitleContentControl" Storyboard.TargetProperty="Margin">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotLandscapeThemePadding}"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                        <VisualStateGroup x:Name="NavigationButtonsVisibility">
+                                            <VisualState x:Name="NavigationButtonsHidden"/>
+                                            <VisualState x:Name="NavigationButtonsVisible">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NextButton" Storyboard.TargetProperty="Opacity">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NextButton" Storyboard.TargetProperty="IsEnabled">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="True"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PreviousButton" Storyboard.TargetProperty="Opacity">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PreviousButton" Storyboard.TargetProperty="IsEnabled">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="True"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                            <VisualState x:Name="PreviousButtonVisible">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PreviousButton" Storyboard.TargetProperty="Opacity">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="PreviousButton" Storyboard.TargetProperty="IsEnabled">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="True"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                            <VisualState x:Name="NextButtonVisible">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NextButton" Storyboard.TargetProperty="Opacity">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="1"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="NextButton" Storyboard.TargetProperty="IsEnabled">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="True"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                        </VisualStateGroup>
+                                        <VisualStateGroup x:Name="HeaderStates">
+                                            <VisualState x:Name="HeaderDynamic"/>
+                                            <VisualState x:Name="HeaderStatic">
+                                                <Storyboard>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Header" Storyboard.TargetProperty="Visibility">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="Collapsed"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="StaticHeader" Storyboard.TargetProperty="Visibility">
+                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
+                                                    </ObjectAnimationUsingKeyFrames>
+                                                </Storyboard>
+                                            </VisualState>
+                                        </VisualStateGroup>
+
+                                    </VisualStateManager.VisualStateGroups>
+
+                                    <ContentControl x:Name="TitleContentControl"
+                                                    Margin="{StaticResource PivotPortraitThemePadding}"
+                                                    Style="{StaticResource TitleContentControlStyle}"
+                                                    Content="{TemplateBinding Title}"
+                                                    ContentTemplate="{TemplateBinding TitleTemplate}"
+                                                    IsTabStop="False"
+                                                    Visibility="Collapsed"/>
+
+                                    <Grid Grid.Row="1">
+                                        <Grid.Resources>
+                                            <ControlTemplate x:Key="NextTemplate" TargetType="Button">
+                                                <Border x:Name="Root"
+                                                        Background="{ThemeResource PivotNextButtonBackground}"
+                                                        BorderBrush="{ThemeResource PivotNextButtonBorderBrush}"
+                                                        BorderThickness="{ThemeResource PivotNavButtonBorderThemeThickness}">
+                                                    <VisualStateManager.VisualStateGroups>
+                                                        <VisualStateGroup x:Name="CommonStates">
+                                                            <VisualState x:Name="Normal"/>
+                                                            <VisualState x:Name="PointerOver">
+                                                                <Storyboard>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonBackgroundPointerOver}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonBorderBrushPointerOver}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonForegroundPointerOver}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                </Storyboard>
+                                                            </VisualState>
+                                                            <VisualState x:Name="Pressed">
+                                                                <Storyboard>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonBackgroundPressed}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonBorderBrushPressed}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotNextButtonForegroundPressed}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                </Storyboard>
+                                                            </VisualState>
+                                                        </VisualStateGroup>
+                                                    </VisualStateManager.VisualStateGroups>
+                                                    <FontIcon x:Name="Arrow"
+                                                              HorizontalAlignment="Center"
+                                                              VerticalAlignment="Center"
+                                                              Foreground="{ThemeResource PivotNextButtonForeground}"
+                                                              FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                              FontSize="12"
+                                                              Glyph="&#xE0E3;"
+                                                              MirroredWhenRightToLeft="True"
+                                                              UseLayoutRounding="False"/>
+                                                </Border>
+                                            </ControlTemplate>
+
+                                            <ControlTemplate x:Key="PreviousTemplate" TargetType="Button">
+                                                <Border x:Name="Root"
+                                                        Background="{ThemeResource PivotPreviousButtonBackground}"
+                                                        BorderBrush="{ThemeResource PivotPreviousButtonBorderBrush}"
+                                                        BorderThickness="{ThemeResource PivotNavButtonBorderThemeThickness}">
+                                                    <VisualStateManager.VisualStateGroups>
+                                                        <VisualStateGroup x:Name="CommonStates">
+                                                            <VisualState x:Name="Normal"/>
+                                                            <VisualState x:Name="PointerOver">
+                                                                <Storyboard>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonBackgroundPointerOver}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonBorderBrushPointerOver}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonForegroundPointerOver}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                </Storyboard>
+                                                            </VisualState>
+                                                            <VisualState x:Name="Pressed">
+                                                                <Storyboard>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="Background">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonBackgroundPressed}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Root" Storyboard.TargetProperty="BorderBrush">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonBorderBrushPressed}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Arrow" Storyboard.TargetProperty="Foreground">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotPreviousButtonForegroundPressed}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                </Storyboard>
+                                                            </VisualState>
+                                                        </VisualStateGroup>
+                                                    </VisualStateManager.VisualStateGroups>
+                                                    <FontIcon x:Name="Arrow"
+                                                              HorizontalAlignment="Center"
+                                                              VerticalAlignment="Center"
+                                                              Foreground="{ThemeResource PivotPreviousButtonForeground}"
+                                                              FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                              FontSize="12"
+                                                              Glyph="&#xE0E2;"
+                                                              MirroredWhenRightToLeft="True"
+                                                              UseLayoutRounding="False"/>
+                                                </Border>
+                                            </ControlTemplate>
+                                        </Grid.Resources>
+
+                                        <ScrollViewer x:Name="ScrollViewer"
+                                                      Margin="{TemplateBinding Padding}"
+                                                      VerticalContentAlignment="Stretch"
+                                                      BringIntoViewOnFocusChange="False"
+                                                      HorizontalScrollBarVisibility="Hidden"
+                                                      HorizontalSnapPointsAlignment="Center"
+                                                      HorizontalSnapPointsType="MandatorySingle"
+                                                      Template="{StaticResource ScrollViewerScrollBarlessTemplate}"
+                                                      VerticalScrollBarVisibility="Disabled"
+                                                      VerticalScrollMode="Disabled"
+                                                      VerticalSnapPointsType="None"
+                                                      ZoomMode="Disabled">
+                                            <PivotPanel x:Name="Panel"
+                                                        VerticalAlignment="Stretch"
+                                                        ManipulationMode="None">
+                                                <Grid x:Name="PivotLayoutElement">
+                                                    <Grid.RowDefinitions>
+                                                        <RowDefinition Height="Auto"/>
+                                                        <RowDefinition Height="*"/>
+                                                    </Grid.RowDefinitions>
+                                                    <Grid.ColumnDefinitions>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                        <ColumnDefinition Width="*"/>
+                                                        <ColumnDefinition Width="Auto"/>
+                                                    </Grid.ColumnDefinitions>
+                                                    <Grid.RenderTransform>
+                                                        <CompositeTransform x:Name="PivotLayoutElementTranslateTransform"/>
+                                                    </Grid.RenderTransform>
+                                                    <ContentPresenter x:Name="LeftHeaderPresenter"
+                                                                      HorizontalAlignment="Stretch"
+                                                                      VerticalAlignment="Stretch"
+                                                                      Content="{TemplateBinding LeftHeader}"
+                                                                      ContentTemplate="{TemplateBinding LeftHeaderTemplate}"/>
+                                                    <ContentControl x:Name="HeaderClipper"
+                                                                    Grid.Column="1"
+                                                                    HorizontalContentAlignment="Stretch"
+                                                                    UseSystemFocusVisuals="{StaticResource UseSystemFocusVisuals}">
+                                                        <ContentControl.Clip>
+                                                            <RectangleGeometry x:Name="HeaderClipperGeometry"/>
+                                                        </ContentControl.Clip>
+                                                        <Grid Background="{ThemeResource PivotHeaderBackground}">
+                                                            <Grid.RenderTransform>
+                                                                <CompositeTransform x:Name="HeaderOffsetTranslateTransform"/>
+                                                            </Grid.RenderTransform>
+                                                            <PivotHeaderPanel x:Name="StaticHeader" Visibility="Collapsed">
+                                                                <PivotHeaderPanel.RenderTransform>
+                                                                    <CompositeTransform x:Name="StaticHeaderTranslateTransform"/>
+                                                                </PivotHeaderPanel.RenderTransform>
+                                                            </PivotHeaderPanel>
+                                                            <PivotHeaderPanel x:Name="Header">
+                                                                <PivotHeaderPanel.RenderTransform>
+                                                                    <CompositeTransform x:Name="HeaderTranslateTransform"/>
+                                                                </PivotHeaderPanel.RenderTransform>
+                                                            </PivotHeaderPanel>
+                                                            <Rectangle x:Name="FocusFollower"
+                                                                       HorizontalAlignment="Stretch"
+                                                                       VerticalAlignment="Stretch"
+                                                                       Fill="Transparent"
+                                                                       Control.IsTemplateFocusTarget="True"
+                                                                       IsHitTestVisible="False"/>
+                                                        </Grid>
+                                                    </ContentControl>
+                                                    <Button x:Name="PreviousButton"
+                                                            Grid.Column="1"
+                                                            Width="20"
+                                                            Height="36"
+                                                            Margin="{ThemeResource PivotNavButtonMargin}"
+                                                            HorizontalAlignment="Left"
+                                                            VerticalAlignment="Top"
+                                                            Background="Transparent"
+                                                            Opacity="0"
+                                                            IsTabStop="False"
+                                                            Template="{StaticResource PreviousTemplate}"
+                                                            UseSystemFocusVisuals="False"
+                                                            IsEnabled="False"/>
+                                                    <Button x:Name="NextButton"
+                                                            Grid.Column="1"
+                                                            Width="20"
+                                                            Height="36"
+                                                            Margin="{ThemeResource PivotNavButtonMargin}"
+                                                            HorizontalAlignment="Right"
+                                                            VerticalAlignment="Top"
+                                                            Background="Transparent"
+                                                            Opacity="0"
+                                                            IsTabStop="False"
+                                                            Template="{StaticResource NextTemplate}"
+                                                            UseSystemFocusVisuals="False"
+                                                            IsEnabled="False"/>
+                                                    <ContentPresenter x:Name="RightHeaderPresenter"
+                                                                      Grid.Column="2"
+                                                                      HorizontalAlignment="Stretch"
+                                                                      VerticalAlignment="Stretch"
+                                                                      Content="{TemplateBinding RightHeader}"
+                                                                      ContentTemplate="{TemplateBinding RightHeaderTemplate}"/>
+                                                    <ItemsPresenter x:Name="PivotItemPresenter"
+                                                                    Grid.Row="1"
+                                                                    Grid.ColumnSpan="3">
+                                                        <ItemsPresenter.RenderTransform>
+                                                            <TransformGroup>
+                                                                <TranslateTransform x:Name="ItemsPresenterTranslateTransform"/>
+                                                                <CompositeTransform x:Name="ItemsPresenterCompositeTransform"/>
+                                                            </TransformGroup>
+                                                        </ItemsPresenter.RenderTransform>
+                                                    </ItemsPresenter>
+                                                </Grid>
+                                            </PivotPanel>
+                                        </ScrollViewer>
                                     </Grid>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
-                </Pivot.Resources>
-                <PivotItem x:Name="HistoryPivotItem"
-                           x:Uid="HistoryPivotItem"
-                           Margin="0,10,0,0"
-                           AutomationProperties.AutomationId="HistoryLabel">
-                    <PivotItem.Header>
-                        <TextBlock x:Uid="HistoryLabel" AccessKeyInvoked="OnHistoryAccessKeyInvoked"/>
-                    </PivotItem.Header>
-                    <Border x:Name="DockHistoryHolder"/>
-                </PivotItem>
-                <PivotItem x:Name="MemoryPivotItem"
-                           x:Uid="MemoryPivotItem"
-                           Margin="0,10,0,0"
-                           AutomationProperties.AutomationId="MemoryLabel">
-                    <PivotItem.Header>
-                        <TextBlock x:Uid="MemoryLabel" AccessKeyInvoked="OnMemoryAccessKeyInvoked"/>
-                    </PivotItem.Header>
-                    <Border x:Name="DockMemoryHolder"/>
-                </PivotItem>
-            </Pivot>
-        </Border>
+                                </Grid>
+                            </ControlTemplate>
+                        </Border.Resources>
+
+                        <Pivot x:Name="DockPivot"
+                               TabIndex="5"
+                               Tapped="DockPanelTapped"
+                               Template="{StaticResource DockPanelTemplate}">
+                            <Pivot.Resources>
+                                <Style TargetType="PivotHeaderItem">
+                                    <Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}"/>
+                                    <Setter Property="Background" Value="{ThemeResource SystemControlBackgroundTransparentBrush}"/>
+                                    <Setter Property="Template">
+                                        <Setter.Value>
+                                            <ControlTemplate TargetType="PivotHeaderItem">
+                                                <Grid x:Name="Grid"
+                                                      Padding="{TemplateBinding Padding}"
+                                                      Background="{TemplateBinding Background}">
+                                                    <Grid.RenderTransform>
+                                                        <TranslateTransform x:Name="ContentPresenterTranslateTransform"/>
+                                                    </Grid.RenderTransform>
+                                                    <VisualStateManager.VisualStateGroups>
+                                                        <VisualStateGroup x:Name="SelectionStates">
+                                                            <VisualStateGroup.Transitions>
+                                                                <VisualTransition From="Unselected"
+                                                                                  GeneratedDuration="0:0:0.33"
+                                                                                  To="UnselectedLocked"/>
+                                                                <VisualTransition From="UnselectedLocked"
+                                                                                  GeneratedDuration="0:0:0.33"
+                                                                                  To="Unselected"/>
+                                                            </VisualStateGroup.Transitions>
+                                                            <VisualState x:Name="Disabled">
+                                                                <VisualState.Setters>
+                                                                    <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
+                                                                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundDisabled}"/>
+                                                                    <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundDisabled}"/>
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                            <VisualState x:Name="Unselected"/>
+                                                            <VisualState x:Name="UnselectedLocked">
+                                                                <VisualState.Setters>
+                                                                    <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
+                                                                    <Setter Target="ContentPresenter.(UIElement.Opacity)" Value="0"/>
+                                                                </VisualState.Setters>
+                                                                <Storyboard>
+                                                                    <DoubleAnimation Duration="0"
+                                                                                     Storyboard.TargetName="ContentPresenterTranslateTransform"
+                                                                                     Storyboard.TargetProperty="X"
+                                                                                     To="{ThemeResource PivotHeaderItemLockedTranslation}"/>
+                                                                </Storyboard>
+                                                            </VisualState>
+                                                            <VisualState x:Name="Selected">
+                                                                <!--
+                                                                    TODO: MSFT 13767760: Need to use storyboards here because
+                                                                    visualstate setters are bugged
+                                                                -->
+                                                                <Storyboard>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SelectedPipe" Storyboard.TargetProperty="Visibility">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="Visible"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemForegroundSelected}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                    <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
+                                                                        <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundSelected}"/>
+                                                                    </ObjectAnimationUsingKeyFrames>
+                                                                </Storyboard>
+                                                            </VisualState>
+                                                            <VisualState x:Name="UnselectedPointerOver">
+                                                                <VisualState.Setters>
+                                                                    <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
+                                                                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundUnselectedPointerOver}"/>
+                                                                    <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundUnselectedPointerOver}"/>
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                            <VisualState x:Name="SelectedPointerOver">
+                                                                <VisualState.Setters>
+                                                                    <Setter Target="SelectedPipe.Visibility" Value="Visible"/>
+                                                                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundSelectedPointerOver}"/>
+                                                                    <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundSelectedPointerOver}"/>
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                            <VisualState x:Name="UnselectedPressed">
+                                                                <VisualState.Setters>
+                                                                    <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
+                                                                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundUnselectedPressed}"/>
+                                                                    <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundUnselectedPressed}"/>
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                            <VisualState x:Name="SelectedPressed">
+                                                                <VisualState.Setters>
+                                                                    <Setter Target="SelectedPipe.Visibility" Value="Visible"/>
+                                                                    <Setter Target="ContentPresenter.Foreground" Value="{ThemeResource PivotHeaderItemForegroundSelectedPressed}"/>
+                                                                    <Setter Target="Grid.Background" Value="{ThemeResource PivotHeaderItemBackgroundSelectedPressed}"/>
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                        </VisualStateGroup>
+                                                        <VisualStateGroup x:Name="FocusStates">
+                                                            <VisualState x:Name="Focused">
+                                                                <VisualState.Setters>
+                                                                    <Setter Target="FocusPipe.Visibility" Value="Visible"/>
+                                                                </VisualState.Setters>
+                                                            </VisualState>
+                                                            <VisualState x:Name="Unfocused"/>
+                                                        </VisualStateGroup>
+                                                    </VisualStateManager.VisualStateGroups>
+                                                    <Rectangle x:Name="FocusPipe"
+                                                               Stroke="{ThemeResource SystemControlFocusVisualPrimaryBrush}"
+                                                               StrokeThickness="2"
+                                                               Visibility="Collapsed"/>
+                                                    <Grid Margin="4,0,4,0">
+                                                        <ContentPresenter x:Name="ContentPresenter"
+                                                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                                          FontFamily="{TemplateBinding FontFamily}"
+                                                                          FontSize="{TemplateBinding FontSize}"
+                                                                          FontWeight="{TemplateBinding FontWeight}"
+                                                                          Content="{TemplateBinding Content}"
+                                                                          ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                                          OpticalMarginAlignment="TrimSideBearings"/>
+                                                        <Rectangle x:Name="SelectedPipe"
+                                                                   Height="3"
+                                                                   Margin="0,0,0,6"
+                                                                   HorizontalAlignment="Stretch"
+                                                                   VerticalAlignment="Bottom"
+                                                                   Fill="{ThemeResource AppControlTransparentAccentColorBrush}"
+                                                                   Visibility="Collapsed"/>
+                                                    </Grid>
+                                                </Grid>
+                                            </ControlTemplate>
+                                        </Setter.Value>
+                                    </Setter>
+                                </Style>
+                            </Pivot.Resources>
+                            <PivotItem x:Name="HistoryPivotItem"
+                                       x:Uid="HistoryPivotItem"
+                                       Margin="0,10,0,0"
+                                       AutomationProperties.AutomationId="HistoryLabel">
+                                <PivotItem.Header>
+                                    <TextBlock x:Uid="HistoryLabel" AccessKeyInvoked="OnHistoryAccessKeyInvoked"/>
+                                </PivotItem.Header>
+                                <Border x:Name="DockHistoryHolder"/>
+                            </PivotItem>
+                            <PivotItem x:Name="MemoryPivotItem"
+                                       x:Uid="MemoryPivotItem"
+                                       Margin="0,10,0,0"
+                                       AutomationProperties.AutomationId="MemoryLabel">
+                                <PivotItem.Header>
+                                    <TextBlock x:Uid="MemoryLabel" AccessKeyInvoked="OnMemoryAccessKeyInvoked"/>
+                                </PivotItem.Header>
+                                <Border x:Name="DockMemoryHolder"/>
+                            </PivotItem>
+                        </Pivot>
+                    </Border>
+                </Grid>
+            </controls:TwoPaneViewCX.Pane2>
+        </controls:TwoPaneViewCX>
     </Grid>
 </UserControl>

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -675,6 +675,10 @@ void Calculator::UnregisterEventHandlers()
 {
     ExpressionText->UnregisterEventHandlers();
     AlwaysOnTopResults->UnregisterEventHandlers();
+    if (DualScreenExpressionText != nullptr)
+    {
+        DualScreenExpressionText->UnregisterEventHandlers();
+    }
 }
 
 void Calculator::OnErrorVisualStateCompleted(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e)

--- a/src/Calculator/Views/Calculator.xaml.h
+++ b/src/Calculator/Views/Calculator.xaml.h
@@ -24,6 +24,7 @@
 #include "Views/Memory.xaml.h"
 #include "Views/OperatorsPanel.xaml.h"
 #include "Views/StateTriggers/ControlSizeTrigger.h"
+#include "Views/StateTriggers/ApplicationViewModeTrigger.h"
 
 namespace CalculatorApp
 {

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -818,7 +818,7 @@
                                 <Flyout x:Uid="ColorChooserFlyout" Placement="Bottom">
                                     <local:EquationStylePanelControl EnableLineStylePicker="{x:Bind GraphEquation.IsInequality, Converter={StaticResource BooleanNegationConverter}, Mode=OneWay}"
                                                                      SelectedColor="{x:Bind LineColor, Mode=TwoWay}"
-                                                                     SelectedColorIndex="{x:Bind LineColorIndex, Mode=TwoWay}"
+                                                                     SelectedColorIndex="{x:Bind LineColorIndex , Mode=TwoWay}"
                                                                      SelectedStyle="{x:Bind GraphEquation.EquationStyle, Mode=TwoWay}"/>
                                 </Flyout>
                             </controls:EquationTextBox.ColorChooserFlyout>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -3,11 +3,14 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:contract7Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
              xmlns:contract8Present="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractPresent(Windows.Foundation.UniversalApiContract, 8)"
+             xmlns:controls="using:CalculatorApp.Controls"
              xmlns:converters="using:CalculatorApp.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:graphControl="using:GraphControl"
              xmlns:local="using:CalculatorApp"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
+             xmlns:states="using:CalculatorApp.Views.StateTriggers"
              x:Name="Control"
              DataContextChanged="GraphingCalculator_DataContextChanged"
              mc:Ignorable="d">
@@ -426,10 +429,12 @@
                     </Style>
                     <Style x:Key="ThemedGraphRepeatButtonStyle"
                            BasedOn="{StaticResource GraphRepeatButtonStyle}"
-                           TargetType="RepeatButton"/>
+                           TargetType="RepeatButton">
+                    </Style>
                     <Style x:Key="ThemedGraphButtonStyle"
                            BasedOn="{StaticResource GraphButtonStyle}"
-                           TargetType="Button"/>
+                           TargetType="Button">
+                    </Style>
                     <Style x:Key="ThemedGraphToggleButtonStyle"
                            BasedOn="{StaticResource GraphToggleButtonStyle}"
                            TargetType="ToggleButton"/>
@@ -485,26 +490,60 @@
             <RowDefinition Height="{StaticResource HamburgerHeightGridLength}"/>
             <RowDefinition/>
         </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="2*"/>
-            <ColumnDefinition Width="1*"
-                              MinWidth="300"
-                              MaxWidth="420"/>
-        </Grid.ColumnDefinitions>
         <VisualStateManager.VisualStateGroups>
-            <VisualStateGroup CurrentStateChanged="OnVisualStateChanged">
-                <VisualState x:Name="ColumnsState">
+            <VisualStateGroup>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <states:ApplicationViewModeTrigger ViewMode="DoubleLandscape"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="KeyGraphFeaturesControl.(Grid.Row)" Value="0"/>
+                        <Setter Target="EquationInputAreaControl.(Grid.Row)" Value="0"/>
+                        <Setter Target="GraphingNumPad.(Grid.Row)" Value="0"/>
+                        <Setter Target="KeyGraphFeaturesControl.(Grid.RowSpan)" Value="2"/>
+                        <Setter Target="EquationInputAreaControl.(Grid.RowSpan)" Value="2"/>
+                        <Setter Target="GraphingNumPad.(Grid.RowSpan)" Value="2"/>
+                        <Setter Target="KeyGraphFeaturesControl.(Grid.Column)" Value="1"/>
+                        <Setter Target="EquationInputAreaControl.(Grid.Column)" Value="1"/>
+                        <Setter Target="GraphingNumPad.(Grid.Column)" Value="0"/>
+                        <Setter Target="KeyGraphFeaturesControl.(Grid.ColumnSpan)" Value="1"/>
+                        <Setter Target="EquationInputAreaControl.(Grid.ColumnSpan)" Value="1"/>
+                        <Setter Target="GraphingNumPad.(Grid.ColumnSpan)" Value="1"/>
+                        <Setter Target="RightGrid.Margin" Value="24"/>
+                        <Setter Target="GraphingNumPad.Margin" Value="0,0,24,0"/>
+                        <Setter Target="KeyGraphFeaturesControl.Margin" Value="0,40,0,0"/>
+                        <Setter Target="EquationInputAreaControl.Margin" Value="0,40,0,0"/>
+                        <Setter Target="PaneView.TallModeConfiguration">
+                            <Setter.Value>
+                                <muxc:TwoPaneViewTallModeConfiguration>TopBottom</muxc:TwoPaneViewTallModeConfiguration>
+                            </Setter.Value>
+                        </Setter>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <states:ApplicationViewModeTrigger ViewMode="DoublePortrait"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="RightGrid.Margin" Value="24,0,24,24"/>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState>
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="800"/>
                     </VisualState.StateTriggers>
                 </VisualState>
-                <VisualState x:Name="SmallState">
+                <VisualState>
                     <VisualState.StateTriggers>
                         <AdaptiveTrigger MinWindowWidth="0"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
                         <Setter Target="Control.IsSmallState" Value="True"/>
-                        <Setter Target="LeftGrid.(Grid.ColumnSpan)" Value="2"/>
+                        <Setter Target="PaneView.WideModeConfiguration">
+                            <Setter.Value>
+                                <muxc:TwoPaneViewWideModeConfiguration>SinglePane</muxc:TwoPaneViewWideModeConfiguration>
+                            </Setter.Value>
+                        </Setter>
                         <Setter Target="RightGrid.(Grid.ColumnSpan)" Value="2"/>
                         <Setter Target="RightGrid.(Grid.Column)" Value="0"/>
                         <Setter Target="SwitchModeToggleButton.Visibility" Value="Visible"/>
@@ -536,166 +575,172 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
         <!-- Top panel -->
-        <Grid Grid.ColumnSpan="2">
-            <ToggleSwitch x:Name="SwitchModeToggleButton"
-                          x:Uid="SwitchModeToggleButton"
-                          Margin="0,0,12,2"
-                          HorizontalAlignment="Right"
-                          VerticalAlignment="Center"
-                          Style="{StaticResource GraphModeToggleSwitchStyle}"
-                          AutomationProperties.AutomationId="SwitchModeToggleButton"
-                          AutomationProperties.Name="{x:Bind local:GraphingCalculator.GetInfoForSwitchModeToggleButton(SwitchModeToggleButton.IsOn), Mode=OneWay}"
-                          Toggled="SwitchModeToggleButton_Toggled"
-                          ToolTipService.ToolTip="{x:Bind local:GraphingCalculator.GetInfoForSwitchModeToggleButton(SwitchModeToggleButton.IsOn), Mode=OneWay}"
-                          Visibility="Collapsed"/>
-        </Grid>
-        <!-- Left portion of the screen -->
-        <Grid x:Name="LeftGrid"
-              Grid.Row="1"
-              Padding="0,4,0,0"
-              Visibility="{x:Bind ShouldDisplayPanel(IsSmallState, SwitchModeToggleButton.IsOn, x:True), Mode=OneWay}">
-            <Grid.Resources>
-                <ResourceDictionary>
-                    <ResourceDictionary.ThemeDictionaries>
-                        <ResourceDictionary x:Key="Light">
-                            <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#10000000"/>
-                            <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#20000000"/>
-                            <SolidColorBrush x:Key="RepeatButtonBackgroundPointerOver" Color="#10000000"/>
-                            <SolidColorBrush x:Key="RepeatButtonBackgroundPressed" Color="#20000000"/>
-                            <CornerRadius x:Key="TopButtonCornerRadius">4,4,0,0</CornerRadius>
-                            <CornerRadius x:Key="BottomButtonCornerRadius">0,0,4,4</CornerRadius>
-                            <CornerRadius x:Key="LeftButtonCornerRadius">4,0,0,4</CornerRadius>
-                            <CornerRadius x:Key="RightButtonCornerRadius">0,4,4,0</CornerRadius>
-                        </ResourceDictionary>
-                        <ResourceDictionary x:Key="Dark">
-                            <CornerRadius x:Key="TopButtonCornerRadius">4,4,0,0</CornerRadius>
-                            <CornerRadius x:Key="BottomButtonCornerRadius">0,0,4,4</CornerRadius>
-                            <CornerRadius x:Key="LeftButtonCornerRadius">4,0,0,4</CornerRadius>
-                            <CornerRadius x:Key="RightButtonCornerRadius">0,4,4,0</CornerRadius>
-                        </ResourceDictionary>
-                        <ResourceDictionary x:Key="HighContrast">
-                            <CornerRadius x:Key="TopButtonCornerRadius">0</CornerRadius>
-                            <CornerRadius x:Key="BottomButtonCornerRadius">0</CornerRadius>
-                            <CornerRadius x:Key="LeftButtonCornerRadius">0</CornerRadius>
-                            <CornerRadius x:Key="RightButtonCornerRadius">0</CornerRadius>
-                        </ResourceDictionary>
-                    </ResourceDictionary.ThemeDictionaries>
-                </ResourceDictionary>
-            </Grid.Resources>
-            <graphControl:Grapher Name="GraphingControl"
-                                  AutomationProperties.Name="{x:Bind GraphControlAutomationName, Mode=OneWay}"
-                                  ForceProportionalAxes="False"
-                                  GraphPlottedEvent="GraphingControl_GraphPlottedEvent"
-                                  GraphViewChangedEvent="GraphingControl_GraphViewChangedEvent"
-                                  IsKeepCurrentView="{x:Bind IsManualAdjustment, Mode=TwoWay}"
-                                  LosingFocus="GraphingControl_LosingFocus"
-                                  LostFocus="GraphingControl_LostFocus"
-                                  RequestedTheme="Light"
-                                  UseSystemFocusVisuals="True"
-                                  VariablesUpdated="GraphingControl_VariablesUpdated">
-                <graphControl:Grapher.ContextFlyout>
-                    <MenuFlyout Placement="Bottom">
-                        <MenuFlyoutItem x:Uid="GraphCopyMenuItem"
-                                        Click="GraphMenuFlyoutItem_Click"
-                                        Icon="Copy"/>
-                    </MenuFlyout>
-                </graphControl:Grapher.ContextFlyout>
-            </graphControl:Grapher>
-            <Border MinHeight="36"
-                    Margin="0,12,12,0"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Top"
-                    Style="{ThemeResource GraphControlCommandPanel}">
-                <StackPanel Orientation="Horizontal">
-                    <ToggleButton x:Name="ActiveTracing"
-                                  MinWidth="40"
-                                  Margin="0,-1"
-                                  Style="{ThemeResource ThemedGraphToggleButtonStyle}"
-                                  contract7Present:CornerRadius="{ThemeResource LeftButtonCornerRadius}"
-                                  AutomationProperties.Name="{x:Bind local:GraphingCalculator.GetTracingLegend(GraphingControl.ActiveTracing), Mode=OneWay}"
-                                  Checked="ActiveTracing_Checked"
-                                  IsChecked="{x:Bind GraphingControl.ActiveTracing, Mode=TwoWay}"
-                                  Unchecked="ActiveTracing_Unchecked">
-                        <ToolTipService.ToolTip>
-                            <ToolTip Content="{x:Bind ActiveTracing.(AutomationProperties.Name), Mode=OneWay}"/>
-                        </ToolTipService.ToolTip>
-                        <FontIcon FontFamily="{StaticResource CalculatorFontFamily}"
-                                  FontSize="18"
-                                  Glyph="&#xE3B3;"/>
-                    </ToggleButton>
+        <ToggleSwitch x:Name="SwitchModeToggleButton"
+                      x:Uid="SwitchModeToggleButton"
+                      Margin="0,0,12,2"
+                      HorizontalAlignment="Right"
+                      VerticalAlignment="Center"
+                      Style="{StaticResource GraphModeToggleSwitchStyle}"
+                      AutomationProperties.AutomationId="SwitchModeToggleButton"
+                      AutomationProperties.Name="{x:Bind local:GraphingCalculator.GetInfoForSwitchModeToggleButton(SwitchModeToggleButton.IsOn), Mode=OneWay}"
+                      Toggled="SwitchModeToggleButton_Toggled"
+                      ToolTipService.ToolTip="{x:Bind local:GraphingCalculator.GetInfoForSwitchModeToggleButton(SwitchModeToggleButton.IsOn), Mode=OneWay}"
+                      Visibility="Collapsed"/>
 
-                    <Button x:Uid="shareButton"
-                            MinWidth="40"
-                            Style="{ThemeResource ThemedGraphButtonStyle}"
-                            Click="OnShareClick">
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                  FontSize="18"
-                                  Glyph="&#xE72D;"/>
-                    </Button>
+        <controls:TwoPaneViewCX x:Name="PaneView"
+                                Grid.Row="1"
+                                MinTallModeHeight="Infinity"
+                                MinWideModeWidth="0"
+                                Pane1Length="2*"
+                                Pane2Length="1*"
+                                Pane2MaxLength="420"
+                                Pane2MinLength="300"
+                                PanePriority="{x:Bind local:GraphingCalculator.GetPanePriority(SwitchModeToggleButton.IsOn), Mode=OneWay}"
+                                TallModeConfiguration="SinglePane">
+            <controls:TwoPaneViewCX.Pane1>
+                <Grid x:Name="LeftGrid" Padding="0,4,0,0">
+                    <Grid.Resources>
+                        <ResourceDictionary>
+                            <ResourceDictionary.ThemeDictionaries>
+                                <ResourceDictionary x:Key="Light">
+                                    <SolidColorBrush x:Key="ButtonBackgroundPointerOver" Color="#10000000"/>
+                                    <SolidColorBrush x:Key="ButtonBackgroundPressed" Color="#20000000"/>
+                                    <SolidColorBrush x:Key="RepeatButtonBackgroundPointerOver" Color="#10000000"/>
+                                    <SolidColorBrush x:Key="RepeatButtonBackgroundPressed" Color="#20000000"/>
+                                    <CornerRadius x:Key="TopButtonCornerRadius">4,4,0,0</CornerRadius>
+                                    <CornerRadius x:Key="BottomButtonCornerRadius">0,0,4,4</CornerRadius>
+                                    <CornerRadius x:Key="LeftButtonCornerRadius">4,0,0,4</CornerRadius>
+                                    <CornerRadius x:Key="RightButtonCornerRadius">0,4,4,0</CornerRadius>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="Dark">
+                                    <CornerRadius x:Key="TopButtonCornerRadius">4,4,0,0</CornerRadius>
+                                    <CornerRadius x:Key="BottomButtonCornerRadius">0,0,4,4</CornerRadius>
+                                    <CornerRadius x:Key="LeftButtonCornerRadius">4,0,0,4</CornerRadius>
+                                    <CornerRadius x:Key="RightButtonCornerRadius">0,4,4,0</CornerRadius>
+                                </ResourceDictionary>
+                                <ResourceDictionary x:Key="HighContrast">
+                                    <CornerRadius x:Key="TopButtonCornerRadius">0</CornerRadius>
+                                    <CornerRadius x:Key="BottomButtonCornerRadius">0</CornerRadius>
+                                    <CornerRadius x:Key="LeftButtonCornerRadius">0</CornerRadius>
+                                    <CornerRadius x:Key="RightButtonCornerRadius">0</CornerRadius>
+                                </ResourceDictionary>
+                            </ResourceDictionary.ThemeDictionaries>
+                        </ResourceDictionary>
+                    </Grid.Resources>
+                    <graphControl:Grapher Name="GraphingControl"
+                                          AutomationProperties.Name="{x:Bind GraphControlAutomationName, Mode=OneWay}"
+                                          ForceProportionalAxes="False"
+                                          GraphPlottedEvent="GraphingControl_GraphPlottedEvent"
+                                          GraphViewChangedEvent="GraphingControl_GraphViewChangedEvent"
+                                          IsKeepCurrentView="{x:Bind IsManualAdjustment, Mode=TwoWay}"
+                                          LosingFocus="GraphingControl_LosingFocus"
+                                          LostFocus="GraphingControl_LostFocus"
+                                          RequestedTheme="Light"
+                                          UseSystemFocusVisuals="True"
+                                          VariablesUpdated="GraphingControl_VariablesUpdated">
+                        <graphControl:Grapher.ContextFlyout>
+                            <MenuFlyout Placement="Bottom">
+                                <MenuFlyoutItem x:Uid="GraphCopyMenuItem"
+                                                Click="GraphMenuFlyoutItem_Click"
+                                                Icon="Copy"/>
+                            </MenuFlyout>
+                        </graphControl:Grapher.ContextFlyout>
+                    </graphControl:Grapher>
+                    <Border MinHeight="36"
+                            Margin="0,12,12,0"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Top"
+                            Style="{ThemeResource GraphControlCommandPanel}">
+                        <StackPanel Orientation="Horizontal">
+                            <ToggleButton x:Name="ActiveTracing"
+                                          MinWidth="40"
+                                          Margin="0,-1"
+                                          Style="{ThemeResource ThemedGraphToggleButtonStyle}"
+                                          contract7Present:CornerRadius="{ThemeResource LeftButtonCornerRadius}"
+                                          AutomationProperties.Name="{x:Bind local:GraphingCalculator.GetTracingLegend(GraphingControl.ActiveTracing), Mode=OneWay}"
+                                          Checked="ActiveTracing_Checked"
+                                          IsChecked="{x:Bind GraphingControl.ActiveTracing, Mode=TwoWay}"
+                                          Unchecked="ActiveTracing_Unchecked">
+                                <ToolTipService.ToolTip>
+                                    <ToolTip Content="{x:Bind ActiveTracing.(AutomationProperties.Name), Mode=OneWay}"/>
+                                </ToolTipService.ToolTip>
+                                <FontIcon FontFamily="{StaticResource CalculatorFontFamily}"
+                                          FontSize="18"
+                                          Glyph="&#xE3B3;"/>
+                            </ToggleButton>
 
-                    <Button x:Name="GraphSettingsButton"
-                            x:Uid="graphSettingsButton"
-                            MinWidth="40"
-                            Style="{ThemeResource ThemedGraphButtonStyle}"
-                            contract7Present:CornerRadius="{ThemeResource RightButtonCornerRadius}"
-                            Click="GraphSettingsButton_Click">
-                        <FontIcon FontFamily="{StaticResource CalculatorFontFamily}"
-                                  FontSize="18"
-                                  Glyph="&#xE3B4;"/>
-                    </Button>
-                </StackPanel>
-            </Border>
-            <Canvas x:Name="TraceCanvas"
-                    SizeChanged="Canvas_SizeChanged"
-                    x:Load="False">
-                <Grid x:Name="TracePointer" Visibility="Collapsed">
-                    <Border x:Name="CursorShadow"/>
-                    <Path x:Name="CursorPath"
-                          Width="18"
-                          Height="18"
-                          Style="{ThemeResource TracePointerPathStyle}"
-                          Data="M0 0 l1371 1371 H538 l-538 538 Z"
-                          Stretch="Uniform"/>
-                </Grid>
-            </Canvas>
-            <Border MinWidth="36"
-                    Margin="0,0,12,12"
-                    HorizontalAlignment="Right"
-                    VerticalAlignment="Bottom"
-                    Style="{ThemeResource GraphControlCommandPanel}">
-                <StackPanel Orientation="Vertical">
-                    <RepeatButton x:Name="ZoomInButton"
-                                  x:Uid="zoomInButton"
-                                  MinHeight="40"
-                                  HorizontalAlignment="Stretch"
-                                  Style="{ThemeResource ThemedGraphRepeatButtonStyle}"
-                                  FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                  contract7Present:CornerRadius="{ThemeResource TopButtonCornerRadius}"
-                                  AutomationProperties.AutomationId="zoomInButton"
-                                  Command="{x:Bind ZoomInButtonPressed, Mode=OneTime}">
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                  FontSize="14"
-                                  Glyph="&#xE710;"/>
-                        <RepeatButton.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="Add" Modifiers="Control"/>
-                        </RepeatButton.KeyboardAccelerators>
-                    </RepeatButton>
+                            <Button x:Uid="shareButton"
+                                    MinWidth="40"
+                                    Style="{ThemeResource ThemedGraphButtonStyle}"
+                                    Click="OnShareClick">
+                                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                          FontSize="18"
+                                          Glyph="&#xE72D;"/>
+                            </Button>
 
-                    <RepeatButton x:Name="ZoomOutButton"
-                                  x:Uid="zoomOutButton"
-                                  MinHeight="40"
-                                  HorizontalAlignment="Stretch"
-                                  Style="{ThemeResource ThemedGraphRepeatButtonStyle}"
-                                  FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                  AutomationProperties.AutomationId="zoomOutButton"
-                                  Command="{x:Bind ZoomOutButtonPressed, Mode=OneTime}">
-                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
-                                  FontSize="14"
-                                  Glyph="&#xE738;"/>
-                        <RepeatButton.KeyboardAccelerators>
-                            <KeyboardAccelerator Key="Subtract" Modifiers="Control"/>
-                        </RepeatButton.KeyboardAccelerators>
-                    </RepeatButton>
+                            <Button x:Name="GraphSettingsButton"
+                                    x:Uid="graphSettingsButton"
+                                    MinWidth="40"
+                                    Style="{ThemeResource ThemedGraphButtonStyle}"
+                                    contract7Present:CornerRadius="{ThemeResource RightButtonCornerRadius}"
+                                    Click="GraphSettingsButton_Click">
+                                <FontIcon FontFamily="{StaticResource CalculatorFontFamily}"
+                                          FontSize="18"
+                                          Glyph="&#xE3B4;"/>
+                            </Button>
+                        </StackPanel>
+                    </Border>
+                    <Canvas x:Name="TraceCanvas"
+                            SizeChanged="Canvas_SizeChanged"
+                            x:Load="False">
+                        <Grid x:Name="TracePointer" Visibility="Collapsed">
+                            <Border x:Name="CursorShadow"/>
+                            <Path x:Name="CursorPath"
+                                  Width="18"
+                                  Height="18"
+                                  Style="{ThemeResource TracePointerPathStyle}"
+                                  Data="M0 0 l1371 1371 H538 l-538 538 Z"
+                                  Stretch="Uniform"/>
+                        </Grid>
+                    </Canvas>
+                    <Border MinWidth="36"
+                            Margin="0,0,12,12"
+                            HorizontalAlignment="Right"
+                            VerticalAlignment="Bottom"
+                            Style="{ThemeResource GraphControlCommandPanel}">
+                        <StackPanel Orientation="Vertical">
+                            <RepeatButton x:Name="ZoomInButton"
+                                          x:Uid="zoomInButton"
+                                          MinHeight="40"
+                                          HorizontalAlignment="Stretch"
+                                          Style="{ThemeResource ThemedGraphRepeatButtonStyle}"
+                                          FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                          contract7Present:CornerRadius="{ThemeResource TopButtonCornerRadius}"
+                                          AutomationProperties.AutomationId="zoomInButton"
+                                          Command="{x:Bind ZoomInButtonPressed, Mode=OneTime}">
+                                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                          FontSize="14"
+                                          Glyph="&#xE710;"/>
+                                <RepeatButton.KeyboardAccelerators>
+                                    <KeyboardAccelerator Key="Add" Modifiers="Control"/>
+                                </RepeatButton.KeyboardAccelerators>
+                            </RepeatButton>
+
+                            <RepeatButton x:Name="ZoomOutButton"
+                                          x:Uid="zoomOutButton"
+                                          MinHeight="40"
+                                          HorizontalAlignment="Stretch"
+                                          Style="{ThemeResource ThemedGraphRepeatButtonStyle}"
+                                          FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                          AutomationProperties.AutomationId="zoomOutButton"
+                                          Command="{x:Bind ZoomOutButtonPressed, Mode=OneTime}">
+                                <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}"
+                                          FontSize="14"
+                                          Glyph="&#xE738;"/>
+                                <RepeatButton.KeyboardAccelerators>
+                                    <KeyboardAccelerator Key="Subtract" Modifiers="Control"/>
+                                </RepeatButton.KeyboardAccelerators>
+                            </RepeatButton>
 
                     <ToggleButton x:Uid="graphViewButton"
                                   MinWidth="40"
@@ -742,26 +787,27 @@
                            AutomationProperties.LiveSetting="Polite"/>
             </Border>
         </Grid>
+      </controls:TwoPaneViewCX.Pane1>
+            <controls:TwoPaneViewCX.Pane2>
+                <Grid x:Name="RightGrid">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*"/>
+                        <RowDefinition Height="2.2*" MaxHeight="400"/>
+                    </Grid.RowDefinitions>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="1.5*"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
 
-        <!-- Right portion of the screen -->
-        <Grid x:Name="RightGrid"
-              Grid.Row="1"
-              Grid.RowSpan="2"
-              Grid.Column="1"
-              Visibility="{x:Bind local:GraphingCalculator.ShouldDisplayPanel(IsSmallState, SwitchModeToggleButton.IsOn, x:False), Mode=OneWay}">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="*"/>
-                <RowDefinition Height="2.2*" MaxHeight="400"/>
-            </Grid.RowDefinitions>
-
-            <!-- Ideally the KeyGraphFeaturesPanel should be a frame so that navigation to and from the panel could be handled nicely -->
-            <local:KeyGraphFeaturesPanel x:Name="KeyGraphFeaturesControl"
-                                         Grid.RowSpan="2"
-                                         Margin="0,4,0,0"
-                                         KeyGraphFeaturesClosed="OnKeyGraphFeaturesClosed"
-                                         ViewModel="{x:Bind ViewModel.SelectedEquation, Mode=OneWay}"
-                                         Visibility="{x:Bind IsKeyGraphFeaturesVisible, Mode=OneWay}"
-                                         x:Load="{x:Bind IsKeyGraphFeaturesVisible, Mode=OneWay}"/>
+                    <!-- Ideally the KeyGraphFeaturesPanel should be a frame so that navigation to and from the panel could be handled nicely -->
+                    <local:KeyGraphFeaturesPanel x:Name="KeyGraphFeaturesControl"
+                                                 Grid.RowSpan="2"
+                                                 Grid.ColumnSpan="2"
+                                                 Margin="0,4,0,0"
+                                                 KeyGraphFeaturesClosed="OnKeyGraphFeaturesClosed"
+                                                 ViewModel="{x:Bind ViewModel.SelectedEquation, Mode=OneWay}"
+                                                 Visibility="{x:Bind IsKeyGraphFeaturesVisible, Mode=OneWay}"
+                                                 x:Load="{x:Bind IsKeyGraphFeaturesVisible, Mode=OneWay}"/>
 
             <!-- This control should be within a grid that limits the height to keep the sticky footer functionality from breaking -->
             <local:EquationInputArea x:Name="EquationInputAreaControl"
@@ -769,16 +815,19 @@
                                      Margin="0,4,0,0"
                                      EquationFormatRequested="OnEquationFormatRequested"
                                      Equations="{x:Bind ViewModel.Equations}"
-                                     IsMatchAppTheme="{x:Bind IsMatchAppTheme, Mode=OneWay}"
                                      KeyGraphFeaturesRequested="OnEquationKeyGraphFeaturesRequested"
                                      Variables="{x:Bind ViewModel.Variables}"
-                                     Visibility="{x:Bind IsKeyGraphFeaturesVisible, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
+                                     Visibility="{x:Bind IsKeyGraphFeaturesVisible, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"
+                                     IsMatchAppTheme="{x:Bind IsMatchAppTheme, Mode=OneWay}"/>
 
-            <local:GraphingNumPad x:Name="GraphingNumPad"
-                                  Grid.Row="1"
-                                  Margin="2,0,2,2"
-                                  Visibility="{x:Bind IsKeyGraphFeaturesVisible, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
+                    <local:GraphingNumPad x:Name="GraphingNumPad"
+                                          Grid.Row="1"
+                                          Grid.ColumnSpan="2"
+                                          Margin="2,0,2,2"
+                                          Visibility="{x:Bind IsKeyGraphFeaturesVisible, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
 
-        </Grid>
+                </Grid>
+            </controls:TwoPaneViewCX.Pane2>
+        </controls:TwoPaneViewCX>
     </Grid>
 </UserControl>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -500,10 +500,8 @@
                         <Setter Target="KeyGraphFeaturesControl.(Grid.RowSpan)" Value="2"/>
                         <Setter Target="EquationInputAreaControl.(Grid.RowSpan)" Value="2"/>
                         <Setter Target="GraphingNumPad.(Grid.RowSpan)" Value="2"/>
-                        <Setter Target="KeyGraphFeaturesControl.(Grid.Column)" Value="1"/>
                         <Setter Target="EquationInputAreaControl.(Grid.Column)" Value="1"/>
                         <Setter Target="GraphingNumPad.(Grid.Column)" Value="0"/>
-                        <Setter Target="KeyGraphFeaturesControl.(Grid.ColumnSpan)" Value="1"/>
                         <Setter Target="EquationInputAreaControl.(Grid.ColumnSpan)" Value="1"/>
                         <Setter Target="GraphingNumPad.(Grid.ColumnSpan)" Value="1"/>
                         <Setter Target="RightGrid.Margin" Value="24"/>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -9,7 +9,6 @@
              xmlns:graphControl="using:GraphControl"
              xmlns:local="using:CalculatorApp"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
              xmlns:states="using:CalculatorApp.Views.StateTriggers"
              x:Name="Control"
              DataContextChanged="GraphingCalculator_DataContextChanged"
@@ -429,12 +428,10 @@
                     </Style>
                     <Style x:Key="ThemedGraphRepeatButtonStyle"
                            BasedOn="{StaticResource GraphRepeatButtonStyle}"
-                           TargetType="RepeatButton">
-                    </Style>
+                           TargetType="RepeatButton"/>
                     <Style x:Key="ThemedGraphButtonStyle"
                            BasedOn="{StaticResource GraphButtonStyle}"
-                           TargetType="Button">
-                    </Style>
+                           TargetType="Button"/>
                     <Style x:Key="ThemedGraphToggleButtonStyle"
                            BasedOn="{StaticResource GraphToggleButtonStyle}"
                            TargetType="ToggleButton"/>
@@ -515,7 +512,7 @@
                         <Setter Target="EquationInputAreaControl.Margin" Value="0,40,0,0"/>
                         <Setter Target="PaneView.TallModeConfiguration">
                             <Setter.Value>
-                                <muxc:TwoPaneViewTallModeConfiguration>TopBottom</muxc:TwoPaneViewTallModeConfiguration>
+                                <controls:TwoPaneViewCXTallModeConfiguration>TopBottom</controls:TwoPaneViewCXTallModeConfiguration>
                             </Setter.Value>
                         </Setter>
                     </VisualState.Setters>
@@ -541,7 +538,7 @@
                         <Setter Target="Control.IsSmallState" Value="True"/>
                         <Setter Target="PaneView.WideModeConfiguration">
                             <Setter.Value>
-                                <muxc:TwoPaneViewWideModeConfiguration>SinglePane</muxc:TwoPaneViewWideModeConfiguration>
+                                <controls:TwoPaneViewCXWideModeConfiguration>SinglePane</controls:TwoPaneViewCXWideModeConfiguration>
                             </Setter.Value>
                         </Setter>
                         <Setter Target="RightGrid.(Grid.ColumnSpan)" Value="2"/>
@@ -809,16 +806,16 @@
                                                  Visibility="{x:Bind IsKeyGraphFeaturesVisible, Mode=OneWay}"
                                                  x:Load="{x:Bind IsKeyGraphFeaturesVisible, Mode=OneWay}"/>
 
-            <!-- This control should be within a grid that limits the height to keep the sticky footer functionality from breaking -->
-            <local:EquationInputArea x:Name="EquationInputAreaControl"
-                                     Grid.ColumnSpan="2"
-                                     Margin="0,4,0,0"
-                                     EquationFormatRequested="OnEquationFormatRequested"
-                                     Equations="{x:Bind ViewModel.Equations}"
-                                     KeyGraphFeaturesRequested="OnEquationKeyGraphFeaturesRequested"
-                                     Variables="{x:Bind ViewModel.Variables}"
-                                     Visibility="{x:Bind IsKeyGraphFeaturesVisible, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"
-                                     IsMatchAppTheme="{x:Bind IsMatchAppTheme, Mode=OneWay}"/>
+                    <!-- This control should be within a grid that limits the height to keep the sticky footer functionality from breaking -->
+                    <local:EquationInputArea x:Name="EquationInputAreaControl"
+                                             Grid.ColumnSpan="2"
+                                             Margin="0,4,0,0"
+                                             EquationFormatRequested="OnEquationFormatRequested"
+                                             Equations="{x:Bind ViewModel.Equations}"
+                                             IsMatchAppTheme="{x:Bind IsMatchAppTheme, Mode=OneWay}"
+                                             KeyGraphFeaturesRequested="OnEquationKeyGraphFeaturesRequested"
+                                             Variables="{x:Bind ViewModel.Variables}"
+                                             Visibility="{x:Bind IsKeyGraphFeaturesVisible, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
 
                     <local:GraphingNumPad x:Name="GraphingNumPad"
                                           Grid.Row="1"

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -51,6 +51,7 @@ using namespace Windows::UI::Xaml::Media;
 using namespace Windows::UI::Xaml::Media::Imaging;
 using namespace Windows::UI::Popups;
 using namespace Windows::UI::ViewManagement;
+namespace MUXC = Microsoft::UI::Xaml::Controls;
 
 constexpr auto sc_ViewModelPropertyName = L"ViewModel";
 constexpr auto sc_IsGraphThemeMatchApp = L"IsGraphThemeMatchApp";
@@ -497,9 +498,9 @@ void GraphingCalculator::OnKeyGraphFeaturesClosed(Object ^ sender, RoutedEventAr
     EquationInputAreaControl->FocusEquationTextBox(ViewModel->SelectedEquation);
 }
 
-Visibility GraphingCalculator::ShouldDisplayPanel(bool isSmallState, bool isEquationModeActivated, bool isGraphPanel)
+MUXC::TwoPaneViewPriority GraphingCalculator::GetPanePriority(bool isEquationModeActivated)
 {
-    return (!isSmallState || isEquationModeActivated ^ isGraphPanel) ? ::Visibility::Visible : ::Visibility::Collapsed;
+    return isEquationModeActivated ? MUXC::TwoPaneViewPriority::Pane2 : MUXC::TwoPaneViewPriority::Pane1;
 }
 
 Platform::String ^ GraphingCalculator::GetInfoForSwitchModeToggleButton(bool isChecked)

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -51,7 +51,6 @@ using namespace Windows::UI::Xaml::Media;
 using namespace Windows::UI::Xaml::Media::Imaging;
 using namespace Windows::UI::Popups;
 using namespace Windows::UI::ViewManagement;
-namespace MUXC = Microsoft::UI::Xaml::Controls;
 
 constexpr auto sc_ViewModelPropertyName = L"ViewModel";
 constexpr auto sc_IsGraphThemeMatchApp = L"IsGraphThemeMatchApp";
@@ -498,9 +497,9 @@ void GraphingCalculator::OnKeyGraphFeaturesClosed(Object ^ sender, RoutedEventAr
     EquationInputAreaControl->FocusEquationTextBox(ViewModel->SelectedEquation);
 }
 
-MUXC::TwoPaneViewPriority GraphingCalculator::GetPanePriority(bool isEquationModeActivated)
+TwoPaneViewCXPriority GraphingCalculator::GetPanePriority(bool isEquationModeActivated)
 {
-    return isEquationModeActivated ? MUXC::TwoPaneViewPriority::Pane2 : MUXC::TwoPaneViewPriority::Pane1;
+    return isEquationModeActivated ? TwoPaneViewCXPriority::Pane2 : TwoPaneViewCXPriority::Pane1;
 }
 
 Platform::String ^ GraphingCalculator::GetInfoForSwitchModeToggleButton(bool isChecked)

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -39,7 +39,7 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
             void set(CalculatorApp::ViewModel::GraphingCalculatorViewModel^ vm);
         }
 
-        static Microsoft::UI::Xaml::Controls::TwoPaneViewPriority GetPanePriority(bool isEquationModeActivated);
+        static CalculatorApp::Controls::TwoPaneViewCXPriority GetPanePriority(bool isEquationModeActivated);
         static Platform::String ^ GetInfoForSwitchModeToggleButton(bool isChecked);
         static Windows::UI::Xaml::Visibility ManageEditVariablesButtonVisibility(unsigned int numberOfVariables);
         static Platform::String ^ GetTracingLegend(Platform::IBox<bool> ^ isTracing);

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -9,6 +9,8 @@
 #include "Views\GraphingCalculator\KeyGraphFeaturesPanel.xaml.h"
 #include "Views\GraphingCalculator\GraphingNumPad.xaml.h"
 #include "Views\GraphingCalculator\GraphingSettings.xaml.h"
+#include "Views\StateTriggers\ApplicationViewModeTrigger.h"
+#include "Controls\TwoPaneViewCX.h"
 #include "CalcViewModel\Common\TraceLogger.h"
 
 namespace CalculatorApp
@@ -37,7 +39,7 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
             void set(CalculatorApp::ViewModel::GraphingCalculatorViewModel^ vm);
         }
 
-        static Windows::UI::Xaml::Visibility ShouldDisplayPanel(bool isSmallState, bool isEquationModeActivated, bool isGraphPanel);
+        static Microsoft::UI::Xaml::Controls::TwoPaneViewPriority GetPanePriority(bool isEquationModeActivated);
         static Platform::String ^ GetInfoForSwitchModeToggleButton(bool isChecked);
         static Windows::UI::Xaml::Visibility ManageEditVariablesButtonVisibility(unsigned int numberOfVariables);
         static Platform::String ^ GetTracingLegend(Platform::IBox<bool> ^ isTracing);

--- a/src/Calculator/Views/StateTriggers/ApplicationViewModeTrigger.cpp
+++ b/src/Calculator/Views/StateTriggers/ApplicationViewModeTrigger.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "pch.h"
+#include "ApplicationViewModeTrigger.h"
+using namespace CalculatorApp::Views::StateTriggers;
+using namespace Windows::System::Profile;
+using namespace Windows::UI::ViewManagement;
+using namespace Windows::UI::Xaml;
+
+DEPENDENCY_PROPERTY_INITIALIZATION(ApplicationViewModeTrigger, ViewMode);
+DEPENDENCY_PROPERTY_INITIALIZATION(ApplicationViewModeTrigger, MinWindowHeight);
+DEPENDENCY_PROPERTY_INITIALIZATION(ApplicationViewModeTrigger, MinWindowWidth);
+
+ApplicationViewModeTrigger::ApplicationViewModeTrigger()
+{
+    m_windowSizeEventToken = Window::Current->SizeChanged += ref new WindowSizeChangedEventHandler(this, &ApplicationViewModeTrigger::WindowSizeChanged);
+    UpdateTrigger();
+}
+
+void ApplicationViewModeTrigger::WindowSizeChanged(_In_ Platform::Object ^ /*sender*/, _In_ Windows::UI::Core::WindowSizeChangedEventArgs ^ /*e*/)
+{
+    // We don't use layout aware page's view states, we have our own
+    UpdateTrigger();
+}
+void ApplicationViewModeTrigger::OnViewModePropertyChanged(_In_ AppViewMode /*oldValue*/, _In_ AppViewMode /*newValue*/)
+{
+    UpdateTrigger();
+}
+void ApplicationViewModeTrigger::OnMinWindowHeightPropertyChanged(double /*oldValue*/, double /*newValue*/)
+{
+    UpdateTrigger();
+}
+
+void ApplicationViewModeTrigger::OnMinWindowWidthPropertyChanged(double /*oldValue*/, double /*newValue*/)
+{
+    UpdateTrigger();
+}
+
+void ApplicationViewModeTrigger::UpdateTrigger()
+{
+    auto applicationView = ApplicationView::GetForCurrentView();
+    auto viewMode = applicationView->ViewMode;
+    if (applicationView->VisibleBounds.Width < this->MinWindowWidth || applicationView->VisibleBounds.Height < this->MinWindowHeight)
+    {
+        SetActive(false);
+        return;
+    }
+
+    switch (static_cast<int>(viewMode))
+    {
+    case 0 /*ApplicationViewMode::Default*/:
+        SetActive(this->ViewMode == AppViewMode::Normal);
+        break;
+    case 1 /*ApplicationViewMode::CompactOverlay*/:
+        SetActive(this->ViewMode == AppViewMode::CompactOverlay);
+        break;
+    case 2 /*ApplicationViewMode::Spanning*/:
+
+        // We will need to update this code to use new SpanningRects API instead of DisplayRegions when the app will use the SDK for windows 10 2004.
+        auto displayRegions = applicationView->GetDisplayRegions();
+        if (displayRegions->Size == 2)
+        {
+            auto display1 = displayRegions->GetAt(0);
+            auto display2 = displayRegions->GetAt(1);
+            if (display1->WorkAreaOffset.X < display2->WorkAreaOffset.X && display1->WorkAreaOffset.Y == display2->WorkAreaOffset.Y)
+            {
+                this->SetActive(this->ViewMode == AppViewMode::DoublePortrait);
+                return;
+            }
+            else if (display1->WorkAreaOffset.X == display2->WorkAreaOffset.X && display1->WorkAreaOffset.Y < display2->WorkAreaOffset.Y)
+            {
+                this->SetActive(this->ViewMode == AppViewMode::DoubleLandscape);
+                return;
+            }
+        }
+        SetActive(this->ViewMode == AppViewMode::Normal);
+        break;
+    }
+}

--- a/src/Calculator/Views/StateTriggers/ApplicationViewModeTrigger.h
+++ b/src/Calculator/Views/StateTriggers/ApplicationViewModeTrigger.h
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+#include "CalcViewModel/Common/Utils.h"
+
+namespace CalculatorApp::Views::StateTriggers
+{
+public
+    enum class AppViewMode
+    {
+        Normal = 0,
+        CompactOverlay = 1,
+        DoublePortrait = 2,
+        DoubleLandscape = 3
+    };
+
+public
+    ref class ApplicationViewModeTrigger sealed : public Windows::UI::Xaml::StateTriggerBase
+    {
+    public:
+        ApplicationViewModeTrigger();
+        DEPENDENCY_PROPERTY_OWNER(ApplicationViewModeTrigger);
+
+        /* The view mode that will cause the trigger to fire. */
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(AppViewMode, ViewMode, AppViewMode::Normal);
+
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, MinWindowHeight, -1);
+
+        DEPENDENCY_PROPERTY_WITH_DEFAULT_AND_CALLBACK(double, MinWindowWidth, -1);
+    private:
+        void OnViewModePropertyChanged(AppViewMode oldValue, AppViewMode newValue);
+        void OnMinWindowHeightPropertyChanged(double oldValue, double newValue);
+        void OnMinWindowWidthPropertyChanged(double oldValue, double newValue);
+        void WindowSizeChanged(_In_ Platform::Object ^ sender, _In_ Windows::UI::Core::WindowSizeChangedEventArgs ^ e);
+        void UpdateTrigger();
+    private:
+        Windows::Foundation::EventRegistrationToken m_windowSizeEventToken;
+    };
+}

--- a/src/Calculator/Views/TitleBar.xaml.cpp
+++ b/src/Calculator/Views/TitleBar.xaml.cpp
@@ -5,9 +5,11 @@
 #include "TitleBar.xaml.h"
 #include "CalcViewModel/Common/AppResourceProvider.h"
 #include "CalcViewModel/Common/Utils.h"
+#include "CalcViewModel/Utils/DeviceFamilyHelper.h"
 
 using namespace std;
 using namespace Platform;
+using namespace CalculatorApp::ViewModel::Utils;
 using namespace Windows::ApplicationModel;
 using namespace Windows::ApplicationModel::Core;
 using namespace Windows::Foundation;
@@ -83,12 +85,25 @@ namespace CalculatorApp
 
     void TitleBar::SetTitleBarVisibility()
     {
-        this->LayoutRoot->Visibility = m_coreTitleBar->IsVisible || IsAlwaysOnTopMode ? ::Visibility::Visible : ::Visibility::Collapsed;
+        // CoreApplication::GetCurrentView()->TitleBar->IsVisible currently returns False instead of True on Windows 10X.
+        // This issue is already tracked and will be fixed in a future preview version of 10X.
+        this->LayoutRoot->Visibility = m_coreTitleBar->IsVisible || DeviceFamilyHelper::GetDeviceFamily() == DeviceFamily::WindowsCore || IsAlwaysOnTopMode
+                                           ? ::Visibility::Visible
+                                           : ::Visibility::Collapsed;
     }
 
     void TitleBar::SetTitleBarHeight()
     {
-        this->LayoutRoot->Height = m_coreTitleBar->Height;
+        if (m_coreTitleBar->Height == 0 && DeviceFamilyHelper::GetDeviceFamily() == DeviceFamily::WindowsCore)
+        {
+            // CoreApplication::GetCurrentView()->TitleBar doesn't return the correct height on Windows 10X.
+            // This issue is already tracked and will be fixed in a future preview version of 10X.
+            this->LayoutRoot->Height = 32;
+        }
+        else
+        {
+            this->LayoutRoot->Height = m_coreTitleBar->Height;
+        }
     }
 
     void TitleBar::SetTitleBarPadding()

--- a/src/Calculator/Views/TitleBar.xaml.h
+++ b/src/Calculator/Views/TitleBar.xaml.h
@@ -27,6 +27,7 @@ public
         void OnLoaded(_In_ Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void OnUnloaded(_In_ Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
 
+        void SetTitleBarText(Platform::String ^ text);
         void SetTitleBarVisibility();
         void SetTitleBarHeight();
         void SetTitleBarPadding();

--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -277,36 +277,47 @@
     <Grid x:Name="UnitConverterRootGrid"
           HorizontalAlignment="Stretch"
           AutomationProperties.LandmarkType="Main">
-        <Grid.RowDefinitions>
-            <RowDefinition x:Name="RowTopNav" Height="{StaticResource HamburgerHeightGridLength}"/>
-            <RowDefinition x:Name="RowDisplay1"
-                           Height="56*"
-                           MinHeight="56"/>
-            <RowDefinition x:Name="RowUnit1"
-                           Height="32*"
-                           MinHeight="32"/>
-            <RowDefinition x:Name="RowDisplay2"
-                           Height="56*"
-                           MinHeight="56"/>
-            <RowDefinition x:Name="RowUnit2"
-                           Height="32*"
-                           MinHeight="32"/>
-            <RowDefinition x:Name="RowDltrUnits"
-                           Height="Auto"
-                           MinHeight="48"/>
-            <RowDefinition x:Name="RowNumPad" Height="272*"/>
-        </Grid.RowDefinitions>
-        <Grid.ColumnDefinitions>
-            <ColumnDefinition x:Name="GutterLeft" Width="0"/>
-            <ColumnDefinition x:Name="ColumnLeft" Width="1*"/>
-            <ColumnDefinition x:Name="ColumnRight" Width="0"/>
-            <ColumnDefinition x:Name="GutterRight" Width="0"/>
-        </Grid.ColumnDefinitions>
-        <!-- End ConverterNumPad -->
 
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="Layout">
-                <VisualState x:Name="PortraitLayout"/>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <triggers:ApplicationViewModeTrigger ViewMode="DoubleLandscape"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Pane2Panel.Margin" Value="12"/>
+                        <Setter Target="Pane1Panel.Margin" Value="24,48,0,48"/>
+                        <Setter Target="SupplementaryResults.VerticalAlignment" Value="Top"/>
+                        <Setter Target="Value1.Style" Value="{ThemeResource ValueLargeStyle}"/>
+                        <Setter Target="Value2.Style" Value="{ThemeResource ValueLargeStyle}"/>
+                        <Setter Target="CurrencySymbol1Block.Style" Value="{ThemeResource CurrencySymbolLargeStyle}"/>
+                        <Setter Target="CurrencySymbol2Block.Style" Value="{ThemeResource CurrencySymbolLargeStyle}"/>
+                        <Setter Target="Units1.Height" Value="44"/>
+                        <Setter Target="Units2.Height" Value="44"/>
+                        <Setter Target="ConverterNegateButton.FontSize" Value="{StaticResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="ClearEntryButtonPos0.FontSize" Value="{StaticResource CalcStandardOperatorCaptionSize}"/>
+                        <Setter Target="NumberPad.ButtonStyle" Value="{StaticResource NumericButtonStyle34}"/>
+                        <Setter Target="SupplementaryResultsPanelInGrid.Padding" Value="12,0"/>
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <triggers:ApplicationViewModeTrigger ViewMode="DoublePortrait"/>
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="Pane2Panel.Margin" Value="12"/>
+                        <Setter Target="Pane1Panel.Margin" Value="24,48,0,0"/>
+                        <Setter Target="RowDisplay1.Height" Value="4*"/>
+                        <Setter Target="RowUnit1.Height" Value="2*"/>
+                        <Setter Target="RowDisplay2.Height" Value="4*"/>
+                        <Setter Target="RowUnit2.Height" Value="2*"/>
+                        <Setter Target="RowDltrUnits.Height" Value="2*"/>
+                        <Setter Target="ConverterNumPad.(Grid.Row)" Value="1"/>
+                        <Setter Target="ConverterNumPad.(Grid.RowSpan)" Value="5"/>
+                        <Setter Target="SupplementaryResults.VerticalAlignment" Value="Top"/>
+                        <Setter Target="Pane2RowTopNav.Height" Value="{StaticResource HamburgerHeightGridLength}"/>
+                    </VisualState.Setters>
+                </VisualState>
                 <VisualState x:Name="LandscapeLayout">
                     <VisualState.StateTriggers>
                         <triggers:AspectRatioTrigger ActiveIfEqual="True"
@@ -315,23 +326,21 @@
                                                      Threshold="1"/>
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="GutterLeft.Width" Value="48"/>
-                        <Setter Target="GutterRight.Width" Value="48"/>
-                        <Setter Target="ColumnLeft.Width" Value="1*"/>
-                        <Setter Target="ColumnRight.Width" Value="1*"/>
+                        <Setter Target="TwoPaneView.MinWideModeWidth" Value="0"/>
+                        <Setter Target="TwoPaneView.MinTallModeHeight" Value="Infinity"/>
+                        <Setter Target="TwoPaneView.Pane1Length" Value="*"/>
+                        <Setter Target="TwoPaneView.Pane1MinLength" Value="0"/>
+                        <Setter Target="TwoPaneView.Pane2Length" Value="*"/>
                         <Setter Target="RowDisplay1.Height" Value="4*"/>
                         <Setter Target="RowUnit1.Height" Value="2*"/>
                         <Setter Target="RowDisplay2.Height" Value="4*"/>
                         <Setter Target="RowUnit2.Height" Value="2*"/>
                         <Setter Target="RowDltrUnits.Height" Value="2*"/>
-                        <Setter Target="CurrencyLoadingGrid.(Grid.ColumnSpan)" Value="2"/>
                         <Setter Target="ConverterNumPad.(Grid.Row)" Value="1"/>
                         <Setter Target="ConverterNumPad.(Grid.RowSpan)" Value="5"/>
-                        <Setter Target="ConverterNumPad.(Grid.Column)" Value="2"/>
-                        <Setter Target="ConverterNumPad.(Grid.ColumnSpan)" Value="2"/>
                         <Setter Target="SupplementaryResults.VerticalAlignment" Value="Top"/>
-                        <Setter Target="RowNumPad.MinHeight" Value="0"/>
-                        <Setter Target="RowNumPad.Height" Value="0"/>
+                        <Setter Target="Pane2RowTopNav.Height" Value="{StaticResource HamburgerHeightGridLength}"/>
+                        <Setter Target="Pane1Panel.Margin" Value="48,0,0,0"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -400,7 +409,6 @@
                         <Setter Target="ClearEntryButtonPos0.Margin" Value="1"/>
                         <Setter Target="BackSpaceButtonSmall.Margin" Value="1"/>
                         <Setter Target="ConverterNegateButton.Margin" Value="1"/>
-
                         <Setter Target="NumberPad.ButtonStyle" Value="{StaticResource NumericButtonStyle18}"/>
                     </VisualState.Setters>
                 </VisualState>
@@ -437,8 +445,8 @@
                     <VisualState.Setters>
                         <Setter Target="CurrencySymbol1Block.Padding" Value="0,0,12,0"/>
                         <Setter Target="CurrencySymbol2Block.Padding" Value="0,0,12,0"/>
-                        <Setter Target="CurrencySymbol1Block.(Grid.Column)" Value="2"/>
-                        <Setter Target="CurrencySymbol2Block.(Grid.Column)" Value="2"/>
+                        <Setter Target="CurrencySymbol1Block.(Grid.Column)" Value="1"/>
+                        <Setter Target="CurrencySymbol2Block.(Grid.Column)" Value="1"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -506,259 +514,287 @@
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
 
-        <Grid x:Name="CurrencyLoadingGrid"
-              Grid.Row="1"
-              Grid.RowSpan="5"
-              Grid.Column="0"
-              Grid.ColumnSpan="4">
-            <Grid.RowDefinitions>
-                <RowDefinition Height="10*"/>
-                <RowDefinition Height="7*"/>
-                <RowDefinition Height="10*"/>
-            </Grid.RowDefinitions>
-            <ProgressRing x:Name="CurrencyLoadingProgressRing"
+        <controls:TwoPaneViewCX x:Name="TwoPaneView"
+                                MinTallModeHeight="0"
+                                MinWideModeWidth="Infinity"
+                                Pane1Length="16*"
+                                Pane1MinLength="260"
+                                Pane2Length="18*">
+            <controls:TwoPaneViewCX.Pane1>
+                <Grid x:Name="Pane1Panel">
+                    <Grid.RowDefinitions>
+                        <RowDefinition x:Name="RowTopNav" Height="{StaticResource HamburgerHeightGridLength}"/>
+                        <RowDefinition x:Name="RowDisplay1"
+                                       Height="56*"
+                                       MinHeight="56"/>
+                        <RowDefinition x:Name="RowUnit1"
+                                       Height="32*"
+                                       MinHeight="32"/>
+                        <RowDefinition x:Name="RowDisplay2"
+                                       Height="56*"
+                                       MinHeight="56"/>
+                        <RowDefinition x:Name="RowUnit2"
+                                       Height="32*"
+                                       MinHeight="32"/>
+                        <RowDefinition x:Name="RowDltrUnits"
+                                       Height="Auto"
+                                       MinHeight="48"/>
+                    </Grid.RowDefinitions>
+                    <Grid x:Name="CurrencyLoadingGrid"
                           Grid.Row="1"
-                          Grid.Column="1"
-                          MaxWidth="140"
-                          MaxHeight="140"
-                          HorizontalAlignment="Stretch"
-                          VerticalAlignment="Stretch"
-                          IsActive="False"/>
-        </Grid>
+                          Grid.RowSpan="5"
+                          Visibility="Collapsed">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="10*"/>
+                            <RowDefinition Height="7*"/>
+                            <RowDefinition Height="10*"/>
+                        </Grid.RowDefinitions>
+                        <ProgressRing x:Name="CurrencyLoadingProgressRing"
+                                      Grid.Row="1"
+                                      Grid.Column="1"
+                                      MaxWidth="140"
+                                      MaxHeight="140"
+                                      HorizontalAlignment="Stretch"
+                                      VerticalAlignment="Stretch"
+                                      IsActive="False"/>
+                    </Grid>
 
-        <Grid x:Name="Value1Container"
-              Grid.Row="1"
-              Grid.Column="1"
-              HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
-              Style="{ThemeResource ValueContainerStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <TextBlock x:Name="CurrencySymbol1Block"
-                       Grid.Column="0"
-                       Padding="12,0,0,0"
-                       Style="{ThemeResource CurrencySymbolMediumStyle}"
-                       AutomationProperties.AccessibilityView="Raw"
-                       Text="{x:Bind Model.CurrencySymbol1, Mode=OneWay}"
-                       Visibility="{x:Bind Model.CurrencySymbolVisibility, Mode=OneWay}"/>
-            <controls:CalculationResult x:Name="Value1"
-                                        Grid.Column="1"
-                                        Style="{ThemeResource ValueMediumStyle}"
-                                        AutomationProperties.AutomationId="Value1"
-                                        AutomationProperties.Name="{x:Bind Model.Value1AutomationName, Mode=OneWay}"
-                                        ContextCanceled="OnContextCanceled"
-                                        ContextRequested="OnContextRequested"
-                                        DisplayValue="{x:Bind Model.Value1, Mode=OneWay}"
-                                        FlowDirection="{x:Bind LayoutDirection}"
-                                        IsActive="{Binding Value1Active, Mode=TwoWay}"
-                                        KeyDown="OnValueKeyDown"
-                                        Selected="OnValueSelected"
-                                        TabIndex="1"/>
-        </Grid>
+                    <Grid x:Name="Value1Container"
+                          Grid.Row="1"
+                          HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
+                          Style="{ThemeResource ValueContainerStyle}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="CurrencySymbol1Block"
+                                   Grid.Column="0"
+                                   Padding="12,0,0,0"
+                                   Style="{ThemeResource CurrencySymbolMediumStyle}"
+                                   AutomationProperties.AccessibilityView="Raw"
+                                   Text="{x:Bind Model.CurrencySymbol1, Mode=OneWay}"
+                                   Visibility="{x:Bind Model.CurrencySymbolVisibility, Mode=OneWay}"/>
+                        <controls:CalculationResult x:Name="Value1"
+                                                    Grid.Column="1"
+                                                    Style="{ThemeResource ValueMediumStyle}"
+                                                    AutomationProperties.AutomationId="Value1"
+                                                    AutomationProperties.Name="{x:Bind Model.Value1AutomationName, Mode=OneWay}"
+                                                    ContextCanceled="OnContextCanceled"
+                                                    ContextRequested="OnContextRequested"
+                                                    DisplayValue="{x:Bind Model.Value1, Mode=OneWay}"
+                                                    FlowDirection="{x:Bind LayoutDirection}"
+                                                    IsActive="{Binding Value1Active, Mode=TwoWay}"
+                                                    KeyDown="OnValueKeyDown"
+                                                    Selected="OnValueSelected"
+                                                    TabIndex="1"/>
+                    </Grid>
 
-        <ComboBox x:Name="Units1"
-                  Grid.Row="2"
-                  Grid.Column="1"
-                  HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
-                  Style="{ThemeResource ComboStyle}"
-                  AutomationProperties.AutomationId="Units1"
-                  AutomationProperties.Name="{x:Bind Model.Unit1AutomationName, Mode=OneWay}"
-                  DropDownClosed="UpdateDropDownState"
-                  DropDownOpened="UpdateDropDownState"
-                  FlowDirection="{x:Bind LayoutDirection}"
-                  IsEnabledChanged="Units1_IsEnabledChanged"
-                  ItemTemplate="{StaticResource UnitTemplate}"
-                  ItemsSource="{Binding Units, Converter={StaticResource AlwaysSelectedConverter}}"
-                  SelectedItem="{Binding Unit1, Mode=TwoWay, Converter={StaticResource ValidSelectedItemConverter}}"
-                  TabIndex="2"
-                  IsEnabled="{Binding IsDropDownEnabled}"/>
+                    <ComboBox x:Name="Units1"
+                              Grid.Row="2"
+                              HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
+                              Style="{ThemeResource ComboStyle}"
+                              AutomationProperties.AutomationId="Units1"
+                              AutomationProperties.Name="{x:Bind Model.Unit1AutomationName, Mode=OneWay}"
+                              DropDownClosed="UpdateDropDownState"
+                              DropDownOpened="UpdateDropDownState"
+                              FlowDirection="{x:Bind LayoutDirection}"
+                              IsEnabledChanged="Units1_IsEnabledChanged"
+                              ItemTemplate="{StaticResource UnitTemplate}"
+                              ItemsSource="{Binding Units, Converter={StaticResource AlwaysSelectedConverter}}"
+                              SelectedItem="{Binding Unit1, Mode=TwoWay, Converter={StaticResource ValidSelectedItemConverter}}"
+                              TabIndex="2"
+                              IsEnabled="{Binding IsDropDownEnabled}"/>
 
-        <Grid x:Name="Value2Container"
-              Grid.Row="3"
-              Grid.Column="1"
-              HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
-              Style="{ThemeResource ValueContainerStyle}">
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto"/>
-                <ColumnDefinition Width="*"/>
-                <ColumnDefinition Width="Auto"/>
-            </Grid.ColumnDefinitions>
-            <TextBlock x:Name="CurrencySymbol2Block"
-                       Grid.Column="0"
-                       Padding="12,0,0,0"
-                       Style="{ThemeResource CurrencySymbolMediumStyle}"
-                       AutomationProperties.AccessibilityView="Raw"
-                       Text="{x:Bind Model.CurrencySymbol2, Mode=OneWay}"
-                       Visibility="{x:Bind Model.CurrencySymbolVisibility, Mode=OneWay}"/>
-            <controls:CalculationResult x:Name="Value2"
-                                        Grid.Column="1"
-                                        Style="{ThemeResource ValueMediumStyle}"
-                                        AutomationProperties.AutomationId="Value2"
-                                        AutomationProperties.LiveSetting="Polite"
-                                        AutomationProperties.Name="{x:Bind Model.Value2AutomationName, Mode=OneWay}"
-                                        ContextCanceled="OnContextCanceled"
-                                        ContextRequested="OnContextRequested"
-                                        DisplayValue="{x:Bind Model.Value2, Mode=OneWay}"
-                                        FlowDirection="{x:Bind LayoutDirection}"
-                                        IsActive="{Binding Value2Active, Mode=TwoWay}"
-                                        KeyDown="OnValueKeyDown"
-                                        Selected="OnValueSelected"
-                                        TabIndex="3"/>
-        </Grid>
+                    <Grid x:Name="Value2Container"
+                          Grid.Row="3"
+                          HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
+                          Style="{ThemeResource ValueContainerStyle}">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto"/>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+                        <TextBlock x:Name="CurrencySymbol2Block"
+                                   Grid.Column="0"
+                                   Padding="12,0,0,0"
+                                   Style="{ThemeResource CurrencySymbolMediumStyle}"
+                                   AutomationProperties.AccessibilityView="Raw"
+                                   Text="{x:Bind Model.CurrencySymbol2, Mode=OneWay}"
+                                   Visibility="{x:Bind Model.CurrencySymbolVisibility, Mode=OneWay}"/>
+                        <controls:CalculationResult x:Name="Value2"
+                                                    Grid.Column="1"
+                                                    Style="{ThemeResource ValueMediumStyle}"
+                                                    AutomationProperties.AutomationId="Value2"
+                                                    AutomationProperties.LiveSetting="Polite"
+                                                    AutomationProperties.Name="{x:Bind Model.Value2AutomationName, Mode=OneWay}"
+                                                    ContextCanceled="OnContextCanceled"
+                                                    ContextRequested="OnContextRequested"
+                                                    DisplayValue="{x:Bind Model.Value2, Mode=OneWay}"
+                                                    FlowDirection="{x:Bind LayoutDirection}"
+                                                    IsActive="{Binding Value2Active, Mode=TwoWay}"
+                                                    KeyDown="OnValueKeyDown"
+                                                    Selected="OnValueSelected"
+                                                    TabIndex="3"/>
+                    </Grid>
 
-        <ComboBox x:Name="Units2"
-                  Grid.Row="4"
-                  Grid.Column="1"
-                  HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
-                  Style="{ThemeResource ComboStyle}"
-                  AutomationProperties.AutomationId="Units2"
-                  AutomationProperties.Name="{x:Bind Model.Unit2AutomationName, Mode=OneWay}"
-                  DropDownClosed="UpdateDropDownState"
-                  DropDownOpened="UpdateDropDownState"
-                  FlowDirection="{x:Bind LayoutDirection}"
-                  ItemTemplate="{StaticResource UnitTemplate}"
-                  ItemsSource="{Binding Units, Converter={StaticResource AlwaysSelectedConverter}}"
-                  SelectedItem="{Binding Unit2, Mode=TwoWay, Converter={StaticResource ValidSelectedItemConverter}}"
-                  TabIndex="4"
-                  IsEnabled="{Binding IsDropDownEnabled}"/>
+                    <ComboBox x:Name="Units2"
+                              Grid.Row="4"
+                              HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
+                              Style="{ThemeResource ComboStyle}"
+                              AutomationProperties.AutomationId="Units2"
+                              AutomationProperties.Name="{x:Bind Model.Unit2AutomationName, Mode=OneWay}"
+                              DropDownClosed="UpdateDropDownState"
+                              DropDownOpened="UpdateDropDownState"
+                              FlowDirection="{x:Bind LayoutDirection}"
+                              ItemTemplate="{StaticResource UnitTemplate}"
+                              ItemsSource="{Binding Units, Converter={StaticResource AlwaysSelectedConverter}}"
+                              SelectedItem="{Binding Unit2, Mode=TwoWay, Converter={StaticResource ValidSelectedItemConverter}}"
+                              TabIndex="4"
+                              IsEnabled="{Binding IsDropDownEnabled}"/>
 
-        <StackPanel x:Name="SupplementaryResultsPanelInGrid"
-                    Grid.Row="5"
-                    Grid.Column="1"
-                    MinHeight="48"
-                    Padding="12,0,6,0"
-                    HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
-                    VerticalAlignment="Top"
-                    FlowDirection="{x:Bind LayoutDirection}"
-                    SizeChanged="SupplementaryResultsPanelInGrid_SizeChanged">
-            <local:SupplementaryResults x:Name="SupplementaryResults"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        Results="{x:Bind Model.SupplementaryResults, Mode=OneWay}"
-                                        Visibility="{x:Bind Model.SupplementaryVisibility, Mode=OneWay}"/>
-            <StackPanel Visibility="{x:Bind Model.IsCurrencyCurrentCategory, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
-                <!-- Currency Ratio Equality -->
-                <TextBlock x:Name="CurrencyRatioEqualityBlock"
-                           Style="{ThemeResource CaptionTextBlockStyle}"
-                           Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
-                           AutomationProperties.Name="{x:Bind Model.CurrencyRatioEqualityAutomationName, Mode=OneWay}"
-                           Text="{x:Bind Model.CurrencyRatioEquality, Mode=OneWay}"/>
+                    <StackPanel x:Name="SupplementaryResultsPanelInGrid"
+                                Grid.Row="5"
+                                MinHeight="48"
+                                Padding="12,0,6,0"
+                                HorizontalAlignment="{x:Bind FlowDirectionHorizontalAlignment}"
+                                VerticalAlignment="Top"
+                                FlowDirection="{x:Bind LayoutDirection}"
+                                SizeChanged="SupplementaryResultsPanelInGrid_SizeChanged">
+                        <local:SupplementaryResults x:Name="SupplementaryResults"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    Results="{x:Bind Model.SupplementaryResults, Mode=OneWay}"
+                                                    Visibility="{x:Bind Model.SupplementaryVisibility, Mode=OneWay}"/>
+                        <StackPanel Visibility="{x:Bind Model.IsCurrencyCurrentCategory, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}">
+                            <!-- Currency Ratio Equality -->
+                            <TextBlock x:Name="CurrencyRatioEqualityBlock"
+                                       Style="{ThemeResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
+                                       AutomationProperties.Name="{x:Bind Model.CurrencyRatioEqualityAutomationName, Mode=OneWay}"
+                                       Text="{x:Bind Model.CurrencyRatioEquality, Mode=OneWay}"/>
 
-                <!-- Currency Timestamp -->
-                <TextBlock x:Name="CurrencyTimestampTextBlock"
-                           Style="{ThemeResource CaptionTextBlockStyle}"
-                           Text="{x:Bind Model.CurrencyTimestamp, Mode=OneWay}"/>
+                            <!-- Currency Timestamp -->
+                            <TextBlock x:Name="CurrencyTimestampTextBlock"
+                                       Style="{ThemeResource CaptionTextBlockStyle}"
+                                       Text="{x:Bind Model.CurrencyTimestamp, Mode=OneWay}"/>
 
-                <!-- Currency Refresh button and additional status text -->
-                <ContentControl x:Name="CurrencyRefreshBlockControl"
-                                IsTabStop="False"
-                                TabIndex="5"
-                                Visibility="Collapsed">
-                    <StackPanel Orientation="Horizontal">
-                        <HyperlinkButton x:Name="CurrencyRefreshBlock"
-                                         x:Uid="RefreshButtonText"
-                                         Foreground="{ThemeResource SystemControlHyperlinkBaseHighBrush}"
-                                         Click="CurrencyRefreshButton_Click"/>
-                        <TextBlock Margin="3,7,0,0" Style="{ThemeResource CaptionTextBlockStyle}">
-                            <Run x:Name="CurrencySecondaryStatus"
-                                 FontWeight="SemiBold"
-                                 Text=""/>
-                        </TextBlock>
+                            <!-- Currency Refresh button and additional status text -->
+                            <ContentControl x:Name="CurrencyRefreshBlockControl"
+                                            IsTabStop="False"
+                                            TabIndex="5"
+                                            Visibility="Collapsed">
+                                <StackPanel Orientation="Horizontal">
+                                    <HyperlinkButton x:Name="CurrencyRefreshBlock"
+                                                     x:Uid="RefreshButtonText"
+                                                     Foreground="{ThemeResource SystemControlHyperlinkBaseHighBrush}"
+                                                     Click="CurrencyRefreshButton_Click"/>
+                                    <TextBlock Margin="3,7,0,0" Style="{ThemeResource CaptionTextBlockStyle}">
+                                        <Run x:Name="CurrencySecondaryStatus"
+                                             FontWeight="SemiBold"
+                                             Text=""/>
+                                    </TextBlock>
+                                </StackPanel>
+                            </ContentControl>
+
+                            <!-- Offline TextBlock -->
+                            <ContentControl x:Name="OfflineBlock"
+                                            IsTabStop="False"
+                                            TabIndex="5"
+                                            Visibility="Collapsed">
+                                <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
+                                           AutomationProperties.AccessibilityView="Raw">
+                                    <Run x:Name="OfflineRunBeforeLink"/>
+                                    <Hyperlink NavigateUri="ms-settings:network-status">
+                                        <Run x:Name="OfflineRunLink"/>
+                                    </Hyperlink>
+                                    <Run x:Name="OfflineRunAfterLink"/>
+                                </TextBlock>
+                            </ContentControl>
+                        </StackPanel>
                     </StackPanel>
-                </ContentControl>
+                </Grid>
+            </controls:TwoPaneViewCX.Pane1>
+            <controls:TwoPaneViewCX.Pane2>
+                <Grid x:Name="Pane2Panel">
+                    <Grid.RowDefinitions>
+                        <RowDefinition x:Name="Pane2RowTopNav" Height="0"/>
+                        <RowDefinition Height="*"/>
+                    </Grid.RowDefinitions>
+                    <Grid x:Name="ConverterNumPad"
+                          Grid.Row="1"
+                          Margin="3,0,3,3"
+                          FlowDirection="LeftToRight"
+                          RenderTransformOrigin="0.5,0.5"
+                          XYFocusKeyboardNavigation="Enabled">
+                        <Grid.RenderTransform>
+                            <CompositeTransform/>
+                        </Grid.RenderTransform>
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="1*"/>
+                            <RowDefinition Height="1*"/>
+                            <RowDefinition Height="1*"/>
+                            <RowDefinition Height="1*"/>
+                            <RowDefinition Height="1*"/>
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="1*"/>
+                            <ColumnDefinition Width="1*"/>
+                            <ColumnDefinition Width="1*"/>
+                        </Grid.ColumnDefinitions>
+                        <Grid x:Uid="DisplayControls"
+                              Grid.Row="0"
+                              Grid.Column="1"
+                              Grid.ColumnSpan="2"
+                              AutomationProperties.HeadingLevel="Level1">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition/>
+                                <ColumnDefinition/>
+                            </Grid.ColumnDefinitions>
+                            <controls:CalculatorButton x:Name="ClearEntryButtonPos0"
+                                                       x:Uid="clearEntryButton"
+                                                       HorizontalAlignment="Stretch"
+                                                       Style="{StaticResource OperatorButtonStyle}"
+                                                       FontSize="16"
+                                                       ButtonId="Clear"
+                                                       Content="CE"
+                                                       TabIndex="7"/>
+                            <controls:CalculatorButton x:Name="BackSpaceButtonSmall"
+                                                       x:Uid="backSpaceButton"
+                                                       Grid.Column="1"
+                                                       Style="{StaticResource SymbolOperatorButtonStyle}"
+                                                       FontFamily="{ThemeResource SymbolThemeFontFamily}"
+                                                       FontSize="16"
+                                                       ButtonId="Backspace"
+                                                       Content="&#xE750;"
+                                                       TabIndex="8"/>
+                        </Grid>
 
-                <!-- Offline TextBlock -->
-                <ContentControl x:Name="OfflineBlock"
-                                IsTabStop="False"
-                                TabIndex="5"
-                                Visibility="Collapsed">
-                    <TextBlock Style="{ThemeResource CaptionTextBlockStyle}"
-                               Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
-                               AutomationProperties.AccessibilityView="Raw">
-                        <Run x:Name="OfflineRunBeforeLink"/>
-                        <Hyperlink NavigateUri="ms-settings:network-status">
-                            <Run x:Name="OfflineRunLink"/>
-                        </Hyperlink>
-                        <Run x:Name="OfflineRunAfterLink"/>
-                    </TextBlock>
-                </ContentControl>
-            </StackPanel>
-        </StackPanel>
-
-        <Grid x:Name="ConverterNumPad"
-              Grid.Row="6"
-              Grid.Column="1"
-              Margin="3,0,3,3"
-              FlowDirection="LeftToRight"
-              RenderTransformOrigin="0.5,0.5"
-              XYFocusKeyboardNavigation="Enabled">
-            <Grid.RenderTransform>
-                <CompositeTransform/>
-            </Grid.RenderTransform>
-            <Grid.RowDefinitions>
-                <RowDefinition Height="1*"/>
-                <RowDefinition Height="1*"/>
-                <RowDefinition Height="1*"/>
-                <RowDefinition Height="1*"/>
-                <RowDefinition Height="1*"/>
-            </Grid.RowDefinitions>
-            <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="1*"/>
-                <ColumnDefinition Width="1*"/>
-                <ColumnDefinition Width="1*"/>
-            </Grid.ColumnDefinitions>
-            <Grid x:Uid="DisplayControls"
-                  Grid.Row="0"
-                  Grid.Column="1"
-                  Grid.ColumnSpan="2"
-                  AutomationProperties.HeadingLevel="Level1">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition/>
-                    <ColumnDefinition/>
-                </Grid.ColumnDefinitions>
-                <controls:CalculatorButton x:Name="ClearEntryButtonPos0"
-                                           x:Uid="clearEntryButton"
-                                           HorizontalAlignment="Stretch"
-                                           Style="{StaticResource OperatorButtonStyle}"
-                                           FontSize="16"
-                                           ButtonId="Clear"
-                                           Content="CE"
-                                           TabIndex="7"/>
-                <controls:CalculatorButton x:Name="BackSpaceButtonSmall"
-                                           x:Uid="backSpaceButton"
-                                           Grid.Column="1"
-                                           Style="{StaticResource SymbolOperatorButtonStyle}"
-                                           FontFamily="{ThemeResource SymbolThemeFontFamily}"
-                                           FontSize="16"
-                                           ButtonId="Backspace"
-                                           Content="&#xE750;"
-                                           TabIndex="8"/>
-            </Grid>
-
-            <local:NumberPad x:Name="NumberPad"
-                             x:Uid="NumberPad"
-                             Grid.Row="1"
-                             Grid.RowSpan="4"
-                             Grid.Column="0"
-                             Grid.ColumnSpan="3"
-                             VerticalAlignment="Stretch"
-                             AutomationProperties.HeadingLevel="Level1"
-                             ButtonStyle="{StaticResource NumericButtonStyle24}"
-                             TabIndex="10"
-                             TabNavigation="Local"/>
-            <controls:CalculatorButton x:Name="ConverterNegateButton"
-                                       x:Uid="converterNegateButton"
-                                       Grid.Row="4"
-                                       Grid.Column="0"
-                                       Style="{StaticResource SymbolOperatorKeypadButtonStyle}"
-                                       FontSize="16"
-                                       ButtonId="Negate"
-                                       Content="&#xF898;"
-                                       TabIndex="6"
-                                       Visibility="{x:Bind Model.CurrentCategory.NegateVisibility, Mode=OneWay}"/>
-        </Grid>
-        <!-- End ConverterNumPad -->
+                        <local:NumberPad x:Name="NumberPad"
+                                         x:Uid="NumberPad"
+                                         Grid.Row="1"
+                                         Grid.RowSpan="4"
+                                         Grid.Column="0"
+                                         Grid.ColumnSpan="3"
+                                         VerticalAlignment="Stretch"
+                                         AutomationProperties.HeadingLevel="Level1"
+                                         ButtonStyle="{StaticResource NumericButtonStyle24}"
+                                         TabIndex="10"
+                                         TabNavigation="Local"/>
+                        <controls:CalculatorButton x:Name="ConverterNegateButton"
+                                                   x:Uid="converterNegateButton"
+                                                   Grid.Row="4"
+                                                   Grid.Column="0"
+                                                   Style="{StaticResource SymbolOperatorKeypadButtonStyle}"
+                                                   FontSize="16"
+                                                   ButtonId="Negate"
+                                                   Content="&#xF898;"
+                                                   TabIndex="6"
+                                                   Visibility="{x:Bind Model.CurrentCategory.NegateVisibility, Mode=OneWay}"/>
+                    </Grid>
+                </Grid>
+            </controls:TwoPaneViewCX.Pane2>
+        </controls:TwoPaneViewCX>
     </Grid>
 </UserControl>

--- a/src/Calculator/Views/UnitConverter.xaml.h
+++ b/src/Calculator/Views/UnitConverter.xaml.h
@@ -13,6 +13,7 @@
 #include "Converters/VisibilityNegationConverter.h"
 #include "CalcViewModel/UnitConverterViewModel.h"
 #include "Views/StateTriggers/AspectRatioTrigger.h"
+#include "Views/StateTriggers/ApplicationViewModeTrigger.h"
 
 namespace CalculatorApp
 {

--- a/src/Calculator/pch.h
+++ b/src/Calculator/pch.h
@@ -43,6 +43,7 @@
 #include "winrt/Windows.System.UserProfile.h"
 #include "winrt/Windows.UI.ViewManagement.h"
 #include "winrt/Windows.UI.Xaml.h"
+#include "winrt/Windows.System.Profile.h"
 #include "winrt/Windows.Foundation.h"
 
 // Project Headers


### PR DESCRIPTION
Add dual screen support to all views.

![image](https://user-images.githubusercontent.com/1226538/78747633-b9b75100-791e-11ea-9864-f0d99032efd2.png)
![image](https://user-images.githubusercontent.com/1226538/78747637-bc19ab00-791e-11ea-864a-843900af5720.png)

![image](https://user-images.githubusercontent.com/1226538/78747628-b1f7ac80-791e-11ea-97f0-106da4819ce1.png)
![image](https://user-images.githubusercontent.com/1226538/78747630-b754f700-791e-11ea-802d-671ba64e0944.png)


### Description of the changes:
- Cherry-pick of #1027 (first commit)
- Replace all enums from WinUI with enums declared locally ([second commit](https://github.com/microsoft/calculator/pull/1156/commits/8b5fcae3427cc2ea6e352052163d2c5bf407e318))

### Original Description

- Add new StateTrigger detecting the different view modes
- Add a fork of TwoPaneView in C++CX for 2 reasons:
     - The fix for C++ apps (crash when navigating) isn't available for the moment
     - Add Pane1MinLength, Pane1MaxLength, Pane2MinLength, Pane2MaxLength properties
- Merge Visual State Group of Unit Converter, causing some issues due to conflicts
- Add DeviceFamilyHelper

**Other changes**
Visual states of Calculator.xaml had some collisions, the states related to AOT (https://github.com/microsoft/calculator/blob/master/src/Calculator/Views/Calculator.xaml#L521) and the states related to CalculationResult (https://github.com/microsoft/calculator/blob/master/src/Calculator/Views/Calculator.xaml#L544) were both triggered by the same type of trigger (window resizing), without checking if the app was AOT or not, and were modifying the same properties which caused some layouts issues.

In order to solve this problem, which also affects dual screens, we have replaced the StateTriggers used in AOT visual states with ApplicationViewModeTrigger in order to activate them only when the application is actually AOT.

### How changes were validated:
- manually on 10 and 10X 

