### PR TITLE
Remove dead code from History

### DIFF
--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -624,30 +624,6 @@ namespace CalculationManager
         return m_currentDegreeMode;
     }
 
-    void CalculatorManager::SetHistory(_In_ CalculatorMode eMode, _In_ vector<shared_ptr<HISTORYITEM>> const& history)
-    {
-        CalculatorHistory* pHistory = nullptr;
-
-        switch (eMode)
-        {
-        case CalculatorMode::Standard:
-            pHistory = m_pStdHistory.get();
-            break;
-        case CalculatorMode::Scientific:
-            pHistory = m_pSciHistory.get();
-            break;
-        }
-
-        if (pHistory)
-        {
-            pHistory->ClearHistory();
-            for (auto const& historyItem : history)
-            {
-                pHistory->AddItem(historyItem);
-            }
-        }
-    }
-
     wstring CalculatorManager::GetResultForRadix(uint32_t radix, int32_t precision, bool groupDigitsPerRadix)
     {
         return m_currentCalculatorEngine ? m_currentCalculatorEngine->GetCurrentResultForRadix(radix, precision, groupDigitsPerRadix) : L"";

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -133,7 +133,6 @@ namespace CalculationManager
             return m_pHistory->MaxHistorySize();
         }
         CalculationManager::Command GetCurrentDegreeMode();
-        void SetHistory(_In_ CalculatorMode eMode, _In_ std::vector<std::shared_ptr<HISTORYITEM>> const& history);
         void SetInHistoryItemLoadMode(_In_ bool isHistoryItemLoadMode);
     };
 }

--- a/src/CalcViewModel/ApplicationViewModel.cpp
+++ b/src/CalcViewModel/ApplicationViewModel.cpp
@@ -232,7 +232,6 @@ task<void> ApplicationViewModel::HandleToggleAlwaysOnTop(float width, float heig
         localSettings->Values->Insert(HeightLocalSettings, height);
 
         bool success = co_await ApplicationView::GetForCurrentView()->TryEnterViewModeAsync(ApplicationViewMode::Default);
-        CalculatorViewModel->AreHistoryShortcutsEnabled = success;
         CalculatorViewModel->HistoryVM->AreHistoryShortcutsEnabled = success;
         CalculatorViewModel->IsAlwaysOnTop = !success;
         IsAlwaysOnTop = !success;
@@ -261,7 +260,6 @@ task<void> ApplicationViewModel::HandleToggleAlwaysOnTop(float width, float heig
         }
 
         bool success = co_await ApplicationView::GetForCurrentView()->TryEnterViewModeAsync(ApplicationViewMode::CompactOverlay, compactOptions);
-        CalculatorViewModel->AreHistoryShortcutsEnabled = !success;
         CalculatorViewModel->HistoryVM->AreHistoryShortcutsEnabled = !success;
         CalculatorViewModel->IsAlwaysOnTop = success;
         IsAlwaysOnTop = success;

--- a/src/CalcViewModel/Common/Utils.h
+++ b/src/CalcViewModel/Common/Utils.h
@@ -386,13 +386,6 @@ namespace Utils
     double GetDoubleFromWstring(std::wstring input);
     int GetWindowId();
     void RunOnUIThreadNonblocking(std::function<void()>&& function, _In_ Windows::UI::Core::CoreDispatcher ^ currentDispatcher);
-    void SerializeCommandsAndTokens(
-        _In_ std::shared_ptr<std::vector<std::pair<std::wstring, int>>> const& tokens,
-        _In_ std::shared_ptr<std::vector<std::shared_ptr<IExpressionCommand>>> const& commands,
-        Windows::Storage::Streams::DataWriter ^ writer);
-
-    const std::shared_ptr<std::vector<std::shared_ptr<IExpressionCommand>>> DeserializeCommands(Windows::Storage::Streams::DataReader ^ reader);
-    const std::shared_ptr<std::vector<std::pair<std::wstring, int>>> DeserializeTokens(Windows::Storage::Streams::DataReader ^ reader);
 
     Windows::Foundation::DateTime GetUniversalSystemTime();
     bool IsDateTimeOlderThan(Windows::Foundation::DateTime dateTime, const long long duration);

--- a/src/CalcViewModel/HistoryViewModel.cpp
+++ b/src/CalcViewModel/HistoryViewModel.cpp
@@ -161,4 +161,3 @@ unsigned long long HistoryViewModel::GetMaxItemSize()
 {
     return static_cast<unsigned long long>(m_calculatorManager->MaxHistorySize());
 }
-

--- a/src/CalcViewModel/HistoryViewModel.cpp
+++ b/src/CalcViewModel/HistoryViewModel.cpp
@@ -21,6 +21,7 @@ using namespace Windows::Security::Cryptography;
 using namespace Windows::Foundation::Collections;
 
 static StringReference HistoryVectorLengthKey{ L"HistoryVectorLength" };
+static StringReference ItemsSizeKey{ L"ItemsSize" };
 
 namespace CalculatorApp::ViewModel::HistoryResourceKeys
 {
@@ -34,7 +35,6 @@ HistoryViewModel::HistoryViewModel(_In_ CalculationManager::CalculatorManager* c
     AreHistoryShortcutsEnabled = true;
 
     Items = ref new Platform::Collections::Vector<HistoryItemViewModel ^>();
-    ItemSize = 0;
 }
 
 // this will reload Items with the history list based on current mode
@@ -75,7 +75,7 @@ void HistoryViewModel::ReloadHistory(_In_ ViewMode currentMode)
     }
 
     Items = historyListVM;
-    UpdateItemSize();
+    RaisePropertyChanged(ItemsSizeKey);
 }
 
 void HistoryViewModel::OnHistoryItemAdded(_In_ unsigned int addedItemIndex)
