### PR TITLE
Fix Logical_Operator_Decimal tests

### DIFF
--- a/src/CalculatorUITests/ProgrammerModeFunctionalTests.cs
+++ b/src/CalculatorUITests/ProgrammerModeFunctionalTests.cs
@@ -559,6 +559,7 @@ namespace CalculatorUITests
         [Priority(1)]
         public void Logical_Operator_Decimal_LeftShift()
         {
+            page.ProgrammerOperators.DecButton.Click();
             page.ProgrammerOperators.SetLogicalShift();
             page.StandardOperators.NumberPad.Input(7);
             page.ProgrammerOperators.LeftShiftLogicalButton.Click();
@@ -571,6 +572,7 @@ namespace CalculatorUITests
         [Priority(1)]
         public void Logical_Operator_Decimal_RightShift()
         {
+            page.ProgrammerOperators.DecButton.Click();
             page.ProgrammerOperators.SetLogicalShift();
             page.StandardOperators.NumberPad.Input(16);
             page.StandardOperators.NegateButton.Click();


### PR DESCRIPTION
CI builds have been failing since #779 was merged because the Logical_Operator_Decimal_LeftShift test is failing. Looking at the screen capture of the failed test, the issue is that the Calculator is in hex mode when the test starts. Changing the test to explicitly switch into decimal mode should address this issue.