### PR TITLE
Fix bug preventing the app to launch from the start menu when compiled in debug

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.cpp
@@ -22,79 +22,6 @@ using namespace Windows::UI::Xaml::Input;
 using namespace Windows::UI::Xaml::Media;
 using namespace Windows::UI::Xaml::Navigation;
 
-// Dictionary of the enum of the button clicked mapped to an object with the string to enter into the rich edit, and the start and end of the selection after
-// text has been entered.
-static const std::unordered_map<NumbersAndOperatorsEnum, std::tuple<Platform::String ^, int, int>> buttonOutput = {
-    { NumbersAndOperatorsEnum::Sin, { L"sin()", 4, 0 } },
-    { NumbersAndOperatorsEnum::Cos, { L"cos()", 4, 0 } },
-    { NumbersAndOperatorsEnum::Tan, { L"tan()", 4, 0 } },
-    { NumbersAndOperatorsEnum::Sec, { L"sec()", 4, 0 } },
-    { NumbersAndOperatorsEnum::Csc, { L"csc()", 4, 0 } },
-    { NumbersAndOperatorsEnum::Cot, { L"cot()", 4, 0 } },
-    { NumbersAndOperatorsEnum::InvSin, { L"arcsin()", 7, 0 } },
-    { NumbersAndOperatorsEnum::InvCos, { L"arccos()", 7, 0 } },
-    { NumbersAndOperatorsEnum::InvTan, { L"arctan()", 7, 0 } },
-    { NumbersAndOperatorsEnum::InvSec, { L"arcsec()", 7, 0 } },
-    { NumbersAndOperatorsEnum::InvCsc, { L"arccsc()", 7, 0 } },
-    { NumbersAndOperatorsEnum::InvCot, { L"arccot()", 7, 0 } },
-    { NumbersAndOperatorsEnum::Sinh, { L"sinh()", 5, 0 } },
-    { NumbersAndOperatorsEnum::Cosh, { L"cosh()", 5, 0 } },
-    { NumbersAndOperatorsEnum::Tanh, { L"tanh()", 5, 0 } },
-    { NumbersAndOperatorsEnum::Sech, { L"sech()", 5, 0 } },
-    { NumbersAndOperatorsEnum::Csch, { L"csch()", 5, 0 } },
-    { NumbersAndOperatorsEnum::Coth, { L"coth()", 5, 0 } },
-    { NumbersAndOperatorsEnum::InvSinh, { L"arcsinh()", 8, 0 } },
-    { NumbersAndOperatorsEnum::InvCosh, { L"arccosh()", 8, 0 } },
-    { NumbersAndOperatorsEnum::InvTanh, { L"arctanh()", 8, 0 } },
-    { NumbersAndOperatorsEnum::InvSech, { L"arcsech()", 8, 0 } },
-    { NumbersAndOperatorsEnum::InvCsch, { L"arccsch()", 8, 0 } },
-    { NumbersAndOperatorsEnum::InvCoth, { L"arccoth()", 8, 0 } },
-    { NumbersAndOperatorsEnum::Abs, { L"abs()", 4, 0 } },
-    { NumbersAndOperatorsEnum::Floor, { L"floor()", 6, 0 } },
-    { NumbersAndOperatorsEnum::Ceil, { L"ceiling()", 8, 0 } },
-    { NumbersAndOperatorsEnum::Pi, { L"\u03C0", 1, 0 } },
-    { NumbersAndOperatorsEnum::Euler, { L"e", 1, 0 } },
-    { NumbersAndOperatorsEnum::XPower2, { L"^2", 2, 0 } },
-    { NumbersAndOperatorsEnum::Cube, { L"^3", 2, 0 } },
-    { NumbersAndOperatorsEnum::XPowerY, { L"^", 1, 0 } },
-    { NumbersAndOperatorsEnum::TenPowerX, { L"10^", 3, 0 } },
-    { NumbersAndOperatorsEnum::LogBase10, { L"log()", 4, 0 } },
-    { NumbersAndOperatorsEnum::LogBaseE, { L"ln()", 3, 0 } },
-    { NumbersAndOperatorsEnum::Sqrt, { L"sqrt()", 5, 0 } },
-    { NumbersAndOperatorsEnum::CubeRoot, { L"cbrt()", 5, 0 } },
-    { NumbersAndOperatorsEnum::YRootX, { L"root(x" + StringReference(LocalizationSettings::GetInstance().GetListSeparator().data()) + L"n)", 7, 1 } },
-    { NumbersAndOperatorsEnum::TwoPowerX, { L"2^", 2, 0 } },
-    { NumbersAndOperatorsEnum::LogBaseY, { "log(b" + StringReference(LocalizationSettings::GetInstance().GetListSeparator().data()) + L" x)", 4, 1 } },
-    { NumbersAndOperatorsEnum::EPowerX, { L"e^", 4, 0 } },
-    { NumbersAndOperatorsEnum::Abs, { L"abs()", 4, 0 } },
-    { NumbersAndOperatorsEnum::X, { L"x", 1, 0 } },
-    { NumbersAndOperatorsEnum::Y, { L"y", 1, 0 } },
-    { NumbersAndOperatorsEnum::OpenParenthesis, { L"(", 1, 0 } },
-    { NumbersAndOperatorsEnum::CloseParenthesis, { L")", 1, 0 } },
-    { NumbersAndOperatorsEnum::Equals, { L"=", 1, 0 } },
-    { NumbersAndOperatorsEnum::Divide, { L"/", 1, 0 } },
-    { NumbersAndOperatorsEnum::Multiply, { L"*", 1, 0 } },
-    { NumbersAndOperatorsEnum::Subtract, { L"-", 1, 0 } },
-    { NumbersAndOperatorsEnum::Add, { L"+", 1, 0 } },
-    { NumbersAndOperatorsEnum::Invert, { L"1/", 2, 0 } },
-    { NumbersAndOperatorsEnum::Negate, { L"-", 1, 0 } },
-    { NumbersAndOperatorsEnum::GreaterThan, { L">", 1, 0 } },
-    { NumbersAndOperatorsEnum::GreaterThanOrEqualTo, { L"\u2265", 1, 0 } },
-    { NumbersAndOperatorsEnum::LessThan, { L"<", 1, 0 } },
-    { NumbersAndOperatorsEnum::LessThanOrEqualTo, { L"\u2264", 1, 0 } },
-    { NumbersAndOperatorsEnum::Zero, { L"0", 1, 0 } },
-    { NumbersAndOperatorsEnum::One, { L"1", 1, 0 } },
-    { NumbersAndOperatorsEnum::Two, { L"2", 1, 0 } },
-    { NumbersAndOperatorsEnum::Three, { L"3", 1, 0 } },
-    { NumbersAndOperatorsEnum::Four, { L"4", 1, 0 } },
-    { NumbersAndOperatorsEnum::Five, { L"5", 1, 0 } },
-    { NumbersAndOperatorsEnum::Six, { L"6", 1, 0 } },
-    { NumbersAndOperatorsEnum::Seven, { L"7", 1, 0 } },
-    { NumbersAndOperatorsEnum::Eight, { L"8", 1, 0 } },
-    { NumbersAndOperatorsEnum::Nine, { L"9", 1, 0 } },
-    { NumbersAndOperatorsEnum::Decimal, { StringReference(LocalizationSettings::GetInstance().GetDecimalSeparatorStr().data()), 1, 0 } },
-};
-
 GraphingNumPad::GraphingNumPad()
 {
     InitializeComponent();
@@ -197,6 +124,84 @@ void GraphingNumPad::SetOperatorRowVisibility()
     InvRow1->Visibility = invRowVis;
 }
 