@@ -101,8 +101,7 @@ void HistoryViewModel::OnHistoryItemAdded(_In_ unsigned int addedItemIndex)
 
     assert(addedItemIndex <= m_calculatorManager->MaxHistorySize() && addedItemIndex >= 0);
     Items->InsertAt(0, item);
-    UpdateItemSize();
-    SaveHistory();
+    RaisePropertyChanged(ItemsSizeKey);
 }
 
 void HistoryViewModel::SetCalculatorDisplay(CalculatorDisplay& calculatorDisplay)
@@ -115,7 +114,7 @@ void HistoryViewModel::ShowItem(_In_ HistoryItemViewModel ^ e)
 {
     unsigned int index;
     Items->IndexOf(e, &index);
-    TraceLogger::GetInstance()->LogHistoryItemLoad((ViewMode)m_currentMode, ItemSize, (int)(index));
+    TraceLogger::GetInstance()->LogHistoryItemLoad((ViewMode)m_currentMode, Items->Size, (int)(index));
     HistoryItemClicked(e);
 }
 
@@ -126,15 +125,8 @@ void HistoryViewModel::DeleteItem(_In_ HistoryItemViewModel ^ e)
     {
         if (m_calculatorManager->RemoveHistoryItem(itemIndex))
         {
-            // Keys for the history container are index based.
-            // SaveHistory() re-inserts the items anyway, so it's faster to just clear out the container.
-            CalculationManager::CalculatorMode currentMode = m_currentMode;
-            ApplicationDataContainer ^ historyContainer = GetHistoryContainer(currentMode);
-            historyContainer->Values->Clear();
-
             Items->RemoveAt(itemIndex);
-            UpdateItemSize();
-            SaveHistory();
+            RaisePropertyChanged(ItemsSizeKey);
         }
     }
 }
@@ -147,16 +139,14 @@ void HistoryViewModel::OnHideCommand(_In_ Platform::Object ^ e)
 
 void HistoryViewModel::OnClearCommand(_In_ Platform::Object ^ e)
 {
-    if (AreHistoryShortcutsEnabled == true)
+    if (AreHistoryShortcutsEnabled)
     {
         m_calculatorManager->ClearHistory();
 
         if (Items->Size > 0)
         {
-            CalculationManager::CalculatorMode currentMode = m_currentMode;
-            ClearHistoryContainer(currentMode);
             Items->Clear();
-            UpdateItemSize();
+            RaisePropertyChanged(ItemsSizeKey);
         }
 
         if (m_localizedHistoryCleared == nullptr)
@@ -167,210 +157,8 @@ void HistoryViewModel::OnClearCommand(_In_ Platform::Object ^ e)
     }
 }
 
