### PR TITLE
Update tooltips for the Equation Button and Style Picker

### DIFF
--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -67,16 +67,6 @@ void EquationTextBox::OnApplyTemplate()
     if (m_equationButton != nullptr)
     {
         m_equationButton->Click += ref new RoutedEventHandler(this, &EquationTextBox::OnEquationButtonClicked);
-
-        auto toolTip = ref new ToolTip();
-
-        auto equationButtonMessage = LocalizationStringUtil::GetLocalizedString(
-            IsEquationLineDisabled ? resProvider->GetResourceString(L"showEquationButtonToolTip")
-                                               : resProvider->GetResourceString(L"hideEquationButtonToolTip"), EquationButtonContentIndex);
-
-        toolTip->Content = equationButtonMessage;
-        ToolTipService::SetToolTip(m_equationButton, toolTip);
-        AutomationProperties::SetName(m_equationButton, equationButtonMessage);
     }
 
     if (m_richEditContextMenu != nullptr)
@@ -235,16 +225,7 @@ void EquationTextBox::OnEquationButtonClicked(Object ^ sender, RoutedEventArgs ^
 {
     EquationButtonClicked(this, ref new RoutedEventArgs());
 
-    auto toolTip = ref new ToolTip();
-    auto resProvider = AppResourceProvider::GetInstance();
-
-    auto equationButtonMessage = LocalizationStringUtil::GetLocalizedString(
-        IsEquationLineDisabled ? resProvider->GetResourceString(L"showEquationButtonToolTip")
-                                           : resProvider->GetResourceString(L"hideEquationButtonToolTip"), EquationButtonContentIndex);
-
-    toolTip->Content = equationButtonMessage;
-    ToolTipService::SetToolTip(m_equationButton, toolTip);
-    AutomationProperties::SetName(m_equationButton, equationButtonMessage);
+    SetEquationButtonTooltipAndAutomationName();
 }
 
 void EquationTextBox::OnRemoveButtonClicked(Object ^ sender, RoutedEventArgs ^ e)
@@ -482,4 +463,27 @@ void EquationTextBox::OnEquationSubmitted(Platform::Object ^ sender, MathRichEdi
 void EquationTextBox::OnEquationFormatRequested(Object ^ sender, MathRichEditBoxFormatRequest ^ args)
 {
     EquationFormatRequested(this, args);
+}
+
+void EquationTextBox::SetEquationButtonTooltipAndAutomationName()
+{
+    auto toolTip = ref new ToolTip();
+    auto resProvider = AppResourceProvider::GetInstance();
+
+    auto equationButtonMessage = LocalizationStringUtil::GetLocalizedString(
+        IsEquationLineDisabled ? resProvider->GetResourceString(L"showEquationButtonAutomationName")
+                               : resProvider->GetResourceString(L"hideEquationButtonAutomationName"),
+        EquationButtonContentIndex);
+
+    auto equationButtonTooltip = LocalizationStringUtil::GetLocalizedString(
+        IsEquationLineDisabled ? resProvider->GetResourceString(L"showEquationButtonToolTip") : resProvider->GetResourceString(L"hideEquationButtonToolTip"));
+
+    toolTip->Content = equationButtonTooltip;
+    ToolTipService::SetToolTip(m_equationButton, toolTip);
+    AutomationProperties::SetName(m_equationButton, equationButtonMessage);
+}
+
+void EquationTextBox::OnEquationButtonContentIndexPropertyChanged(String ^ /*oldValue*/, String ^ newValue)
+{
+    SetEquationButtonTooltipAndAutomationName();
 }

--- a/src/Calculator/Controls/EquationTextBox.h
+++ b/src/Calculator/Controls/EquationTextBox.h
@@ -21,7 +21,7 @@ namespace CalculatorApp
             DEPENDENCY_PROPERTY_OWNER(EquationTextBox);
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Media::SolidColorBrush ^, EquationColor);
             DEPENDENCY_PROPERTY(Windows::UI::Xaml::Controls::Flyout ^, ColorChooserFlyout);
-            DEPENDENCY_PROPERTY(Platform::String ^, EquationButtonContentIndex);
+            DEPENDENCY_PROPERTY_WITH_CALLBACK(Platform::String ^, EquationButtonContentIndex);
             DEPENDENCY_PROPERTY(Platform::String ^, MathEquation);
             DEPENDENCY_PROPERTY_WITH_CALLBACK(bool, HasError);
             DEPENDENCY_PROPERTY_WITH_CALLBACK(bool, IsAddEquationMode);
@@ -73,6 +73,9 @@ namespace CalculatorApp
             void OnColorFlyoutClosed(Platform::Object ^ sender, Platform::Object ^ e);
 
             void OnHasErrorPropertyChanged(bool oldValue, bool newValue);
+            void OnEquationButtonContentIndexPropertyChanged(Platform::String ^ /*oldValue*/, Platform::String ^ newValue);
+
+            void SetEquationButtonTooltipAndAutomationName();
 
             CalculatorApp::Controls::MathRichEditBox ^ m_richEditBox;
             Windows::UI::Xaml::Controls::Primitives::ToggleButton ^ m_equationButton;

--- a/src/Calculator/EquationStylePanelControl.xaml
+++ b/src/Calculator/EquationStylePanelControl.xaml
@@ -80,6 +80,7 @@
                              Fill="{x:Bind}"
                              StrokeThickness="0"
                              AutomationProperties.Name="{x:Bind local:EquationStylePanelControl.GetColorAutomationName((Brush))}"
+                             ToolTipService.ToolTip="{x:Bind local:EquationStylePanelControl.GetColorAutomationName((Brush))}"
                              UseLayoutRounding="false"/>
                 </DataTemplate>
             </GridView.ItemTemplate>

--- a/src/Calculator/EquationStylePanelControl.xaml.cpp
+++ b/src/Calculator/EquationStylePanelControl.xaml.cpp
@@ -197,9 +197,14 @@ String ^ EquationStylePanelControl::GetColorAutomationName(Brush ^ brush)
     {
         return resourceLoader->GetResourceString("equationColor13AutomationName");
     }
+    else if (Application::Current->RequestedTheme == ApplicationTheme::Dark &&
+        color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush14")))
+    {
+        return resourceLoader->GetResourceString("equationColor14WhiteAutomationName");
+    }
     else
     {
-        return resourceLoader->GetResourceString("equationColor14AutomationName");
+        return resourceLoader->GetResourceString("equationColor14BlackAutomationName");
     }
 }
 

--- a/src/Calculator/EquationStylePanelControl.xaml.cpp
+++ b/src/Calculator/EquationStylePanelControl.xaml.cpp
@@ -147,6 +147,7 @@ String ^ EquationStylePanelControl::GetColorAutomationName(Brush ^ brush)
 
     auto lightDictionary = static_cast<ResourceDictionary ^>(Application::Current->Resources->ThemeDictionaries->Lookup(L"Light"));
     auto darkDictionary = static_cast<ResourceDictionary ^>(Application::Current->Resources->ThemeDictionaries->Lookup(L"Default"));
+    auto highContrast = static_cast<ResourceDictionary ^>(Application::Current->Resources->ThemeDictionaries->Lookup(L"HighContrast"));
 
     if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush1"))
         || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush1")))
@@ -217,10 +218,27 @@ String ^ EquationStylePanelControl::GetColorAutomationName(Brush ^ brush)
     {
         return resourceLoader->GetResourceString("equationColor14WhiteAutomationName");
     }
-    else
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush14")))
     {
         return resourceLoader->GetResourceString("equationColor14BlackAutomationName");
     }
+    else if (color == safe_cast<SolidColorBrush ^>(highContrast->Lookup(L"EquationBrush1")))
+    {
+        return resourceLoader->GetResourceString("equationHighContrastColor1AutomationName");
+    }
+    else if (color == safe_cast<SolidColorBrush ^>(highContrast->Lookup(L"EquationBrush2")))
+    {
+        return resourceLoader->GetResourceString("equationHighContrastColor2AutomationName");
+    }
+    else if (color == safe_cast<SolidColorBrush ^>(highContrast->Lookup(L"EquationBrush3")))
+    {
+        return resourceLoader->GetResourceString("equationHighContrastColor3AutomationName");
+    }
+    else
+    {
+        return resourceLoader->GetResourceString("equationHighContrastColor4AutomationName");
+    }
+
 }
 
 String ^ EquationStylePanelControl::GetLineAutomationName(Object ^ line)

