### PR TITLE
Remove saved commands from CalculatorManager

### DIFF
--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -10,15 +10,10 @@ using namespace std;
 using namespace CalcEngine;
 
 static constexpr size_t MAX_HISTORY_ITEMS = 20;
-static constexpr size_t SERIALIZED_NUMBER_MINSIZE = 3;
 
 #ifndef _MSC_VER
 #define __pragma(x)
 #endif
-
-// Converts Memory Command enum value to unsigned char,
-// while ignoring Warning C4309: 'conversion' : truncation of constant value
-#define MEMORY_COMMAND_TO_UNSIGNED_CHAR(c) __pragma(warning(push)) __pragma(warning(disable : 4309)) static_cast<unsigned char>(c) __pragma(warning(pop))
 
 namespace CalculationManager
 {
@@ -30,7 +25,6 @@ namespace CalculationManager
         , m_persistedPrimaryValue()
         , m_isExponentialFormat(false)
         , m_currentDegreeMode(Command::CommandNULL)
-        , m_savedDegreeMode(Command::CommandDEG)
         , m_pStdHistory(new CalculatorHistory(MAX_HISTORY_ITEMS))
         , m_pSciHistory(new CalculatorHistory(MAX_HISTORY_ITEMS))
         , m_pHistory(nullptr)
@@ -132,7 +126,6 @@ namespace CalculationManager
     /// </summary>
     void CalculatorManager::Reset(bool clearMemory /* = true*/)
     {
-        m_savedCommands.clear();
         SetStandardMode();
 
         if (m_scientificCalculatorEngine)
@@ -239,13 +232,6 @@ namespace CalculationManager
                 m_currentCalculatorEngine->ProcessCommand(static_cast<OpCode>(command));
             }
 
-            m_savedCommands.clear(); // Clear the previous command history
-
-            if (command != Command::CommandEQU && command != Command::CommandCLEAR)
-            {
-                m_savedCommands.push_back(MapCommandForSerialize(command));
-            }
-            m_savedDegreeMode = m_currentDegreeMode;
             InputChanged();
             return;
         }
@@ -253,11 +239,6 @@ namespace CalculationManager
         if (command == Command::CommandDEG || command == Command::CommandRAD || command == Command::CommandGRAD)
         {
             m_currentDegreeMode = command;
-        }
-
-        if (command != Command::CommandFE)
-        {
-            m_savedCommands.push_back(MapCommandForSerialize(command)); // Save the commands in the m_savedCommands
         }
 
         switch (command)
@@ -326,37 +307,6 @@ namespace CalculationManager
     }
 
     /// <summary>
-    /// Convert Command to unsigned char.
-    /// Since some Commands are higher than 255, they are saved after subtracting 255
-    /// The smallest Command is CommandSIGN = 80, thus, subtracted value does not overlap with other values.
-    /// </summary>
-    /// <param name="command">Enum Command</command>
-    unsigned char CalculatorManager::MapCommandForSerialize(Command command)
-    {
-        unsigned int commandToSave = static_cast<unsigned int>(command);
-        if (commandToSave > UCHAR_MAX)
-        {
-            commandToSave -= UCHAR_MAX;
-        }
-        return static_cast<unsigned char>(commandToSave);
-    }
-
-    /// <summary>
-    /// Convert Command to unsigned int
-    /// The command that is smaller than 80, CommandSIGN, can be converted back to original value by adding 255.
-    /// </summary>
-    /// <param name="command">unsigned char value represent the saved command</command>
-    unsigned int CalculatorManager::MapCommandForDeSerialize(unsigned char command)
-    {
-        unsigned int commandToLoad = command;
-        if (command < static_cast<unsigned int>(Command::CommandSIGN))
-        {
-            commandToLoad += UCHAR_MAX;
-        }
-        return commandToLoad;
-    }
-
-    /// <summary>
     /// Load the persisted value that is saved in memory of CalcEngine
     /// </summary>
     void CalculatorManager::LoadPersistedPrimaryValue()
