### PR TITLE
Fixes the issues the focus state issues when users open the context menu on EquationEditBoxes

### DIFF
--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -421,6 +421,11 @@ bool EquationTextBox::RichEditHasContent()
 
 void EquationTextBox::OnRichEditMenuOpened(Object ^ /*sender*/, Object ^ /*args*/)
 {
+    if (m_richEditBox != nullptr)
+    {
+        VisualStateManager::GoToState(m_richEditBox, L"Focused", false);
+    }
+
     if (m_kgfEquationMenuItem != nullptr)
     {
         m_kgfEquationMenuItem->IsEnabled = m_HasFocus && !HasError && RichEditHasContent();

--- a/src/Calculator/Controls/EquationTextBox.cpp
+++ b/src/Calculator/Controls/EquationTextBox.cpp
@@ -392,6 +392,12 @@ void EquationTextBox::UpdateCommonVisualState()
     {
         state = "Normal";
     }
+
+    if (m_HasFocus && m_richEditBox != nullptr)
+    {
+        VisualStateManager::GoToState(m_richEditBox, L"Focused", false);
+    }
+
     VisualStateManager::GoToState(this, state, false);
 }
 
@@ -421,11 +427,6 @@ bool EquationTextBox::RichEditHasContent()
 
 void EquationTextBox::OnRichEditMenuOpened(Object ^ /*sender*/, Object ^ /*args*/)
 {
-    if (m_richEditBox != nullptr)
-    {
-        VisualStateManager::GoToState(m_richEditBox, L"Focused", false);
-    }
-
     if (m_kgfEquationMenuItem != nullptr)
     {
         m_kgfEquationMenuItem->IsEnabled = m_HasFocus && !HasError && RichEditHasContent();

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -74,11 +74,11 @@ void EquationInputArea::OnEquationsPropertyChanged()
 {
     if (Equations != nullptr && Equations->Size == 0)
     {
-        AddNewEquation();
+        AddNewEquation(true);
     }
 }
 
-void EquationInputArea::AddNewEquation()
+void EquationInputArea::AddNewEquation(bool isNewEquationFocused)
 {
     if (Equations->Size > 0)
     {
@@ -119,7 +119,11 @@ void EquationInputArea::AddNewEquation()
 
     auto eq = ref new EquationViewModel(ref new Equation(), ++m_lastFunctionLabelIndex, AvailableColors->GetAt(colorIndex)->Color, colorIndex);
     eq->IsLastItemInList = true;
-    m_equationToFocus = eq;
+    if (isNewEquationFocused)
+    {
+        m_equationToFocus = eq;
+    }
+
     Equations->Append(eq);
 }
 
@@ -164,7 +168,7 @@ void EquationInputArea::EquationTextBox_Submitted(Object ^ sender, MathRichEditB
             if (index == Equations->Size - 1)
             {
                 // If it's the last equation of the list
-                AddNewEquation();
+                AddNewEquation(submission->Source != EquationSubmissionSource::FOCUS_LOST);
             }
             else
             {

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.h
@@ -45,7 +45,7 @@ public
         void OnPropertyChanged(Platform::String ^ propertyName);
         void OnEquationsPropertyChanged();
 
-        void AddNewEquation();
+        void AddNewEquation(bool isNewEquationFocused);
 
         void EquationTextBox_GotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void EquationTextBox_LostFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);


### PR DESCRIPTION
## Fixes #1153.


### Description of the changes:
- Updated the AddNewEquation method to only set the focus state to the new equation if the submission source was not lost focus
- Updated the EquationEditBox focus states to also give focus to the RichEditBox when m_hasFocus is true.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manually