--- a/src/Calculator/EquationStylePanelControl.xaml.cpp
+++ b/src/Calculator/EquationStylePanelControl.xaml.cpp
@@ -145,60 +145,75 @@ String ^ EquationStylePanelControl::GetColorAutomationName(Brush ^ brush)
     auto resourceLoader = AppResourceProvider::GetInstance();
     auto color = static_cast<SolidColorBrush ^>(brush);
 
-    if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush1")))
+    auto lightDictionary = static_cast<ResourceDictionary ^>(Application::Current->Resources->ThemeDictionaries->Lookup(L"Light"));
+    auto darkDictionary = static_cast<ResourceDictionary ^>(Application::Current->Resources->ThemeDictionaries->Lookup(L"Default"));
+
+    if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush1"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush1")))
     {
         return resourceLoader->GetResourceString("equationColor1AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush2")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush2"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush2")))
     {
         return resourceLoader->GetResourceString("equationColor2AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush3")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush3"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush3")))
     {
         return resourceLoader->GetResourceString("equationColor3AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush4")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush4"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush4")))
     {
         return resourceLoader->GetResourceString("equationColor4AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush5")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush5"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush5")))
     {
         return resourceLoader->GetResourceString("equationColor5AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush6")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush6"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush6")))
     {
         return resourceLoader->GetResourceString("equationColor6AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush7")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush7"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush7")))
     {
         return resourceLoader->GetResourceString("equationColor7AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush8")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush8"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush8")))
     {
         return resourceLoader->GetResourceString("equationColor8AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush9")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush9"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush9")))
     {
         return resourceLoader->GetResourceString("equationColor9AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush10")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush10"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush10")))
     {
         return resourceLoader->GetResourceString("equationColor10AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush11")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush11"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush11")))
     {
         return resourceLoader->GetResourceString("equationColor11AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush12")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush12"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush12")))
     {
         return resourceLoader->GetResourceString("equationColor12AutomationName");
     }