-// this method restores history vector per mode
-void HistoryViewModel::RestoreHistory(_In_ CalculationManager::CalculatorMode cMode)
-{
-    ApplicationDataContainer ^ historyContainer = GetHistoryContainer(cMode);
-    std::shared_ptr<std::vector<std::shared_ptr<CalculationManager::HISTORYITEM>>> historyVector =
-        std::make_shared<std::vector<std::shared_ptr<CalculationManager::HISTORYITEM>>>();
-    auto historyVectorLength = static_cast<int>(historyContainer->Values->Lookup(HistoryVectorLengthKey));
-    bool failure = false;
-
-    if (historyVectorLength > 0)
-    {
-        for (int i = 0; i < historyVectorLength; ++i)
-        {
-            try
-            {
-                // deserialize each item
-                auto item = DeserializeHistoryItem(i.ToString(), historyContainer);
-                std::shared_ptr<CalculationManager::HISTORYITEM> Item = std::make_shared<CalculationManager::HISTORYITEM>(item);
-                historyVector->push_back(Item);
-            }
-            catch (Platform::Exception ^ e)
-            {
-                failure = true;
-                break;
-            }
-        }
-
-        if (!failure)
-        {
-            // if task has been cancelled set history to 0
-            m_calculatorManager->SetHistory(cMode, *historyVector);
-
-            // update length once again for consistency between stored number of items and length
-            UpdateHistoryVectorLength(static_cast<int>(historyVector->size()), cMode);
-        }
-        else
-        {
-            // in case of failure do not show any item
-            UpdateHistoryVectorLength(0, cMode);
-        }
-    }
-}
-
-Platform::String ^ HistoryViewModel::GetHistoryContainerKey(_In_ CalculationManager::CalculatorMode cMode)
-{
-    Platform::ValueType ^ modeValue = static_cast<int>(cMode);
-    return Platform::String::Concat(modeValue->ToString(), L"_History");
-}
-
-ApplicationDataContainer ^ HistoryViewModel::GetHistoryContainer(_In_ CalculationManager::CalculatorMode cMode)
-{
-    ApplicationDataContainer ^ localSettings = ApplicationData::Current->LocalSettings;
-    ApplicationDataContainer ^ historyContainer;
-
-    // naming container based on mode
-    Platform::String ^ historyContainerKey = GetHistoryContainerKey(cMode);
-
-    if (localSettings->Containers->HasKey(historyContainerKey))
-    {
-        historyContainer = localSettings->Containers->Lookup(historyContainerKey);
-    }
-    else
-    {
-        // create container for adding data
-        historyContainer = localSettings->CreateContainer(historyContainerKey, ApplicationDataCreateDisposition::Always);
-        int initialHistoryVectorLength = 0;
-        historyContainer->Values->Insert(HistoryVectorLengthKey, initialHistoryVectorLength);
-    }
-
-    return historyContainer;
-}
-
-void HistoryViewModel::ClearHistoryContainer(_In_ CalculationManager::CalculatorMode cMode)
-{
-    ApplicationDataContainer ^ localSettings = ApplicationData::Current->LocalSettings;
-    localSettings->DeleteContainer(GetHistoryContainerKey(cMode));
-}
-
-// this method will be used to update the history item length
-void HistoryViewModel::UpdateHistoryVectorLength(_In_ int newValue, _In_ CalculationManager::CalculatorMode cMode)
-{
-    ApplicationDataContainer ^ historyContainer = GetHistoryContainer(cMode);
-    historyContainer->Values->Remove(HistoryVectorLengthKey);
-    historyContainer->Values->Insert(HistoryVectorLengthKey, newValue);
-}
-
-void HistoryViewModel::ClearHistory()
-{
-    ClearHistoryContainer(CalculationManager::CalculatorMode::Standard);
-    ClearHistoryContainer(CalculationManager::CalculatorMode::Scientific);
-}
-
 unsigned long long HistoryViewModel::GetMaxItemSize()
 {
     return static_cast<unsigned long long>(m_calculatorManager->MaxHistorySize());
 }
 
