### PR TITLE
Fix graph dark colors at launch

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -590,7 +590,6 @@
                                   IsKeepCurrentView="{x:Bind IsManualAdjustment, Mode=TwoWay}"
                                   LosingFocus="GraphingControl_LosingFocus"
                                   LostFocus="GraphingControl_LostFocus"
-                                  RequestedTheme="Light"
                                   UseSystemFocusVisuals="True"
                                   VariablesUpdated="GraphingControl_VariablesUpdated">
                 <graphControl:Grapher.ContextFlyout>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.h
@@ -92,7 +92,8 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
         Windows::Foundation::EventRegistrationToken m_vectorChangedToken;
         Windows::Foundation::EventRegistrationToken m_variableUpdatedToken;
         Windows::Foundation::EventRegistrationToken m_activeTracingKeyUpToken;
-        Windows::Foundation::EventRegistrationToken m_ActiveTracingPointerCaptureLost;
+        Windows::Foundation::EventRegistrationToken m_ActiveTracingPointerCaptureLostToken;
+        Windows::Foundation::EventRegistrationToken m_GraphingControlLoadedToken;
         CalculatorApp::ViewModel::GraphingCalculatorViewModel ^ m_viewModel;
         Windows::UI::ViewManagement::AccessibilitySettings ^ m_accessibilitySettings;
         bool m_cursorShadowInitialized;
@@ -107,6 +108,7 @@ public ref class GraphingCalculator sealed : public Windows::UI::Xaml::Data::INo
         std::wstringstream FormatTraceValue(double min, double max, float pointValue);
         void GraphViewButton_Click(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void ShowShareError();
+        void OnGraphingCalculatorLoaded(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
     };
 
 }


### PR DESCRIPTION
The graph will render grid lines with the wrong color if the application is launched in dark-theme mode and the option "match app theme" checked.

The graph control has a bug and will override the value with the default value if the control is not fully loaded. We should fix the issue in the control but in the meantime, we need to mitigate the issue of the current version.

### Description of the changes:
- Move `UpdateGraphColor` from the constructor to `GraphingControl::Loaded`

### How changes were validated:
- manually


![image](https://user-images.githubusercontent.com/1226538/81395843-30d83480-90d9-11ea-95bb-892875ad0290.png)
Left: wrong colors, Right: correct colors