### PR TITLE
Fix issues with sin being parsed incorrectly

### DIFF
--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -10,6 +10,7 @@ using namespace CalculatorApp::Common;
 using namespace CalculatorApp::Controls;
 using namespace std;
 using namespace Windows::ApplicationModel;
+using namespace Windows::UI::Core;
 using namespace Windows::UI::Xaml;
 using namespace Windows::UI::Xaml::Controls;
 using namespace Windows::UI::Text;
@@ -125,6 +126,16 @@ void CalculatorApp::Controls::MathRichEditBox::OnKeyUp(Platform::Object ^ sender
     }
 }
 
+void CalculatorApp::Controls::MathRichEditBox::OnKeyDown(Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e)
+{
+    // suppress control + B to prevent bold input from being entered
+    if ((Window::Current->CoreWindow->GetKeyState(VirtualKey::Control) & CoreVirtualKeyStates::Down) != CoreVirtualKeyStates::Down ||
+        e->Key != VirtualKey::B)
+    {
+        Windows::UI::Xaml::Controls::RichEditBox::OnKeyDown(e);
+    }
+}
+
 void MathRichEditBox::OnMathTextPropertyChanged(Platform::String ^ oldValue, Platform::String ^ newValue)
 {
     SetMathTextProperty(newValue);
@@ -189,7 +200,6 @@ void MathRichEditBox::SubmitEquation(EquationSubmissionSource source)
 
     if (range != nullptr)
     {
-        range->CharacterFormat->Bold = FormatEffect::Off;
         range->CharacterFormat->Underline = UnderlineType::None;
     }
 

--- a/src/Calculator/Controls/MathRichEditBox.h
+++ b/src/Calculator/Controls/MathRichEditBox.h
@@ -60,6 +60,9 @@ namespace CalculatorApp
             void SubmitEquation(EquationSubmissionSource source);
             void BackSpace();
 
+        protected:
+            void OnKeyDown(Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e) override;
+
         private:
             Platform::String ^ GetMathTextProperty();
             void SetMathTextProperty(Platform::String ^ newValue);


### PR DESCRIPTION
## Fixes #1164.
When we try to remove bold from equations, we trigger a format change that results in mathml buildup returning incorrect mathml.  To work around this, bold is no longer removed.  Instead we are preventing from bolding the text in the first place

### Description of the changes:
- remove the code that removes bold formatting from equations
- prevents bold text from being set via keyboard

### How changes were validated:
manually

