### PR TITLE
Don't create a new flyout every time the graph settings button is clicked

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -296,8 +296,7 @@
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
                                         <VisualState x:Name="Normal">
-                                            <Storyboard>
-                                            </Storyboard>
+                                            <Storyboard/>
                                         </VisualState>
                                         <VisualState x:Name="PointerOver">
                                             <Storyboard>
@@ -699,8 +698,8 @@
                     </RepeatButton>
 
                     <ToggleButton x:Uid="graphViewButton"
-                                  MinHeight="40"
                                   MinWidth="40"
+                                  MinHeight="40"
                                   Style="{ThemeResource ThemedGraphViewToggleButtonStyle}"
                                   contract7Present:CornerRadius="{ThemeResource BottomButtonCornerRadius}"
                                   AutomationProperties.AutomationId="graphViewButton"

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -95,7 +95,7 @@ GraphingCalculator::GraphingCalculator()
     {
         SharedShadow->Receivers->Append(GraphingControl);
     }
-    
+
     m_accessibilitySettings->HighContrastChanged +=
         ref new TypedEventHandler<AccessibilitySettings ^, Object ^>(this, &GraphingCalculator::OnHighContrastChanged);
 
@@ -600,17 +600,20 @@ void GraphingCalculator::DisplayGraphSettings()
     {
         m_graphSettings = ref new GraphingSettings();
         m_graphSettings->GraphThemeSettingChanged += ref new EventHandler<bool>(this, &GraphingCalculator::OnGraphThemeSettingChanged);
+        m_graphSettings->SetGrapher(this->GraphingControl);
+    }
+
+    if (m_graphFlyout == nullptr)
+    {
+        m_graphFlyout = ref new Flyout();
+        m_graphFlyout->Content = m_graphSettings;
     }
 
     m_graphSettings->IsMatchAppTheme = IsMatchAppTheme;
-    m_graphSettings->SetGrapher(this->GraphingControl);
-    auto flyoutGraphSettings = ref new Flyout();
-    flyoutGraphSettings->Content = m_graphSettings;
-    flyoutGraphSettings->Closing += ref new TypedEventHandler<FlyoutBase ^, FlyoutBaseClosingEventArgs ^>(this, &GraphingCalculator::OnSettingsFlyout_Closing);
 
     auto options = ref new FlyoutShowOptions();
     options->Placement = FlyoutPlacementMode::BottomEdgeAlignedRight;
-    flyoutGraphSettings->ShowAt(GraphSettingsButton, options);
+    m_graphFlyout->ShowAt(GraphSettingsButton, options);
 }
 
 void CalculatorApp::GraphingCalculator::AddTracePointerShadow()
@@ -626,12 +629,6 @@ void CalculatorApp::GraphingCalculator::AddTracePointerShadow()
     shadowSpriteVisual->Size = ::Numerics::float2(18, 18);
     shadowSpriteVisual->Shadow = dropShadow;
     ::Hosting::ElementCompositionPreview::SetElementChildVisual(CursorShadow, shadowSpriteVisual);
-}
-
-void GraphingCalculator::OnSettingsFlyout_Closing(FlyoutBase ^ sender, FlyoutBaseClosingEventArgs ^ args)
-{
-    auto flyout = static_cast<Flyout ^>(sender);
-    auto graphingSetting = static_cast<GraphingSettings ^>(flyout->Content);
 }
 
 void GraphingCalculator::Canvas_SizeChanged(Object ^ /*sender*/, SizeChangedEventArgs ^ e)
@@ -780,12 +777,12 @@ void GraphingCalculator::OnGraphThemeSettingChanged(Object ^ sender, bool isMatc
     IsMatchAppTheme = isMatchAppTheme;
     WeakReference weakThis(this);
     this->Dispatcher->RunAsync(CoreDispatcherPriority::Normal, ref new DispatchedHandler([weakThis]() {
-                                    auto refThis = weakThis.Resolve<GraphingCalculator>();
-                                    if (refThis != nullptr)
-                                    {
-                                        refThis->UpdateGraphTheme();
-                                    }
-                                }));
+                                   auto refThis = weakThis.Resolve<GraphingCalculator>();
+                                   if (refThis != nullptr)
+                                   {
+                                       refThis->UpdateGraphTheme();
+                                   }
+                               }));
 }
 
 void GraphingCalculator::GraphViewButton_Click(Object ^ sender, RoutedEventArgs ^ e)
@@ -805,5 +802,6 @@ void GraphingCalculator::GraphViewButton_Click(Object ^ sender, RoutedEventArgs 
     auto announcement = CalculatorAnnouncement::GetGraphViewBestFitChangedAnnouncement(announcementText);
     narratorNotifier->Announce(announcement);
 
-    TraceLogger::GetInstance()->LogGraphButtonClicked(GraphButton::GraphView, IsManualAdjustment ? GraphButtonValue::ManualAdjustment : GraphButtonValue::AutomaticBestFit);
+    TraceLogger::GetInstance()->LogGraphButtonClicked(
+        GraphButton::GraphView, IsManualAdjustment ? GraphButtonValue::ManualAdjustment : GraphButtonValue::AutomaticBestFit);
 }

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -600,7 +600,6 @@ void GraphingCalculator::DisplayGraphSettings()
     {
         m_graphSettings = ref new GraphingSettings();
         m_graphSettings->GraphThemeSettingChanged += ref new EventHandler<bool>(this, &GraphingCalculator::OnGraphThemeSettingChanged);
-        m_graphSettings->SetGrapher(this->GraphingControl);
     }
 
     if (m_graphFlyout == nullptr)
@@ -609,6 +608,7 @@ void GraphingCalculator::DisplayGraphSettings()
         m_graphFlyout->Content = m_graphSettings;
     }
 
+    m_graphSettings->SetGrapher(this->GraphingControl);
     m_graphSettings->IsMatchAppTheme = IsMatchAppTheme;
 
     auto options = ref new FlyoutShowOptions();

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -97,8 +97,8 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
         Windows::UI::ViewManagement::AccessibilitySettings ^ m_accessibilitySettings;
         bool m_cursorShadowInitialized;
         Windows::UI::ViewManagement::UISettings ^ m_uiSettings;
+        Windows::UI::Xaml::Controls::Flyout ^ m_graphFlyout;
         CalculatorApp::GraphingSettings ^ m_graphSettings;
-        void OnSettingsFlyout_Closing(Windows::UI::Xaml::Controls::Primitives::FlyoutBase ^ sender, Windows::UI::Xaml::Controls::Primitives::FlyoutBaseClosingEventArgs ^ args);
         void Canvas_SizeChanged(Platform::Object ^ sender, Windows::UI::Xaml::SizeChangedEventArgs ^ e);
         void OnHighContrastChanged(Windows::UI::ViewManagement::AccessibilitySettings ^ sender, Platform::Object ^ args);
         void OnEquationFormatRequested(Platform::Object ^ sender, CalculatorApp::Controls::MathRichEditBoxFormatRequest ^ e);


### PR DESCRIPTION
### Description of the changes:
- We've seen some crashes in this area indicating that the content of this flyout is trying to be used in more than one place. My guess is that a UI test is able to invoke the button without closing the flyout resulting this issue. A regular user would never see this.

### How changes were validated:
- Manual test
