### PR TITLE
Do not submit equations when in read only mode

### DIFF
--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -119,7 +119,7 @@ void CalculatorApp::Controls::MathRichEditBox::OnLosingFocus(Windows::UI::Xaml::
 
 void CalculatorApp::Controls::MathRichEditBox::OnKeyUp(Platform::Object ^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e)
 {
-    if (e->Key == VirtualKey::Enter)
+    if (!this->IsReadOnly && e->Key == VirtualKey::Enter)
     {
         SubmitEquation(EquationSubmissionSource::ENTER_KEY);
     }


### PR DESCRIPTION
## Fixes #1200
Prevents trying to set format on rich edit control that is in read only mode.

### Description of the changes:
- Checks read only status of rich edit textbox before submitting changes

### How changes were validated:
 manual testing
