### PR TITLE
Fix equation submitting twice when submitted via enter key

### DIFF
--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -128,7 +128,9 @@ void CalculatorApp::Controls::MathRichEditBox::OnKeyUp(Platform::Object ^ sender
 void MathRichEditBox::OnMathTextPropertyChanged(Platform::String ^ oldValue, Platform::String ^ newValue)
 {
     SetMathTextProperty(newValue);
-    SetValue(MathTextProperty, newValue);
+
+    // Get the new math text directly from the TextBox since the textbox may have changed its formatting
+    SetValue(MathTextProperty, GetMathTextProperty());
 }
 
 void MathRichEditBox::InsertText(Platform::String ^ text, int cursorOffSet, int selectionLength)


### PR DESCRIPTION
## Fixes #1185


### Description of the changes:
- The equation gets submitted twice in a row because inserting it into the RichTextBox can slightly change the formatting, so when we compare it a second time the text is different.
- The fix is to set put the text into the textbox, and then retrieve it from the textbox before storing it in the MathText property

### How changes were validated:
- Manual testing

