### PR TITLE
Associate Units and Theme labels with the radio button groups

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml
@@ -5,7 +5,6 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="using:CalculatorApp"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
              Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
              mc:Ignorable="d">
     <UserControl.Resources>
@@ -175,7 +174,7 @@
                        Style="{StaticResource SubTitleTextBoxStyle}"
                        AutomationProperties.HeadingLevel="Level2"/>
 
-            <StackPanel Orientation="Horizontal">
+            <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=UnitsHeading}" Orientation="Horizontal">
                 <RadioButton x:Name="Radians"
                              x:Uid="TrigModeRadians"
                              Style="{StaticResource TrigUnitsRadioButtonStyle}"
@@ -219,21 +218,18 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-            <muxc:RadioButtons>
-                <muxc:RadioButtons.HeaderTemplate>
-                    <DataTemplate>
-                        <TextBlock x:Name="GraphThemeHeading"
-                                   x:Uid="GraphThemeHeading"
-                                   Margin="0,16,0,6"
-                                   Style="{StaticResource SubTitleTextBoxStyle}"
-                                   AutomationProperties.HeadingLevel="Level2"/>
-                    </DataTemplate>
-                </muxc:RadioButtons.HeaderTemplate>
+            <TextBlock x:Name="GraphThemeHeading"
+                       x:Uid="GraphThemeHeading"
+                       Margin="0,16,0,6"
+                       Style="{StaticResource SubTitleTextBoxStyle}"
+                       AutomationProperties.HeadingLevel="Level2"/>
+
+            <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=GraphThemeHeading}">
                 <RadioButton x:Uid="AlwaysLightTheme" IsChecked="{x:Bind IsMatchAppTheme, Mode=TwoWay, Converter={StaticResource BooleanNegationConverter}}"/>
                 <RadioButton x:Uid="MatchAppTheme"
                              Margin="1,0"
                              IsChecked="{x:Bind IsMatchAppTheme, Mode=TwoWay}"/>
-            </muxc:RadioButtons>
+            </StackPanel>
         </StackPanel>
     </Grid>
 </UserControl>

--- a/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:local="using:CalculatorApp"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:muxc="using:Microsoft.UI.Xaml.Controls"
              Background="{ThemeResource ApplicationPageBackgroundThemeBrush}"
              mc:Ignorable="d">
     <UserControl.Resources>
@@ -218,19 +219,21 @@
                     </DataTemplate>
                 </ComboBox.ItemTemplate>
             </ComboBox>
-
-            <TextBlock x:Name="GraphThemeHeading"
-                       x:Uid="GraphThemeHeading"
-                       Margin="0,16,0,6"
-                       Style="{StaticResource SubTitleTextBoxStyle}"
-                       AutomationProperties.HeadingLevel="Level2"/>
-
-            <StackPanel Orientation="Vertical">
+            <muxc:RadioButtons>
+                <muxc:RadioButtons.HeaderTemplate>
+                    <DataTemplate>
+                        <TextBlock x:Name="GraphThemeHeading"
+                                   x:Uid="GraphThemeHeading"
+                                   Margin="0,16,0,6"
+                                   Style="{StaticResource SubTitleTextBoxStyle}"
+                                   AutomationProperties.HeadingLevel="Level2"/>
+                    </DataTemplate>
+                </muxc:RadioButtons.HeaderTemplate>
                 <RadioButton x:Uid="AlwaysLightTheme" IsChecked="{x:Bind IsMatchAppTheme, Mode=TwoWay, Converter={StaticResource BooleanNegationConverter}}"/>
                 <RadioButton x:Uid="MatchAppTheme"
                              Margin="1,0"
                              IsChecked="{x:Bind IsMatchAppTheme, Mode=TwoWay}"/>
-            </StackPanel>
+            </muxc:RadioButtons>
         </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Fixes #1178.


### Description of the changes:
- Added the AccessibilityProperty LabeledBy to the stack panels for the Trig Units radio buttons and Graph Theme radio buttons.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manually using narrator