-    else if (color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush13")))
+    else if (color == safe_cast<SolidColorBrush ^>(lightDictionary->Lookup(L"EquationBrush13"))
+        || color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush13")))
     {
         return resourceLoader->GetResourceString("equationColor13AutomationName");
     }
-    else if (Application::Current->RequestedTheme == ApplicationTheme::Dark &&
-        color == safe_cast<SolidColorBrush ^>(Application::Current->Resources->Lookup(L"EquationBrush14")))
+    else if (color == safe_cast<SolidColorBrush ^>(darkDictionary->Lookup(L"EquationBrush14")))
     {
         return resourceLoader->GetResourceString("equationColor14WhiteAutomationName");
     }

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4591,6 +4591,22 @@
     <value>White</value>
     <comment>Name of color in the color picker</comment>
   </data>
+    <data name="equationHighContrastColor1AutomationName" xml:space="preserve">
+    <value>Color 1</value>
+    <comment>Name of color in the color picker</comment>
+  </data>
+    <data name="equationHighContrastColor2AutomationName" xml:space="preserve">
+    <value>Color 2</value>
+    <comment>Name of color in the color picker</comment>
+  </data>
+    <data name="equationHighContrastColor3AutomationName" xml:space="preserve">
+    <value>Color 3</value>
+    <comment>Name of color in the color picker</comment>
+  </data>
+    <data name="equationHighContrastColor4AutomationName" xml:space="preserve">
+    <value>Color 4</value>
+    <comment>Name of color in the color picker</comment>
+  </data>
   <data name="GraphThemeHeading.Text" xml:space="preserve">
     <value>Theme</value>
     <comment>Graph settings heading for the theme options</comment>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4621,7 +4621,7 @@
   </data>
   <data name="KGFEquationTextBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Function Analysis Equation Box</value>
-    <comment>This is the automation name text for the equation box in the function analsis panel</comment>
+    <comment>This is the automation name text for the equation box in the function analysis panel</comment>
   </data>
   <data name="lessThanFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Less than</value>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4539,52 +4539,56 @@
     <value>Seafoam</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor3AutomationName" xml:space="preserve">
+  <data name="equationColor3AutomationName" xml:space="preserve">
     <value>Violet</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor4AutomationName" xml:space="preserve">
+  <data name="equationColor4AutomationName" xml:space="preserve">
     <value>Green</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor5AutomationName" xml:space="preserve">
+  <data name="equationColor5AutomationName" xml:space="preserve">
     <value>Mint Green</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor6AutomationName" xml:space="preserve">
+  <data name="equationColor6AutomationName" xml:space="preserve">
     <value>Dark Green</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor7AutomationName" xml:space="preserve">
+  <data name="equationColor7AutomationName" xml:space="preserve">
     <value>Charcoal</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor8AutomationName" xml:space="preserve">
+  <data name="equationColor8AutomationName" xml:space="preserve">
     <value>Red</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor9AutomationName" xml:space="preserve">
+  <data name="equationColor9AutomationName" xml:space="preserve">
     <value>Plum Light</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor10AutomationName" xml:space="preserve">
+  <data name="equationColor10AutomationName" xml:space="preserve">
     <value>Magenta</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor11AutomationName" xml:space="preserve">
+  <data name="equationColor11AutomationName" xml:space="preserve">
     <value>Yellow Gold</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor12AutomationName" xml:space="preserve">
+  <data name="equationColor12AutomationName" xml:space="preserve">
     <value>Orange Bright</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor13AutomationName" xml:space="preserve">
+  <data name="equationColor13AutomationName" xml:space="preserve">
     <value>Brown</value>
     <comment>Name of color in the color picker</comment>
   </data>
-    <data name="equationColor14AutomationName" xml:space="preserve">
+  <data name="equationColor14BlackAutomationName" xml:space="preserve">
     <value>Black</value>
+    <comment>Name of color in the color picker</comment>
+  </data>
+  <data name="equationColor14WhiteAutomationName" xml:space="preserve">
+    <value>White</value>
     <comment>Name of color in the color picker</comment>
   </data>
   <data name="GraphThemeHeading.Text" xml:space="preserve">
@@ -4603,7 +4607,7 @@
     <value>Theme</value>
     <comment>This is the automation name text for the Graph settings heading for the theme options</comment>
   </data>
-    <data name="AlwaysLightTheme.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+  <data name="AlwaysLightTheme.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Always light</value>
     <comment>This is the automation name text for the Graph settings option to set graph to light theme</comment>
   </data>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3539,6 +3539,10 @@
     <value>Inequalities</value>
     <comment>Displayed on the button that contains a flyout for the inequality functions.</comment>
   </data>
+  <data name="inequalityButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Inequalities</value>
+    <comment>Screen reader prompt for the Inequalities button</comment>
+  </data>
   <data name="bitwiseButton.Text" xml:space="preserve">
     <value>Bitwise</value>
     <comment>Displayed on the button that contains a flyout for the bitwise functions in programmer mode.</comment>
@@ -3842,14 +3846,6 @@
   <data name="GraphingCalculatorModeText" xml:space="preserve">
     <value>Graphing</value>
     <comment>Name of the Graphing mode of the Calculator app. Displayed in the navigation menu.</comment>
-  </data>
-  <data name="graphingEqualButton.[using:CalculatorApp.Common]KeyboardShortcutManager.Character" xml:space="preserve">
-    <value>=</value>
-    <comment>{Locked}This is the character that should trigger this button. Note that it is a character and not a key, so it does not come from the Windows::System::VirtualKey enum.</comment>
-  </data>
-  <data name="graphingEqualButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Equals</value>
-    <comment>Screen reader prompt for the equal button on the graphing calculator operator keypad</comment>
   </data>
   <data name="plotButton.[using:CalculatorApp.Common]KeyboardShortcutManager.VirtualKey" xml:space="preserve">
     <value>Enter</value>
@@ -4319,13 +4315,22 @@
     <comment>This is the text for the for the equation style context menu command</comment>
   </data>
   <data name="showEquationButtonToolTip" xml:space="preserve">
+    <value>Show equation</value>
+    <comment>This is the tooltip/automation name shown when visibility is set to hidden in the graphing calculator.</comment>
+  </data>
+  <data name="hideEquationButtonToolTip" xml:space="preserve">
+    <value>Hide equation</value>
+    <comment>This is the tooltip/automation name shown when visibility is set to visible in the graphing calculator.</comment>
+  </data>
+<data name="showEquationButtonAutomationName" xml:space="preserve">
     <value>Show equation %1</value>
     <comment>{Locked="%1"}, This is the tooltip/automation name shown when visibility is set to hidden in the graphing calculator. %1 is the equation number.</comment>
   </data>
-  <data name="hideEquationButtonToolTip" xml:space="preserve">
+  <data name="hideEquationButtonAutomationName" xml:space="preserve">
     <value>Hide equation %1</value>
     <comment>{Locked="%1"}, This is the tooltip/automation name shown when visibility is set to visible in the graphing calculator. %1 is the equation number.</comment>
   </data>
+    
   <data name="disableTracingButtonToolTip" xml:space="preserve">
     <value>Stop tracing</value>
     <comment>This is the tooltip/automation name for the graphing calculator stop tracing button</comment>
@@ -4613,5 +4618,41 @@
   <data name="KGFEquationTextBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Function Analysis Equation Box</value>
     <comment>This is the automation name text for the equation box in the function analsis panel</comment>
+  </data>
+  <data name="lessThanFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Less than</value>
+    <comment>Screen reader prompt for the Less than button</comment>
+  </data>
+  <data name="lessThanOrEqualFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Less than or equal</value>
+    <comment>Screen reader prompt for the Less than or equal button</comment>
+  </data>
+  <data name="equalsFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Equal</value>
+    <comment>Screen reader prompt for the Equal button</comment>
+  </data>
+  <data name="greaterThanOrEqualFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Greater than or equal</value>
+    <comment>Screen reader prompt for the Greater than or equal button</comment>
+  </data>
+  <data name="greaterThanFlyoutButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Greater than</value>
+    <comment>Screen reader prompt for the Greater than button</comment>
+  </data>
+  <data name="graphingEqualButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Equals</value>
+    <comment>Screen reader prompt for the equal button on the graphing calculator operator keypad</comment>
+  </data>
+    <data name="xButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>X</value>
+    <comment>Screen reader prompt for the X button on the graphing calculator operator keypad</comment>
+  </data>
+    <data name="yButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Y</value>
+    <comment>Screen reader prompt for the Y button on the graphing calculator operator keypad</comment>
+  </data>
+  <data name="submitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Submit</value>
+    <comment>Screen reader prompt for the submit button on the graphing calculator operator keypad</comment>
   </data>
 </root>


### PR DESCRIPTION
## Fixes #1160.


### Description of the changes:
- Updates the equation button automation name and tooltip to use different resource items
- Add tooltips to the colors in the style picker
- Fixed the issue where the white color has the wrong automation name

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manually with narrator and validated the tooltips
