### PR TITLE
Fixed crash when in high contrast

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -48,6 +48,7 @@ EquationInputArea::EquationInputArea()
 {
     m_accessibilitySettings->HighContrastChanged +=
         ref new TypedEventHandler<AccessibilitySettings ^, Object ^>(this, &EquationInputArea::OnHighContrastChanged);
+    m_isHighContrast = m_accessibilitySettings->HighContrast;
 
     m_uiSettings = ref new UISettings();
     m_uiSettings->ColorValuesChanged += ref new TypedEventHandler<UISettings ^, Object ^>(this, &EquationInputArea::OnColorValuesChanged);
@@ -309,6 +310,7 @@ void EquationInputArea::FocusEquationIfNecessary(CalculatorApp::Controls::Equati
 void EquationInputArea::OnHighContrastChanged(AccessibilitySettings ^ sender, Object ^ args)
 {
     ReloadAvailableColors(sender->HighContrast, true);
+    m_isHighContrast = sender->HighContrast;
 }
 
 void EquationInputArea::OnColorValuesChanged(Windows::UI::ViewManagement::UISettings ^ sender, Platform::Object ^ args)
@@ -316,9 +318,9 @@ void EquationInputArea::OnColorValuesChanged(Windows::UI::ViewManagement::UISett
     WeakReference weakThis(this);
     this->Dispatcher->RunAsync(CoreDispatcherPriority::Normal, ref new DispatchedHandler([weakThis]() {
                                    auto refThis = weakThis.Resolve<EquationInputArea>();
-                                   if (refThis != nullptr)
+                                   if (refThis != nullptr && refThis->m_isHighContrast == refThis->m_accessibilitySettings->HighContrast)
                                    {
-                                       refThis->ReloadAvailableColors(refThis->m_accessibilitySettings->HighContrast, false);
+                                       refThis->ReloadAvailableColors(false, false);
                                    }
                                }));
 }
@@ -366,14 +368,14 @@ void EquationInputArea::ReloadAvailableColors(bool isHighContrast, bool reassign
     }
 
     // Reassign colors for each equation
-    if (isHighContrast || reassignColors)
+    if (reassignColors)
     {
         m_lastLineColorIndex = -1;
     }
 
     for (auto equationViewModel : Equations)
     {
-        if (isHighContrast || reassignColors)
+        if (reassignColors)
         {
             m_lastLineColorIndex = (m_lastLineColorIndex + 1) % AvailableColors->Size;
             equationViewModel->LineColorIndex = m_lastLineColorIndex;

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -366,14 +366,14 @@ void EquationInputArea::ReloadAvailableColors(bool isHighContrast, bool reassign
     }
 
     // Reassign colors for each equation
-    if (reassignColors)
+    if (isHighContrast || reassignColors)
     {
         m_lastLineColorIndex = -1;
     }
 
     for (auto equationViewModel : Equations)
     {
-        if (reassignColors)
+        if (isHighContrast || reassignColors)
         {
             m_lastLineColorIndex = (m_lastLineColorIndex + 1) % AvailableColors->Size;
             equationViewModel->LineColorIndex = m_lastLineColorIndex;

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
@@ -81,6 +81,7 @@ public
         Windows::UI::ViewManagement::UISettings ^ m_uiSettings;
         int m_lastLineColorIndex;
         int m_lastFunctionLabelIndex;
+        bool m_isHighContrast;
         ViewModel::EquationViewModel ^ m_equationToFocus;
         Platform::Collections::Map<Platform::String ^, CalculatorApp::DispatcherTimerDelayer ^> ^ variableSliders;
     };


### PR DESCRIPTION
## Fixes ##1150.


### Description of the changes:
- Fixed the issue where the colors were not being reassigned when switching to high contrast, which caused a crash.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manually