+const std::tuple<Platform::String ^, int, int> GraphingNumPad::GetButtonOutput(NumbersAndOperatorsEnum id)
+{
+    // Dictionary of the enum of the button clicked mapped to an object with the string to enter into the rich edit, and the start and end of the selection
+    // after
+    // text has been entered.
+    static const std::unordered_map<NumbersAndOperatorsEnum, std::tuple<Platform::String ^, int, int>> buttonOutput = {
+        { NumbersAndOperatorsEnum::Sin, { L"sin()", 4, 0 } },
+        { NumbersAndOperatorsEnum::Cos, { L"cos()", 4, 0 } },
+        { NumbersAndOperatorsEnum::Tan, { L"tan()", 4, 0 } },
+        { NumbersAndOperatorsEnum::Sec, { L"sec()", 4, 0 } },
+        { NumbersAndOperatorsEnum::Csc, { L"csc()", 4, 0 } },
+        { NumbersAndOperatorsEnum::Cot, { L"cot()", 4, 0 } },
+        { NumbersAndOperatorsEnum::InvSin, { L"arcsin()", 7, 0 } },
+        { NumbersAndOperatorsEnum::InvCos, { L"arccos()", 7, 0 } },
+        { NumbersAndOperatorsEnum::InvTan, { L"arctan()", 7, 0 } },
+        { NumbersAndOperatorsEnum::InvSec, { L"arcsec()", 7, 0 } },
+        { NumbersAndOperatorsEnum::InvCsc, { L"arccsc()", 7, 0 } },
+        { NumbersAndOperatorsEnum::InvCot, { L"arccot()", 7, 0 } },
+        { NumbersAndOperatorsEnum::Sinh, { L"sinh()", 5, 0 } },
+        { NumbersAndOperatorsEnum::Cosh, { L"cosh()", 5, 0 } },
+        { NumbersAndOperatorsEnum::Tanh, { L"tanh()", 5, 0 } },
+        { NumbersAndOperatorsEnum::Sech, { L"sech()", 5, 0 } },
+        { NumbersAndOperatorsEnum::Csch, { L"csch()", 5, 0 } },
+        { NumbersAndOperatorsEnum::Coth, { L"coth()", 5, 0 } },
+        { NumbersAndOperatorsEnum::InvSinh, { L"arcsinh()", 8, 0 } },
+        { NumbersAndOperatorsEnum::InvCosh, { L"arccosh()", 8, 0 } },
+        { NumbersAndOperatorsEnum::InvTanh, { L"arctanh()", 8, 0 } },
+        { NumbersAndOperatorsEnum::InvSech, { L"arcsech()", 8, 0 } },
+        { NumbersAndOperatorsEnum::InvCsch, { L"arccsch()", 8, 0 } },
+        { NumbersAndOperatorsEnum::InvCoth, { L"arccoth()", 8, 0 } },
+        { NumbersAndOperatorsEnum::Abs, { L"abs()", 4, 0 } },
+        { NumbersAndOperatorsEnum::Floor, { L"floor()", 6, 0 } },
+        { NumbersAndOperatorsEnum::Ceil, { L"ceiling()", 8, 0 } },
+        { NumbersAndOperatorsEnum::Pi, { L"\u03C0", 1, 0 } },
+        { NumbersAndOperatorsEnum::Euler, { L"e", 1, 0 } },
+        { NumbersAndOperatorsEnum::XPower2, { L"^2", 2, 0 } },
+        { NumbersAndOperatorsEnum::Cube, { L"^3", 2, 0 } },
+        { NumbersAndOperatorsEnum::XPowerY, { L"^", 1, 0 } },
+        { NumbersAndOperatorsEnum::TenPowerX, { L"10^", 3, 0 } },
+        { NumbersAndOperatorsEnum::LogBase10, { L"log()", 4, 0 } },
+        { NumbersAndOperatorsEnum::LogBaseE, { L"ln()", 3, 0 } },
+        { NumbersAndOperatorsEnum::Sqrt, { L"sqrt()", 5, 0 } },
+        { NumbersAndOperatorsEnum::CubeRoot, { L"cbrt()", 5, 0 } },
+        { NumbersAndOperatorsEnum::YRootX, { L"root(x" + StringReference(LocalizationSettings::GetInstance().GetListSeparator().data()) + L"n)", 7, 1 } },
+        { NumbersAndOperatorsEnum::TwoPowerX, { L"2^", 2, 0 } },
+        { NumbersAndOperatorsEnum::LogBaseY, { "log(b" + StringReference(LocalizationSettings::GetInstance().GetListSeparator().data()) + L" x)", 4, 1 } },
+        { NumbersAndOperatorsEnum::EPowerX, { L"e^", 4, 0 } },
+        { NumbersAndOperatorsEnum::Abs, { L"abs()", 4, 0 } },
+        { NumbersAndOperatorsEnum::X, { L"x", 1, 0 } },
+        { NumbersAndOperatorsEnum::Y, { L"y", 1, 0 } },
+        { NumbersAndOperatorsEnum::OpenParenthesis, { L"(", 1, 0 } },
+        { NumbersAndOperatorsEnum::CloseParenthesis, { L")", 1, 0 } },
+        { NumbersAndOperatorsEnum::Equals, { L"=", 1, 0 } },
+        { NumbersAndOperatorsEnum::Divide, { L"/", 1, 0 } },
+        { NumbersAndOperatorsEnum::Multiply, { L"*", 1, 0 } },
+        { NumbersAndOperatorsEnum::Subtract, { L"-", 1, 0 } },
+        { NumbersAndOperatorsEnum::Add, { L"+", 1, 0 } },
+        { NumbersAndOperatorsEnum::Invert, { L"1/", 2, 0 } },
+        { NumbersAndOperatorsEnum::Negate, { L"-", 1, 0 } },
+        { NumbersAndOperatorsEnum::GreaterThan, { L">", 1, 0 } },
+        { NumbersAndOperatorsEnum::GreaterThanOrEqualTo, { L"\u2265", 1, 0 } },
+        { NumbersAndOperatorsEnum::LessThan, { L"<", 1, 0 } },
+        { NumbersAndOperatorsEnum::LessThanOrEqualTo, { L"\u2264", 1, 0 } },
+        { NumbersAndOperatorsEnum::Zero, { L"0", 1, 0 } },
+        { NumbersAndOperatorsEnum::One, { L"1", 1, 0 } },
+        { NumbersAndOperatorsEnum::Two, { L"2", 1, 0 } },
+        { NumbersAndOperatorsEnum::Three, { L"3", 1, 0 } },
+        { NumbersAndOperatorsEnum::Four, { L"4", 1, 0 } },
+        { NumbersAndOperatorsEnum::Five, { L"5", 1, 0 } },
+        { NumbersAndOperatorsEnum::Six, { L"6", 1, 0 } },
+        { NumbersAndOperatorsEnum::Seven, { L"7", 1, 0 } },
+        { NumbersAndOperatorsEnum::Eight, { L"8", 1, 0 } },
+        { NumbersAndOperatorsEnum::Nine, { L"9", 1, 0 } },
+        { NumbersAndOperatorsEnum::Decimal, { StringReference(LocalizationSettings::GetInstance().GetDecimalSeparatorStr().data()), 1, 0 } },
+    };
+    return buttonOutput.find(id)->second;
+}
+
 void GraphingNumPad::Button_Clicked(Platform::Object ^ sender, DependencyPropertyChangedEventArgs ^ /*e*/)
 {
     auto mathRichEdit = GetActiveRichEdit();
@@ -205,8 +210,8 @@ void GraphingNumPad::Button_Clicked(Platform::Object ^ sender, DependencyPropert
     {
         auto id = button->ButtonId;
         TraceLogger::GetInstance()->UpdateButtonUsage(id, CalculatorApp::Common::ViewMode::Graphing);
-        auto output = buttonOutput.find(id);
-        mathRichEdit->InsertText(std::get<0>(output->second), std::get<1>(output->second), std::get<2>(output->second));
+        std::tuple<Platform::String ^, int, int> output = GraphingNumPad::GetButtonOutput(id);
+        mathRichEdit->InsertText(std::get<0>(output), std::get<1>(output), std::get<2>(output));
     }
 }
 

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml.h
@@ -33,5 +33,8 @@ namespace CalculatorApp
         void GraphingNumPad_PointerPressed(Platform::Object ^ sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs ^ e);
         Controls::MathRichEditBox^ GetActiveRichEdit();
         void Flyout_Opening(Platform::Object ^ sender, Platform::Object ^ e);
+
+    private:
+        static const std::tuple<Platform::String ^, int, int> GetButtonOutput(NumbersAndOperatorsEnum id);
     };
 }


### PR DESCRIPTION
Also remove the `Assert` at launch when debugging with VS.

![image](https://user-images.githubusercontent.com/1226538/78974264-77307880-7ac6-11ea-8e27-ca6cd8955a3d.png)

### Reason
The lock in `LocalizationService::GetInstance` was blocking the launch of the app because called too early during the initialization of the app.

This call was made by the static map `GraphingNumPad:buttonOutput` initialized during the launch, even when Graphing Calculator wasn't the selected mode.
 
### Description of the changes:
- load the map just-in-time, only when users will click on one of the button

### Impact

It should improve the performance of the application launch.

### How changes were validated:
- manually