-void HistoryViewModel::SaveHistory()
-{
-    ApplicationDataContainer ^ historyContainer = GetHistoryContainer(m_currentMode);
-    auto const& currentHistoryVector = m_calculatorManager->GetHistoryItems(m_currentMode);
-    bool failure = false;
-    int index = 0;
-    Platform::String ^ serializedHistoryItem;
-
-    for (auto const& item : currentHistoryVector)
-    {
-        try
-        {
-            serializedHistoryItem = SerializeHistoryItem(item);
-            historyContainer->Values->Insert(index.ToString(), serializedHistoryItem);
-        }
-        catch (Platform::Exception ^)
-        {
-            failure = true;
-            break;
-        }
-
-        ++index;
-    }
-
-    if (!failure)
-    {
-        // insertion is successful
-        UpdateHistoryVectorLength(static_cast<int>(currentHistoryVector.size()), m_currentMode);
-    }
-    else
-    {
-        UpdateHistoryVectorLength(0, m_currentMode);
-    }
-}
-
-// this serializes a history item into a base64 encoded string
-Platform::String ^ HistoryViewModel::SerializeHistoryItem(_In_ std::shared_ptr<CalculationManager::HISTORYITEM> const& item)
-{
-    DataWriter ^ writer = ref new DataWriter();
-    auto expr = item->historyItemVector.expression;
-    auto result = item->historyItemVector.result;
-    auto platformExpr = ref new Platform::String(expr.c_str());
-    writer->WriteUInt32(writer->MeasureString(platformExpr));
-    writer->WriteString(platformExpr);
-    auto platformResult = ref new Platform::String(result.c_str());
-    writer->WriteUInt32(writer->MeasureString(platformResult));
-    writer->WriteString(platformResult);
-
-    Utils::SerializeCommandsAndTokens(item->historyItemVector.spTokens, item->historyItemVector.spCommands, writer);
-
-    IBuffer ^ buffer = writer->DetachBuffer();
-    if (buffer == nullptr)
-    {
-        throw ref new Platform::Exception(E_POINTER, ref new Platform::String(L"History Item is NULL"));
-    }
-
-    return CryptographicBuffer::EncodeToBase64String(buffer);
-}
-
-CalculationManager::HISTORYITEM
-HistoryViewModel::DeserializeHistoryItem(_In_ Platform::String ^ historyItemKey, _In_ ApplicationDataContainer ^ historyContainer)
-{
-    CalculationManager::HISTORYITEM historyItem;
-    if (historyContainer->Values->HasKey(historyItemKey))
-    {
-        Object ^ historyItemValues = historyContainer->Values->Lookup(historyItemKey);
-
-        if (historyItemValues == nullptr)
-        {
-            throw ref new Platform::Exception(E_POINTER, ref new Platform::String(L"History Item is NULL"));
-        }
-
-        String ^ historyData = safe_cast<Platform::String ^>(historyItemValues);
-        IBuffer ^ buffer = CryptographicBuffer::DecodeFromBase64String(historyData);
-
-        if (buffer == nullptr)
-        {
-            throw ref new Platform::Exception(E_POINTER, ref new Platform::String(L"History Item is NULL"));
-        }
-
-        DataReader ^ reader = DataReader::FromBuffer(buffer);
-        auto exprLen = reader->ReadUInt32();
-        auto expression = reader->ReadString(exprLen);
-        historyItem.historyItemVector.expression = expression->Data();
-
-        auto resultLen = reader->ReadUInt32();
-        auto result = reader->ReadString(resultLen);
-        historyItem.historyItemVector.result = result->Data();
-
-        historyItem.historyItemVector.spCommands = Utils::DeserializeCommands(reader);
-        historyItem.historyItemVector.spTokens = Utils::DeserializeTokens(reader);
-    }
-    else
-    {
-        throw ref new Platform::Exception(E_ACCESSDENIED, ref new Platform::String(L"History Item not found"));
-    }
-    return historyItem;
-}
-
-bool HistoryViewModel::IsValid(_In_ CalculationManager::HISTORYITEM item)
-{
-    return (
-        !item.historyItemVector.expression.empty() && !item.historyItemVector.result.empty() && (bool)item.historyItemVector.spCommands
-        && (bool)item.historyItemVector.spTokens);
-}
-
-void HistoryViewModel::UpdateItemSize()
-{
-    ItemSize = Items->Size;
-}

