### PR TITLE
Change "add" button foreground color

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -270,7 +270,6 @@
                                                 <Setter Target="FunctionNumberLabelTextBlock.Visibility" Value="Collapsed"/>
                                                 <Setter Target="EquationButton.Background" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
                                                 <Setter Target="EquationButton.BorderBrush" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
-                                                <Setter Target="EquationButton.Foreground" Value="{ThemeResource EquationButtonHideLineForegroundBrush}"/>
                                                 <Setter Target="EquationButton.IsEnabled" Value="false"/>
                                             </VisualState.Setters>
                                         </VisualState>
@@ -279,7 +278,6 @@
                                                 <Setter Target="FunctionNumberLabelTextBlock.Visibility" Value="Collapsed"/>
                                                 <Setter Target="EquationButton.Background" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
                                                 <Setter Target="EquationButton.BorderBrush" Value="{ThemeResource EquationButtonHideLineBackgroundBrush}"/>
-                                                <Setter Target="EquationButton.Foreground" Value="{ThemeResource EquationButtonHideLineForegroundBrush}"/>
                                                 <Setter Target="EquationButton.IsEnabled" Value="false"/>
                                                 <Setter Target="EquationBoxBorder.Background" Value="{ThemeResource TextBoxBackgroundThemeBrush}"/>
                                             </VisualState.Setters>


### PR DESCRIPTION
## Partially fixes #997

![MicrosoftTeams-image (22)](https://user-images.githubusercontent.com/1226538/81458968-3de53a00-9152-11ea-9c00-22dfacf02f75.png)
_The 'f' should be black in dark mode (see Issue #997)_

### Description of the changes:
- Don't modify `EquationButton.Foreground` when the EquationBox is a "add an equation" placeholder.

### How changes were validated:
- manually in Light, Dark and High contrast mode

