### PR TITLE
Fixed issue where Shortcuts were still enabled in Graphing Mode

### DIFF
--- a/src/Calculator/Common/KeyboardShortcutManager.cpp
+++ b/src/Calculator/Common/KeyboardShortcutManager.cpp
@@ -745,7 +745,7 @@ void KeyboardShortcutManager::HonorShortcuts(bool allow)
     {
         if (s_fDisableShortcuts.find(viewId) != s_fDisableShortcuts.end())
         {
-            if (s_fHonorShortcuts[viewId] && s_fDisableShortcuts[viewId])
+            if (s_fDisableShortcuts[viewId])
             {
                 s_fHonorShortcuts[viewId] = false;
                 return;

--- a/src/Calculator/Common/KeyboardShortcutManager.cpp
+++ b/src/Calculator/Common/KeyboardShortcutManager.cpp
@@ -52,11 +52,10 @@ static map<int, bool> s_IsDropDownOpen;
 static map<int, bool> s_ignoreNextEscape;
 static map<int, bool> s_keepIgnoringEscape;
 static map<int, bool> s_fHonorShortcuts;
+static map<int, bool> s_fDisableShortcuts;
 static map<int, Flyout ^> s_AboutFlyout;
 
 static reader_writer_lock s_keyboardShortcutMapLock;
-
-static bool s_shortcutsDisabled = false;
 
 namespace CalculatorApp
 {
@@ -737,11 +736,6 @@ void KeyboardShortcutManager::UpdateDropDownState(Flyout ^ aboutPageFlyout)
 
 void KeyboardShortcutManager::HonorShortcuts(bool allow)
 {
-    if (s_shortcutsDisabled)
-    {
-        return;
-    }
-
     // Writer lock for the static maps
     reader_writer_lock::scoped_lock lock(s_keyboardShortcutMapLock);
 
@@ -749,6 +743,15 @@ void KeyboardShortcutManager::HonorShortcuts(bool allow)
 
     if (s_fHonorShortcuts.find(viewId) != s_fHonorShortcuts.end())
     {
+        if (s_fDisableShortcuts.find(viewId) != s_fDisableShortcuts.end())
+        {
+            if (s_fHonorShortcuts[viewId] && s_fDisableShortcuts[viewId])
+            {
+                s_fHonorShortcuts[viewId] = false;
+                return;
+            }
+        }
+
         s_fHonorShortcuts[viewId] = allow;
     }
 }
@@ -808,6 +811,7 @@ void KeyboardShortcutManager::RegisterNewAppViewId()
     s_ignoreNextEscape[appViewId] = false;
     s_keepIgnoringEscape[appViewId] = false;
     s_fHonorShortcuts[appViewId] = true;
+    s_fDisableShortcuts[appViewId] = false;
     s_AboutFlyout[appViewId] = nullptr;
 }
 
@@ -833,11 +837,18 @@ void KeyboardShortcutManager::OnWindowClosed(int viewId)
     s_ignoreNextEscape.erase(viewId);
     s_keepIgnoringEscape.erase(viewId);
     s_fHonorShortcuts.erase(viewId);
+    s_fDisableShortcuts.erase(viewId);
     s_AboutFlyout.erase(viewId);
 }
 
 void KeyboardShortcutManager::DisableShortcuts(bool disable)
 {
-    s_shortcutsDisabled = disable;
+    int viewId = Utils::GetWindowId();
+
+    if (s_fDisableShortcuts.find(viewId) != s_fDisableShortcuts.end())
+    {
+        s_fDisableShortcuts[viewId] = disable;
+    }
+
     HonorShortcuts(!disable);
 }


### PR DESCRIPTION
## Fixes #1184.


### Description of the changes:
- Updated DisableShortcuts to track if shortcuts were disabled per view id
- Updated HonorShortcuts to use the disable shortcuts value conditionally

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manually with standard and graphing modes
- manually with multiple windows