--- a/src/CalcViewModel/HistoryViewModel.cpp
+++ b/src/CalcViewModel/HistoryViewModel.cpp
@@ -21,7 +21,7 @@ using namespace Windows::Security::Cryptography;
 using namespace Windows::Foundation::Collections;
 
 static StringReference HistoryVectorLengthKey{ L"HistoryVectorLength" };
-static StringReference ItemsSizeKey{ L"ItemsSize" };
+static StringReference ItemsSizeKey{ L"ItemsCount" };
 
 namespace CalculatorApp::ViewModel::HistoryResourceKeys
 {

--- a/src/CalcViewModel/HistoryViewModel.h
+++ b/src/CalcViewModel/HistoryViewModel.h
@@ -29,7 +29,7 @@ namespace CalculatorApp
             OBSERVABLE_PROPERTY_R(Windows::Foundation::Collections::IObservableVector<HistoryItemViewModel ^> ^, Items);
             OBSERVABLE_PROPERTY_RW(bool, AreHistoryShortcutsEnabled);
             OBSERVABLE_PROPERTY_R(CalculatorApp::Common::Automation::NarratorAnnouncement ^, HistoryAnnouncement);
-            property int ItemsSize
+            property int ItemsCount
             {
                 int get()
                 {

--- a/src/CalcViewModel/HistoryViewModel.h
+++ b/src/CalcViewModel/HistoryViewModel.h
@@ -26,10 +26,16 @@ namespace CalculatorApp
         {
         public:
             OBSERVABLE_OBJECT();
-            OBSERVABLE_PROPERTY_RW(int, ItemSize);
-            OBSERVABLE_PROPERTY_RW(Windows::UI::Xaml::Interop::IBindableObservableVector ^, Items);
+            OBSERVABLE_PROPERTY_R(Windows::Foundation::Collections::IObservableVector<HistoryItemViewModel ^> ^, Items);
             OBSERVABLE_PROPERTY_RW(bool, AreHistoryShortcutsEnabled);
-            OBSERVABLE_PROPERTY_RW(CalculatorApp::Common::Automation::NarratorAnnouncement ^, HistoryAnnouncement);
+            OBSERVABLE_PROPERTY_R(CalculatorApp::Common::Automation::NarratorAnnouncement ^, HistoryAnnouncement);
+            property int ItemsSize
+            {
+                int get()
+                {
+                    return Items->Size;
+                }
+            }
 
             void OnHistoryItemAdded(_In_ unsigned int addedItemIndex);
 
@@ -42,7 +48,6 @@ namespace CalculatorApp
             event HideHistoryClickedHandler ^ HideHistoryClicked;
             event HistoryItemClickedHandler ^ HistoryItemClicked;
             void ShowItem(_In_ CalculatorApp::ViewModel::HistoryItemViewModel ^ e);
-            void ClearHistory();
 
             internal : HistoryViewModel(_In_ CalculationManager::CalculatorManager* calculatorManager);
             void SetCalculatorDisplay(CalculatorDisplay& calculatorDisplay);
@@ -51,27 +56,13 @@ namespace CalculatorApp
 
             void DeleteItem(_In_ CalculatorApp::ViewModel::HistoryItemViewModel ^ e);
 
-            // store history in app data functions
-            Platform::String ^ SerializeHistoryItem(_In_ std::shared_ptr<CalculationManager::HISTORYITEM> const& item);
-            void SaveHistory();
-
         private:
             CalculationManager::CalculatorManager* const m_calculatorManager;
             CalculatorDisplay m_calculatorDisplay;
             CalculationManager::CalculatorMode m_currentMode;
             Platform::String ^ m_localizedHistoryCleared;
 
-            void RestoreHistory(_In_ CalculationManager::CalculatorMode cMode);
-            CalculationManager::HISTORYITEM
-            DeserializeHistoryItem(_In_ Platform::String ^ historyItemKey, _In_ Windows::Storage::ApplicationDataContainer ^ historyContainer);
-            Windows::Storage::ApplicationDataContainer ^ GetHistoryContainer(_In_ CalculationManager::CalculatorMode cMode);
-            Platform::String ^ GetHistoryContainerKey(_In_ CalculationManager::CalculatorMode cMode);
-            void ClearHistoryContainer(_In_ CalculationManager::CalculatorMode cMode);
-            void UpdateHistoryVectorLength(_In_ int newValue, _In_ CalculationManager::CalculatorMode cMode);
-            bool IsValid(_In_ CalculationManager::HISTORYITEM item);
-
             friend class CalculatorDisplay;
-            void UpdateItemSize();
         };
     }
 }

--- a/src/CalcViewModel/HistoryViewModel.h
+++ b/src/CalcViewModel/HistoryViewModel.h
@@ -61,8 +61,6 @@ namespace CalculatorApp
             CalculatorDisplay m_calculatorDisplay;
             CalculationManager::CalculatorMode m_currentMode;
             Platform::String ^ m_localizedHistoryCleared;
-
-            friend class CalculatorDisplay;
         };
     }
 }

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -130,7 +130,6 @@ StandardCalculatorViewModel::StandardCalculatorViewModel()
     IsOperandEnabled = true;
     IsNegateEnabled = true;
     IsDecimalEnabled = true;
