### PR TITLE
Tweak UI: Title and History/Memory panels 

### DIFF
--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -1124,6 +1124,7 @@
             </Border.Resources>
 
             <Pivot x:Name="DockPivot"
+                   Margin="0,-3,0,0"
                    TabIndex="5"
                    Tapped="DockPanelTapped"
                    Template="{StaticResource DockPanelTemplate}">

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -553,7 +553,7 @@
         <Grid x:Name="LeftGrid"
               Grid.Row="1"
               Padding="0,4,0,0"
-              Visibility="{x:Bind ShouldDisplayPanel(IsSmallState, SwitchModeToggleButton.IsOn, x:True), Mode=OneWay}">
+              Visibility="{x:Bind local:GraphingCalculator.ShouldDisplayPanel(IsSmallState, SwitchModeToggleButton.IsOn, x:True), Mode=OneWay}">
             <Grid.Resources>
                 <ResourceDictionary>
                     <ResourceDictionary.ThemeDictionaries>

--- a/src/Calculator/Views/HistoryList.xaml
+++ b/src/Calculator/Views/HistoryList.xaml
@@ -132,9 +132,10 @@
             </Grid.RowDefinitions>
             <TextBlock x:Name="HistoryEmpty"
                        x:Uid="HistoryEmpty"
-                       Margin="12,14,24,0"
+                       Margin="16,14,24,0"
                        Style="{ThemeResource BaseTextBlockStyle}"
                        Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
+                       FontWeight="SemiLight"
                        TextWrapping="Wrap"
                        Visibility="{Binding ItemSize, Converter={StaticResource ItemSizeToVisibilityConverter}}"/>
             <ListView x:Name="HistoryListView"

--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -33,6 +33,12 @@
             <Setter Property="KeyTipPlacementMode" Value="Right"/>
         </Style>
 
+        <Style x:Key="CategoryNameTextBlockStyle" TargetType="TextBlock">
+            <Setter Property="FontSize" Value="20"/>
+            <Setter Property="FontWeight" Value="SemiBold"/>
+            <Setter Property="OpticalMarginAlignment" Value="TrimSideBearings"/>
+        </Style>
+
         <DataTemplate x:Key="NavMenuItemPreviewDataTemplate" x:DataType="x:String">
             <StackPanel Orientation="Horizontal">
                 <TextBlock VerticalAlignment="Center" Text="{x:Bind}"/>
@@ -169,12 +175,12 @@
                     <ColumnDefinition Width="Auto"/>
                     <ColumnDefinition Width="Auto"/>
                 </Grid.ColumnDefinitions>
-                <StackPanel Margin="52,0,0,0" Orientation="Horizontal">
+                <StackPanel Margin="48,0,0,0" Orientation="Horizontal">
                     <TextBlock x:Name="Header"
                                Margin="0,-3,0,0"
                                HorizontalAlignment="Left"
                                VerticalAlignment="Center"
-                               Style="{StaticResource SubtitleTextBlockStyle}"
+                               Style="{StaticResource CategoryNameTextBlockStyle}"
                                Text="{x:Bind Model.CategoryName, Mode=OneWay}"
                                Visibility="{x:Bind Model.IsAlwaysOnTop, Converter={StaticResource BooleanToVisibilityNegationConverter}, Mode=OneWay}"/>
                     <controls:PreviewTagControl Margin="10,0,0,0"

--- a/src/Calculator/Views/Memory.xaml
+++ b/src/Calculator/Views/Memory.xaml
@@ -96,9 +96,10 @@
             </Grid.RowDefinitions>
             <TextBlock x:Name="MemoryPaneEmpty"
                        x:Uid="MemoryPaneEmpty"
-                       Margin="12,14,24,0"
+                       Margin="16,14,24,0"
                        Style="{ThemeResource BaseTextBlockStyle}"
                        Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
+                       FontWeight="SemiLight"
                        TextWrapping="Wrap"
                        Visibility="{Binding IsMemoryEmpty, Converter={StaticResource BooleanToVisibilityConverter}}"/>
             <ListView x:Name="MemoryListView"


### PR DESCRIPTION
### Description of the changes:
- Modify the font weight of titles
- Decrease the margin between the burger menu and titles
- Align `MemoryPaneEmpty` and `HistoryEmpty` with `History` label
- Modify the weight of the font used by `MemoryPaneEmpty` and `HistoryEmpty`
- Align `History`/`Memory` with the title

### How changes were validated:
- Manually, validated during UX review

![MicrosoftTeams-image (19)](https://user-images.githubusercontent.com/1226538/81371889-d8d80880-90ad-11ea-8ae4-d3d96ebb6203.png)
_Fix alignement_

![MicrosoftTeams-image (20)](https://user-images.githubusercontent.com/1226538/81371891-daa1cc00-90ad-11ea-975f-a72a65167515.png)
_Change font weigth of the text displayed when History/Memory panel is empty_

![MicrosoftTeams-image (21)](https://user-images.githubusercontent.com/1226538/81371895-dbd2f900-90ad-11ea-8056-f5d7512a4b00.png)
_Decrease margin between burger menu and title_