### PR TITLE
Fixed narrator issues in KGF and GraphView button, updated Trig radio button corner radius

### DIFF
--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
@@ -160,7 +160,7 @@ NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewChangedAnnouncement(S
         announcement,
         CalculatorActivityIds::GraphViewChanged,
         AutomationNotificationKind::ActionCompleted,
-        AutomationNotificationProcessing::MostRecent);
+        AutomationNotificationProcessing::CurrentThenMostRecent);
 }
 
 NarratorAnnouncement ^ CalculatorAnnouncement::GetFunctionRemovedAnnouncement(String ^ announcement)

--- a/src/Calculator/Calculator.vcxproj.filters
+++ b/src/Calculator/Calculator.vcxproj.filters
@@ -486,9 +486,6 @@
       <Filter>Views</Filter>
     </Page>
     <Page Include="AboutFlyout.xaml" />
-    <Page Include="Views\CalculatorProgrammerDisplayPanel.xaml">
-      <Filter>Views</Filter>
-    </Page>
     <Page Include="Views\CalculatorProgrammerBitFlipPanel.xaml">
       <Filter>Views</Filter>
     </Page>
@@ -524,6 +521,9 @@
     </Page>
     <Page Include="Controls\PreviewTagControl.xaml" />
     <Page Include="EquationStylePanelControl.xaml" />
+    <Page Include="Views\CalculatorProgrammerDisplayPanel.xaml">
+      <Filter>Views\StateTriggers</Filter>
+    </Page>
   </ItemGroup>
   <ItemGroup>
     <PRIResource Include="Resources\en-US\CEngineStrings.resw">
@@ -1579,6 +1579,8 @@
     <ResourceCompile Include="Calculator.rc" />
   </ItemGroup>
   <ItemGroup>
+    <CopyFileToFolders Include="$(GraphingImplDll)" />
+    <CopyFileToFolders Include="$(GraphingEngineDll)" />
     <CopyFileToFolders Include="$(GraphingImplDll)" />
     <CopyFileToFolders Include="$(GraphingEngineDll)" />
   </ItemGroup>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3881,11 +3881,15 @@
   </data>
   <data name="GraphViewAutomaticBestFitAnnouncement" xml:space="preserve">
     <value>Automatic Best Fit</value>
-    <comment>Announcement used in Graphing Calculator when button is clicked and automatic best fit is set</comment>
+    <comment>Announcement used in Graphing Calculator when graph view button is clicked and automatic best fit is set</comment>
   </data>
     <data name="GraphViewManualAdjustmentAnnouncement" xml:space="preserve">
     <value>Manual Adjustment</value>
-    <comment>Announcement used in Graphing Calculator when button is clicked and manual adjustment is set</comment>
+    <comment>Announcement used in Graphing Calculator when graph view button is clicked and manual adjustment is set</comment>
+  </data>
+    <data name="GridResetAnnouncement" xml:space="preserve">
+    <value>Graph view has been reset</value>
+    <comment>Announcement used in Graphing Calculator when graph view button is clicked and automatic best fit is set, resetting the graph</comment>
   </data>
   <data name="zoomInButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
     <value>Zoom In (Ctrl + plus)</value>
@@ -4420,12 +4424,12 @@
     <comment>Y minimum value header</comment>
   </data>
   <data name="graphSettingsButton.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
-    <value>Grid options</value>
-    <comment>This is the tooltip text for the grid options button in Graphing Calculator</comment>
+    <value>Graph options</value>
+    <comment>This is the tooltip text for the graph options button in Graphing Calculator</comment>
   </data>
   <data name="graphSettingsButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Grid options</value>
-    <comment>This is the automation name text for the grid options button in Graphing Calculator</comment>
+    <value>Graph options</value>
+    <comment>This is the automation name text for the graph options button in Graphing Calculator</comment>
   </data>
   <data name="GraphOptionsHeading.Text" xml:space="preserve">
     <value>Graph Options</value>
@@ -4717,6 +4721,14 @@
   </data>
   <data name="submitButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Submit</value>
+    <comment>Screen reader prompt for the submit button on the graphing calculator operator keypad</comment>
+  </data>
+  <data name="FunctionAnalysisGrid.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Function Anaylsis</value>
+    <comment>Screen reader prompt for the submit button on the graphing calculator operator keypad</comment>
+  </data>
+  <data name="GraphSettingsGrid.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Graph Options</value>
     <comment>Screen reader prompt for the submit button on the graphing calculator operator keypad</comment>
   </data>
 </root>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4725,7 +4725,7 @@
   </data>
   <data name="FunctionAnalysisGrid.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Function Anaylsis</value>
-    <comment>Screen reader prompt for the submit button on the graphing calculator operator keypad</comment>
+    <comment>Screen reader prompt for the function analysis grid</comment>
   </data>
   <data name="GraphSettingsGrid.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Graph Options</value>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4729,6 +4729,6 @@
   </data>
   <data name="GraphSettingsGrid.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
     <value>Graph Options</value>
-    <comment>Screen reader prompt for the submit button on the graphing calculator operator keypad</comment>
+    <comment>Screen reader prompt for the graph options panel</comment>
   </data>
 </root>

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -664,7 +664,6 @@ void GraphingCalculator::DisplayGraphSettings()
 
     auto options = ref new FlyoutShowOptions();
     options->Placement = FlyoutPlacementMode::BottomEdgeAlignedRight;
-
     m_graphFlyout->ShowAt(GraphSettingsButton, options);
 }
 

--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -664,6 +664,7 @@ void GraphingCalculator::DisplayGraphSettings()
 
     auto options = ref new FlyoutShowOptions();
     options->Placement = FlyoutPlacementMode::BottomEdgeAlignedRight;
+
     m_graphFlyout->ShowAt(GraphSettingsButton, options);
 }
 
@@ -846,8 +847,9 @@ void GraphingCalculator::GraphViewButton_Click(Object ^ sender, RoutedEventArgs 
     }
     else
     {
-        GraphingControl->ResetGrid();
         announcementText = AppResourceProvider::GetInstance()->GetResourceString(L"GraphViewAutomaticBestFitAnnouncement");
+        announcementText += AppResourceProvider::GetInstance()->GetResourceString(L"GridResetAnnouncement");
+        GraphingControl->ResetGrid();
     }
 
     auto announcement = CalculatorAnnouncement::GetGraphViewBestFitChangedAnnouncement(announcementText);

--- a/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml
@@ -172,7 +172,9 @@
                        Style="{StaticResource SubTitleTextBoxStyle}"
                        AutomationProperties.HeadingLevel="Level2"/>
 
-            <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=UnitsHeading}" Orientation="Horizontal">
+            <StackPanel AutomationProperties.LabeledBy="{Binding ElementName=UnitsHeading}"
+                        CornerRadius="4"
+                        Orientation="Horizontal">
                 <RadioButton x:Name="Radians"
                              x:Uid="TrigModeRadians"
                              Style="{StaticResource TrigUnitsRadioButtonStyle}"

--- a/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
+++ b/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
@@ -218,7 +218,7 @@
         </ResourceDictionary>
     </UserControl.Resources>
 
-    <Grid>
+    <Grid x:Uid="FunctionAnalysisGrid">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>


### PR DESCRIPTION
## Fixes #1126, Fixes #1182, Fixes #1192.


### Description of the changes:
- Set the automation name for the Function Analysis pane so that it is read out when navigating to the pane
- Updated the narrator read out for Graph View Automatic Best Fit so that it includes "Graph view has been reset" and so that the graph reset information does not interrput the button info.
- Updated the stack panel for the Trig Units radio buttons in Graph Settings to have rounded corners.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manually