-    AreHistoryShortcutsEnabled = true;
     AreProgrammerRadixOperatorsEnabled = false;
 }
 

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -77,7 +77,6 @@ namespace CalculatorApp
             OBSERVABLE_PROPERTY_R(CalculatorApp::Common::NumberBase, CurrentRadixType);
             OBSERVABLE_PROPERTY_R(bool, AreTokensUpdated);
             OBSERVABLE_PROPERTY_R(bool, AreAlwaysOnTopResultsUpdated);
-            OBSERVABLE_PROPERTY_RW(bool, AreHistoryShortcutsEnabled);
             OBSERVABLE_PROPERTY_R(bool, AreProgrammerRadixOperatorsEnabled);
             OBSERVABLE_PROPERTY_R(bool, IsInputEmpty);
             OBSERVABLE_PROPERTY_R(CalculatorApp::Common::Automation::NarratorAnnouncement ^, Announcement);

--- a/src/Calculator/Views/HistoryList.xaml
+++ b/src/Calculator/Views/HistoryList.xaml
@@ -137,7 +137,7 @@
                        Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
                        FontWeight="SemiLight"
                        TextWrapping="Wrap"
-                       Visibility="{x:Bind Model.ItemsSize, Converter={StaticResource ItemSizeToVisibilityConverter}, Mode=OneWay}"/>
+                       Visibility="{x:Bind Model.ItemsCount, Converter={StaticResource ItemSizeToVisibilityConverter}, Mode=OneWay}"/>
             <ListView x:Name="HistoryListView"
                       MinHeight="60"
                       Padding="0,12,0,0"
@@ -150,7 +150,7 @@
                       ItemsSource="{x:Bind Model.Items, Mode=OneWay}"
                       SelectionMode="None"
                       TabIndex="0"
-                      Visibility="{x:Bind Model.ItemsSize, Mode=OneWay, Converter={StaticResource ItemSizeToVisibilityNegationConverter}}">
+                      Visibility="{x:Bind Model.ItemsCount, Mode=OneWay, Converter={StaticResource ItemSizeToVisibilityNegationConverter}}">
                 <ListView.ItemContainerTransitions>
                     <TransitionCollection>
                         <AddDeleteThemeTransition/>
@@ -166,7 +166,7 @@
                     AutomationProperties.AutomationId="ClearHistory"
                     Command="{x:Bind Model.ClearCommand, Mode=OneWay}"
                     Content="&#xE74D;"
-                    Visibility="{x:Bind Model.ItemsSize, Mode=OneWay, Converter={StaticResource ItemSizeToVisibilityNegationConverter}}"/>
+                    Visibility="{x:Bind Model.ItemsCount, Mode=OneWay, Converter={StaticResource ItemSizeToVisibilityNegationConverter}}"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/Calculator/Views/HistoryList.xaml
+++ b/src/Calculator/Views/HistoryList.xaml
@@ -137,7 +137,7 @@
                        Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
                        FontWeight="SemiLight"
                        TextWrapping="Wrap"
