### PR TITLE
Switching from Difference between dates to Add or subtract dates igno…

### DIFF
--- a/src/Calculator/Views/DateCalculator.xaml.cpp
+++ b/src/Calculator/Views/DateCalculator.xaml.cpp
@@ -164,7 +164,7 @@ void DateCalculator::CloseCalendarFlyout()
 {
     if (DateDiff_FromDate->IsCalendarOpen)
     {
-        DateDiff_FromDate->IsCalendarOpen = false;        
+        DateDiff_FromDate->IsCalendarOpen = false;
     }
 
     if (DateDiff_ToDate->IsCalendarOpen)
@@ -188,18 +188,24 @@ void DateCalculator::DateCalcOption_Changed(_In_ Platform::Object ^ sender, _In_
     FindName("AddSubtractDateGrid");
     auto dateCalcViewModel = safe_cast<DateCalculatorViewModel ^>(this->DataContext);
 
-    // https://github.com/microsoft/calculator/issues/254
     // From Date Field needs to persist across Date Difference and Add Substract Date Mode.
     // So when the mode dropdown changes, update the other datepicker with the latest date.
     if (dateCalcViewModel->IsDateDiffMode)
     {
-        IBox<DateTime> ^ addSubtractModeFromDate = ref new Box<DateTime>(AddSubtract_FromDate->Date->Value);
-        DateDiff_FromDate->Date = addSubtractModeFromDate;
+        if (AddSubtract_FromDate->Date == nullptr)
+        {
+            return;
+        }
+        DateDiff_FromDate->Date = AddSubtract_FromDate->Date->Value;
     }
     else
     {
-        IBox<DateTime> ^ dateDifferenceModeFromDate = ref new Box<DateTime>(DateDiff_FromDate->Date->Value);
-        AddSubtract_FromDate->Date = dateDifferenceModeFromDate;  
+        if (DateDiff_FromDate->Date == nullptr)
+        {
+            // If no date has been picked, then this can be null.
+            return;
+        }
+        AddSubtract_FromDate->Date = DateDiff_FromDate->Date->Value;
     }
 }
 

--- a/src/Calculator/Views/DateCalculator.xaml.cpp
+++ b/src/Calculator/Views/DateCalculator.xaml.cpp
@@ -164,7 +164,7 @@ void DateCalculator::CloseCalendarFlyout()
 {
     if (DateDiff_FromDate->IsCalendarOpen)
     {
-        DateDiff_FromDate->IsCalendarOpen = false;
+        DateDiff_FromDate->IsCalendarOpen = false;        
     }
 
     if (DateDiff_ToDate->IsCalendarOpen)
@@ -186,7 +186,21 @@ void DateCalculator::SetDefaultFocus()
 void DateCalculator::DateCalcOption_Changed(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::Controls::SelectionChangedEventArgs ^ e)
 {
     FindName("AddSubtractDateGrid");
-    DateCalculationOption->SelectionChanged -= m_dateCalcOptionChangedEventToken;
+    auto dateCalcViewModel = safe_cast<DateCalculatorViewModel ^>(this->DataContext);
+
+    // https://github.com/microsoft/calculator/issues/254
+    // From Date Field needs to persist across Date Difference and Add Substract Date Mode.
+    // So when the mode dropdown changes, update the other datepicker with the latest date.
+    if (dateCalcViewModel->IsDateDiffMode)
+    {
+        IBox<DateTime> ^ addSubtractModeFromDate = ref new Box<DateTime>(AddSubtract_FromDate->Date->Value);
+        DateDiff_FromDate->Date = addSubtractModeFromDate;
+    }
+    else
+    {
+        IBox<DateTime> ^ dateDifferenceModeFromDate = ref new Box<DateTime>(DateDiff_FromDate->Date->Value);
+        AddSubtract_FromDate->Date = dateDifferenceModeFromDate;  
+    }
 }
 
 void CalculatorApp::DateCalculator::AddSubtractDateGrid_Loaded(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e)


### PR DESCRIPTION
https://github.com/microsoft/calculator/issues/254

Date field needs to persist across Date Difference and Add/Subtract From Date Mode.

## Fixes #254.


### Description of the changes:
- Modifying the date calculator's mode dropdown to assist in persisting the from date to be used in the add or subtract mode or date difference mode.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Can test by changing the from date in either date mode (add/subtract or difference mode) and verifying the correct date is persisted to the other date mode. Also verified the day calculations were still valid.