@@ -372,8 +322,6 @@ namespace CalculationManager
     /// </summary>
     void CalculatorManager::MemorizeNumber()
     {
-        m_savedCommands.push_back(MEMORY_COMMAND_TO_UNSIGNED_CHAR(MemoryCommand::MemorizeNumber));
-
         if (m_currentCalculatorEngine->FInErrorState())
         {
             return;
@@ -401,8 +349,6 @@ namespace CalculationManager
     /// <param name="indexOfMemory">Index of the target memory</param>
     void CalculatorManager::MemorizedNumberLoad(_In_ unsigned int indexOfMemory)
     {
-        SaveMemoryCommand(MemoryCommand::MemorizedNumberLoad, indexOfMemory);
-
         if (m_currentCalculatorEngine->FInErrorState())
         {
             return;
@@ -421,8 +367,6 @@ namespace CalculationManager
     /// <param name="indexOfMemory">Index of the target memory</param>
     void CalculatorManager::MemorizedNumberAdd(_In_ unsigned int indexOfMemory)
     {
-        SaveMemoryCommand(MemoryCommand::MemorizedNumberAdd, indexOfMemory);
-
         if (m_currentCalculatorEngine->FInErrorState())
         {
             return;
@@ -449,7 +393,6 @@ namespace CalculationManager
     {
         if (indexOfMemory < m_memorizedNumbers.size())
         {
-            SaveMemoryCommand(MemoryCommand::MemorizedNumberClear, indexOfMemory);
             m_memorizedNumbers.erase(m_memorizedNumbers.begin() + indexOfMemory);
         }
     }
@@ -462,8 +405,6 @@ namespace CalculationManager
     /// <param name="indexOfMemory">Index of the target memory</param>
     void CalculatorManager::MemorizedNumberSubtract(_In_ unsigned int indexOfMemory)
     {
-        SaveMemoryCommand(MemoryCommand::MemorizedNumberSubtract, indexOfMemory);
-
         if (m_currentCalculatorEngine->FInErrorState())
         {
             return;
@@ -495,7 +436,6 @@ namespace CalculationManager
     /// </summary>
     void CalculatorManager::MemorizedNumberClearAll()
     {
-        m_savedCommands.push_back(MEMORY_COMMAND_TO_UNSIGNED_CHAR(MemoryCommand::MemorizedNumberClearAll));
         m_memorizedNumbers.clear();
 
         m_currentCalculatorEngine->ProcessCommand(IDC_MCLEAR);
@@ -535,16 +475,6 @@ namespace CalculationManager
         {
             m_memorizedNumbers.at(indexOfMemory) = *memoryObject;
         }
-    }
-
-    void CalculatorManager::SaveMemoryCommand(_In_ MemoryCommand command, _In_ unsigned int indexOfMemory)
-    {
-        m_savedCommands.push_back(MEMORY_COMMAND_TO_UNSIGNED_CHAR(command));
-        if (indexOfMemory > UCHAR_MAX)
-        {
-            throw invalid_argument("Unexpected value. IndexOfMemory is bigger than the biggest unsigned char");
-        }
-        m_savedCommands.push_back(static_cast<unsigned char>(indexOfMemory));
     }
 
     vector<shared_ptr<HISTORYITEM>> const& CalculatorManager::GetHistoryItems()

--- a/src/CalcManager/CalculatorManager.h
+++ b/src/CalcManager/CalculatorManager.h
@@ -44,6 +44,7 @@ namespace CalculationManager
     class CalculatorManager final : public ICalcDisplay
     {
     private:
+        static const unsigned int m_maximumMemorySize = 100;
         ICalcDisplay* const m_displayCallback;
         CCalcEngine* m_currentCalculatorEngine;
         std::unique_ptr<CCalcEngine> m_scientificCalculatorEngine;
@@ -54,21 +55,8 @@ namespace CalculationManager
 
         std::vector<CalcEngine::Rational> m_memorizedNumbers;
         CalcEngine::Rational m_persistedPrimaryValue;
-
         bool m_isExponentialFormat;
-
-        static const unsigned int m_maximumMemorySize = 100;
-
-        // For persistence
-        std::vector<unsigned char> m_savedCommands;
-        std::vector<long> m_savedPrimaryValue;
-        std::vector<long> m_currentSerializedMemory;
         Command m_currentDegreeMode;
-        Command m_savedDegreeMode;
-        unsigned char MapCommandForSerialize(Command command);
-        unsigned int MapCommandForDeSerialize(unsigned char command);
-
-        void SaveMemoryCommand(_In_ MemoryCommand command, _In_ unsigned int indexOfMemory);
 
         void MemorizedNumberSelect(_In_ unsigned int);
         void MemorizedNumberChanged(_In_ unsigned int);
@@ -112,10 +100,6 @@ namespace CalculationManager
 
         bool IsEngineRecording();
         bool IsInputEmpty();
-        const std::vector<unsigned char>& GetSavedCommands() const
-        {
-            return m_savedCommands;
-        }
         void SetRadix(RadixType iRadixType);
         void SetMemorizedNumbersString();
         std::wstring GetResultForRadix(uint32_t radix, int32_t precision, bool groupDigitsPerRadix);

--- a/src/CalcManager/Command.h
+++ b/src/CalcManager/Command.h
@@ -69,10 +69,6 @@ namespace CalculationManager
 
         CommandNULL = 0,
 
-        // No new command should not be added before CommandSign, 80
-        // If it is needed, the following two functions need to be revised too.
-        // CalculatorManager::MapCommandForSerialize(Command command);
-        // CalculatorManager::MapCommandForDeSerialize(unsigned char command);
         CommandSIGN = 80,
         CommandCLEAR = 81,
         CommandCENTR = 82,

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1655,66 +1655,6 @@ void StandardCalculatorViewModel::UpdateOperand(int pos, String ^ text)
     }
 }
 
-void StandardCalculatorViewModel::UpdateCommandsInRecordingMode()
-{
-    shared_ptr<vector<int>> commands = make_shared<vector<int>>();
-    bool isDecimal = false;
-    bool isNegative = false;
-    bool isExpMode = false;
-    bool ePlusMode = false;
-    bool eMinusMode = false;
-
-    for (const auto savedCommand : m_standardCalculatorManager.GetSavedCommands())
-    {
-        const Command val = static_cast<Command>(savedCommand);
-        if (val == Command::CommandSIGN)
-        {
-            isNegative = true;
-            continue;
-        }
-        else if ((val >= Command::Command0 && val <= Command::Command9))
-        {
-        }
-        else if (val == Command::CommandPNT)
-        {
-            isDecimal = true;
-        }
-        else if (val == Command::CommandEXP)
-        {
-            isExpMode = true;
-        }
-        else if (isExpMode && !ePlusMode && (val == Command::CommandMPLUS))
-        {
-            ePlusMode = true;
-            continue;
-        }
-        else if (isExpMode && !eMinusMode && (val == Command::CommandMMINUS))
-        {
-            eMinusMode = true;
-            continue;
-        }
-        else
-        {
-            // Reset all vars
-            isDecimal = false;
-            isNegative = false;
-            isExpMode = false;
-            ePlusMode = false;
-            eMinusMode = false;
-            commands->clear();
-            continue;
-        }
-        commands->push_back(static_cast<int>(val));
-    }
-
-    if (!commands->empty())
-    {
-        shared_ptr<IOpndCommand> sp = make_shared<COpndCommand>(commands, isNegative, isDecimal, isExpMode);
-        m_commands->push_back(sp);
-    }
-    Recalculate();
-}
-
 void StandardCalculatorViewModel::OnMaxDigitsReached()
 {
     if (m_localizedMaxDigitsReachedAutomationFormat == nullptr)

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -38,7 +38,6 @@ namespace CalculatorApp
         public:
             StandardCalculatorViewModel();
             void UpdateOperand(int pos, Platform::String ^ text);
-            void UpdateCommandsInRecordingMode();
 
             OBSERVABLE_OBJECT_CALLBACK(OnPropertyChanged);
             OBSERVABLE_PROPERTY_RW(Platform::String ^, DisplayValue);


### PR DESCRIPTION
### Description of the changes:
- Code cleaning: Remove recording mode from CalculatorManager/StandardCalculatorViewModel and all associated methods/fields, and removing some restrictions on commands due to this mode.

### How changes were validated:
- Manually