-                       Visibility="{Binding ItemSize, Converter={StaticResource ItemSizeToVisibilityConverter}}"/>
+                       Visibility="{x:Bind Model.ItemsSize, Converter={StaticResource ItemSizeToVisibilityConverter}, Mode=OneWay}"/>
             <ListView x:Name="HistoryListView"
                       MinHeight="60"
                       Padding="0,12,0,0"
@@ -150,7 +150,7 @@
                       ItemsSource="{x:Bind Model.Items, Mode=OneWay}"
                       SelectionMode="None"
                       TabIndex="0"
-                      Visibility="{x:Bind Model.ItemSize, Mode=OneWay, Converter={StaticResource ItemSizeToVisibilityNegationConverter}}">
+                      Visibility="{x:Bind Model.ItemsSize, Mode=OneWay, Converter={StaticResource ItemSizeToVisibilityNegationConverter}}">
                 <ListView.ItemContainerTransitions>
                     <TransitionCollection>
                         <AddDeleteThemeTransition/>
@@ -166,7 +166,7 @@
                     AutomationProperties.AutomationId="ClearHistory"
                     Command="{x:Bind Model.ClearCommand, Mode=OneWay}"
                     Content="&#xE74D;"
-                    Visibility="{x:Bind Model.ItemSize, Mode=OneWay, Converter={StaticResource ItemSizeToVisibilityNegationConverter}}"/>
+                    Visibility="{x:Bind Model.ItemsSize, Mode=OneWay, Converter={StaticResource ItemSizeToVisibilityNegationConverter}}"/>
         </Grid>
     </Grid>
 </UserControl>

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -89,11 +89,6 @@ MainPage::MainPage()
 
 void MainPage::OnNavigatedTo(NavigationEventArgs ^ e)
 {
-    if (m_model->CalculatorViewModel)
-    {
-        m_model->CalculatorViewModel->HistoryVM->ClearHistory();
-    }
-
     ViewMode initialMode = ViewMode::Standard;
     if (e->Parameter != nullptr)
     {
@@ -134,7 +129,6 @@ void MainPage::OnAppPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows
         if (newValue == ViewMode::Standard)
         {
             EnsureCalculator();
-            m_model->CalculatorViewModel->AreHistoryShortcutsEnabled = true;
             m_model->CalculatorViewModel->HistoryVM->AreHistoryShortcutsEnabled = true;
             m_calculator->AnimateCalculator(NavCategory::IsConverterViewMode(previousMode));
             m_model->CalculatorViewModel->HistoryVM->ReloadHistory(newValue);
@@ -142,7 +136,6 @@ void MainPage::OnAppPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows
         else if (newValue == ViewMode::Scientific)
         {
             EnsureCalculator();
-            m_model->CalculatorViewModel->AreHistoryShortcutsEnabled = true;
             m_model->CalculatorViewModel->HistoryVM->AreHistoryShortcutsEnabled = true;
             if (m_model->PreviousMode != ViewMode::Scientific)
             {
@@ -153,7 +146,6 @@ void MainPage::OnAppPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows
         }
         else if (newValue == ViewMode::Programmer)
         {
-            m_model->CalculatorViewModel->AreHistoryShortcutsEnabled = false;
             m_model->CalculatorViewModel->HistoryVM->AreHistoryShortcutsEnabled = false;
             EnsureCalculator();
             if (m_model->PreviousMode != ViewMode::Programmer)
@@ -165,7 +157,6 @@ void MainPage::OnAppPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows
         {
             if (m_model->CalculatorViewModel)
             {
-                m_model->CalculatorViewModel->AreHistoryShortcutsEnabled = false;
                 m_model->CalculatorViewModel->HistoryVM->AreHistoryShortcutsEnabled = false;
             }
             EnsureDateCalculator();
@@ -179,7 +170,6 @@ void MainPage::OnAppPropertyChanged(_In_ Platform::Object ^ sender, _In_ Windows
         {
             if (m_model->CalculatorViewModel)
             {
-                m_model->CalculatorViewModel->AreHistoryShortcutsEnabled = false;
                 m_model->CalculatorViewModel->HistoryVM->AreHistoryShortcutsEnabled = false;
             }
             EnsureConverter();

--- a/src/CalculatorUnitTests/MultiWindowUnitTests.cpp
+++ b/src/CalculatorUnitTests/MultiWindowUnitTests.cpp
@@ -369,7 +369,7 @@ TEST_METHOD(MultipleModesHistoryAddItemTest)
         ChangeMode(viewModels[i], i);
 
         // Validate that the history items list is initially empty
-        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemSize);
+        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemsCount);
     }
 
     // Perform Calculations on both the instances and check that the History items work independently
@@ -390,7 +390,7 @@ TEST_METHOD(MultipleModesHistoryAddItemTest)
     ValidateViewModelByCommands(viewModels[1], scientificModeTestItems, true);
 
     // Assert for the history list items of 1st instance
-    VERIFY_IS_TRUE(1 == viewModels[0]->HistoryVM->ItemSize);
+    VERIFY_IS_TRUE(1 == viewModels[0]->HistoryVM->ItemsCount);
 
     auto item1 = static_cast<HistoryItemViewModel ^>(viewModels[0]->HistoryVM->Items->GetAt(0));
     String ^ expression1 = L"1   +   2 =";
@@ -400,7 +400,7 @@ TEST_METHOD(MultipleModesHistoryAddItemTest)
     VERIFY_ARE_EQUAL(result1, item1->Result);
 
     // Assert for the history list items of 2nd instance
-    VERIFY_IS_TRUE(1 == viewModels[1]->HistoryVM->ItemSize);
+    VERIFY_IS_TRUE(1 == viewModels[1]->HistoryVM->ItemsCount);
 
     auto item2 = static_cast<HistoryItemViewModel ^>(viewModels[1]->HistoryVM->Items->GetAt(0));
     String ^ expression2 = L"1   +   2   " + UtfUtils::MUL + L"   3 =";
@@ -424,7 +424,7 @@ TEST_METHOD(MultipleStandardModesHistoryAddItemTest)
         ChangeMode(viewModels[i], 0);
 
         // Validate that the history items list is initially empty
-        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemSize);
+        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemsCount);
     }
 
     // Perform Calculations on both the instances and check that the History items work independently
@@ -457,7 +457,7 @@ TEST_METHOD(MultipleStandardModesHistoryAddItemTest)
     // Assert for the history list items of the instances
     for (int i = 0; i < 2; i++)
     {
-        VERIFY_IS_TRUE(1 == viewModels[i]->HistoryVM->ItemSize);
+        VERIFY_IS_TRUE(1 == viewModels[i]->HistoryVM->ItemsCount);
 
         auto item = static_cast<HistoryItemViewModel ^>(viewModels[i]->HistoryVM->Items->GetAt(0));
 
@@ -480,7 +480,7 @@ TEST_METHOD(MultipleScientificModesHistoryAddItemTest)
         ChangeMode(viewModels[i], 1);
 
         // Validate that the history items list is initially empty
-        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemSize);
+        VERIFY_IS_TRUE(0 == viewModels[i]->HistoryVM->ItemsCount);
     }
 
     // Perform Calculations on both the instances and check that the History items work independently
@@ -513,7 +513,7 @@ TEST_METHOD(MultipleScientificModesHistoryAddItemTest)
     // Assert for the history list items of the instances
     for (int i = 0; i < 2; i++)
     {
-        VERIFY_IS_TRUE(1 == viewModels[i]->HistoryVM->ItemSize);
+        VERIFY_IS_TRUE(1 == viewModels[i]->HistoryVM->ItemsCount);
 
         auto item = static_cast<HistoryItemViewModel ^>(viewModels[i]->HistoryVM->Items->GetAt(0));
 


### PR DESCRIPTION
### Description of the changes:
- Remove serialization/deserialization of history items (never used) and all methods associated
- Remove `CalculatorViewModel->AreHistoryShortcutsEnabled` (never used contrary to `CalculatorViewModel->HistoryVM->AreHistoryShortcutsEnabled`)
- Replace the property HistoryViewModel::ItemSize with a "facade" property `ItemsCount`, returning the value of `Items->Size`.

### How changes were validated:
- Manually

