### PR TITLE
Updates ResetGrid to account for when equations are added during Manual Adjustment mode

### DIFF
--- a/build/pipelines/templates/build-app-internal.yaml
+++ b/build/pipelines/templates/build-app-internal.yaml
@@ -29,7 +29,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.40
+      vstsPackageVersion: 0.0.44
 
   - template: ./build-single-architecture.yaml
     parameters:

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -96,7 +96,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.40
+      vstsPackageVersion: 0.0.44
 
   - powershell: |
       # Just modify this line to indicate where your en-us PDP file is. Leave the other lines alone.

--- a/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
+++ b/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
@@ -100,8 +100,7 @@ void GraphingSettingsViewModel::UpdateDisplayRange()
         return;
     }
 
-    m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue);
-    m_Graph->RangeUpdatedBySettings = true;
+    m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue, true);
 
     TraceLogger::GetInstance()->LogGraphSettingsChanged(GraphSettingsType::Grid, L"");
 }

--- a/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
+++ b/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
@@ -101,6 +101,7 @@ void GraphingSettingsViewModel::UpdateDisplayRange()
     }
 
     m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue);
+    m_Graph->RangeUpdatedBySettings = true;
 
     TraceLogger::GetInstance()->LogGraphSettingsChanged(GraphSettingsType::Grid, L"");
 }

--- a/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
+++ b/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
@@ -100,7 +100,7 @@ void GraphingSettingsViewModel::UpdateDisplayRange()
         return;
     }
 
-    m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue, true);
+    m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue);
 
     TraceLogger::GetInstance()->LogGraphSettingsChanged(GraphSettingsType::Grid, L"");
 }

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -124,13 +124,15 @@ namespace GraphControl
                 {
                     TryPlotGraph(false, false);
                     m_resetUsingInitialDisplayRange = false;
-                }
-                else if (SUCCEEDED(renderer->ResetRange()))
-                {
-                    m_renderMain->RunRenderPass();
+                    GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
+                    return;
                 }
 
-                GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
+                if (SUCCEEDED(renderer->ResetRange()))
+                {
+                    m_renderMain->RunRenderPass();
+                    GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
+                }
             }
         }
     }

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -122,22 +122,15 @@ namespace GraphControl
             {
                 if (m_resetUsingInitialDisplayRange)
                 {
-                    renderer->SetDisplayRanges(m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
-                    auto xCenter = (m_initialDisplayRangeXMax - m_initialDisplayRangeXMin) / 2;
-                    auto yCenter = (m_initialDisplayRangeYMax - m_initialDisplayRangeYMin) / 2;
-                    renderer->ScaleRange(xCenter, yCenter, 1);
+                    TryPlotGraph(false, false);
                     m_resetUsingInitialDisplayRange = false;
-                    m_renderMain->RunRenderPass();
-                    GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
-                    return;
                 }
-                if (SUCCEEDED(renderer->ResetRange()))
+                else if (SUCCEEDED(renderer->ResetRange()))
                 {
                     m_renderMain->RunRenderPass();
                 }
 
                 GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
-                return;
             }
         }
     }
@@ -1106,8 +1099,6 @@ optional<vector<shared_ptr<Graphing::IEquation>>> Grapher::TryInitializeGraph(bo
         auto initResult = m_graph->TryInitialize(graphingExp);
         if (IsKeepCurrentView)
         {
-            m_graph->GetRenderer()->GetDisplayRanges(
-                m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
             m_resetUsingInitialDisplayRange = true;
         }
         m_graph->GetRenderer()->SetDisplayRanges(xMin, xMax, yMin, yMax);

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -121,6 +121,10 @@ namespace GraphControl
             if(auto renderer = m_graph->GetRenderer())
             {
                 HRESULT hr;
+
+                // Reset the Grid using the m_initialDisplayRange properties when the user was last in Manual Adjustment mode and an equation was added.
+                // Reset the Grid using the TryPlotGraph method when the range is updated via Graph Settings. Return out of this block so we don't render 2 times.
+                // Reset the Grid using the ResetRange() in all other cases.
                 if (m_resetUsingInitialDisplayRange)
                 {
                     hr = renderer->SetDisplayRanges(m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
@@ -1116,8 +1120,10 @@ optional<vector<shared_ptr<Graphing::IEquation>>> Grapher::TryInitializeGraph(bo
         {
             if (IsKeepCurrentView)
             {
+                // PrepareGraph() populates the values of the graph after TryInitialize but before rendering. This allows us to get the range of the graph to be rendered.
                 if (SUCCEEDED(renderer->PrepareGraph()))
                 {
+                    // Get the initial display ranges from the graph that was just initialized to be used in ResetGrid if they user clicks the GraphView button.
                     renderer->GetDisplayRanges(m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
                     m_resetUsingInitialDisplayRange = true;
                 }

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -1110,7 +1110,10 @@ optional<vector<shared_ptr<Graphing::IEquation>>> Grapher::TryInitializeGraph(bo
                 m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
             m_resetUsingInitialDisplayRange = true;
         }
-        renderer->SetDisplayRanges(xMin, xMax, yMin, yMax);
+        if (initResult != nullopt)
+        {
+            renderer->SetDisplayRanges(xMin, xMax, yMin, yMax);
+        }
 
         m_replot = true;
 

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -128,7 +128,9 @@ namespace GraphControl
                 }
                 else if (m_rangeUpdatedBySettings)
                 {
+                    IsKeepCurrentView = false;
                     TryPlotGraph(false, false);
+                    m_rangeUpdatedBySettings = false;
                     GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
                     return;
                 }

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -148,7 +148,6 @@ namespace GraphControl
                     m_renderMain->RunRenderPass();
                     GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
                 }
-
             }
         }
     }
@@ -1132,13 +1131,11 @@ optional<vector<shared_ptr<Graphing::IEquation>>> Grapher::TryInitializeGraph(bo
             renderer->SetDisplayRanges(xMin, xMax, yMin, yMax);
         }
 
-        m_replot = true;
-
         return initResult;
     }
     else
     {
-        m_replot = false;
+        m_resetUsingInitialDisplayRange = false;
         return m_graph->TryInitialize(graphingExp);
     }
 }

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -120,15 +120,18 @@ namespace GraphControl
         {
             if(auto renderer = m_graph->GetRenderer())
             {
+                HRESULT hr;
                 if (m_resetUsingInitialDisplayRange)
                 {
-                    TryPlotGraph(false, false);
+                    hr = renderer->SetDisplayRanges(m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
                     m_resetUsingInitialDisplayRange = false;
-                    GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
-                    return;
+                }
+                else
+                {
+                    hr = renderer->ResetRange();
                 }
 
-                if (SUCCEEDED(renderer->ResetRange()))
+                if (SUCCEEDED(hr))
                 {
                     m_renderMain->RunRenderPass();
                     GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
@@ -1096,14 +1099,18 @@ optional<vector<shared_ptr<Graphing::IEquation>>> Grapher::TryInitializeGraph(bo
 {
     if (keepCurrentView || IsKeepCurrentView)
     {
+        auto renderer = m_graph->GetRenderer();
         double xMin, xMax, yMin, yMax;
-        m_graph->GetRenderer()->GetDisplayRanges(xMin, xMax, yMin, yMax);
+        renderer->GetDisplayRanges(xMin, xMax, yMin, yMax);
         auto initResult = m_graph->TryInitialize(graphingExp);
         if (IsKeepCurrentView)
         {
+            renderer->PrepareGraph();
+            renderer->GetDisplayRanges(
+                m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
             m_resetUsingInitialDisplayRange = true;
         }
-        m_graph->GetRenderer()->SetDisplayRanges(xMin, xMax, yMin, yMax);
+        renderer->SetDisplayRanges(xMin, xMax, yMin, yMax);
 
         m_replot = true;
 

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -126,6 +126,12 @@ namespace GraphControl
                     hr = renderer->SetDisplayRanges(m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
                     m_resetUsingInitialDisplayRange = false;
                 }
+                else if (m_rangeUpdatedBySettings)
+                {
+                    TryPlotGraph(false, false);
+                    GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
+                    return;
+                }
                 else
                 {
                     hr = renderer->ResetRange();
@@ -136,6 +142,7 @@ namespace GraphControl
                     m_renderMain->RunRenderPass();
                     GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
                 }
+
             }
         }
     }
@@ -1103,15 +1110,17 @@ optional<vector<shared_ptr<Graphing::IEquation>>> Grapher::TryInitializeGraph(bo
         double xMin, xMax, yMin, yMax;
         renderer->GetDisplayRanges(xMin, xMax, yMin, yMax);
         auto initResult = m_graph->TryInitialize(graphingExp);
-        if (IsKeepCurrentView)
-        {
-            renderer->PrepareGraph();
-            renderer->GetDisplayRanges(
-                m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
-            m_resetUsingInitialDisplayRange = true;
-        }
         if (initResult != nullopt)
         {
+            if (IsKeepCurrentView)
+            {
+                if (SUCCEEDED(renderer->PrepareGraph()))
+                {
+                    renderer->GetDisplayRanges(m_initialDisplayRangeXMin, m_initialDisplayRangeXMax, m_initialDisplayRangeYMin, m_initialDisplayRangeYMax);
+                    m_resetUsingInitialDisplayRange = true;
+                }
+            }
+
             renderer->SetDisplayRanges(xMin, xMax, yMin, yMax);
         }
 

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -228,6 +228,19 @@ public enum class GraphViewChangedReason
             }
         }
 
+        property bool RangeUpdatedBySettings
+        {
+            bool get()
+            {
+                return m_rangeUpdatedBySettings;
+            }
+
+            void set(bool value)
+            {
+                m_rangeUpdatedBySettings = value;
+            }
+        }
+
         void GetDisplayRanges(double* xMin, double* xMax, double* yMin, double* yMax)
         {
             try
@@ -353,6 +366,7 @@ public enum class GraphViewChangedReason
         int m_errorType;
         int m_errorCode;
         bool m_resetUsingInitialDisplayRange;
+        bool m_rangeUpdatedBySettings;
         double m_initialDisplayRangeXMin;
         double m_initialDisplayRangeXMax;
         double m_initialDisplayRangeYMin;

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -353,10 +353,6 @@ public enum class GraphViewChangedReason
         int m_errorType;
         int m_errorCode;
         bool m_resetUsingInitialDisplayRange;
-        double m_initialDisplayRangeXMin;
-        double m_initialDisplayRangeXMax;
-        double m_initialDisplayRangeYMin;
-        double m_initialDisplayRangeYMax;
 
     public:
         Windows::Storage::Streams::RandomAccessStreamReference ^ GetGraphBitmapStream();

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -247,14 +247,14 @@ public enum class GraphViewChangedReason
             }
         }
 
-        void SetDisplayRanges(double xMin, double xMax, double yMin, double yMax, bool isSettings)
+        void SetDisplayRanges(double xMin, double xMax, double yMin, double yMax)
         {
             try
             {
                 if (auto render = m_graph->GetRenderer())
                 {
                     render->SetDisplayRanges(xMin, xMax, yMin, yMax);
-                    m_rangeUpdatedBySettings = isSettings;
+                    m_rangeUpdatedBySettings = true;
                     if (m_renderMain)
                     {
                         m_renderMain->RunRenderPass();

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -353,6 +353,10 @@ public enum class GraphViewChangedReason
         int m_errorType;
         int m_errorCode;
         bool m_resetUsingInitialDisplayRange;
+        double m_initialDisplayRangeXMin;
+        double m_initialDisplayRangeXMax;
+        double m_initialDisplayRangeYMin;
+        double m_initialDisplayRangeYMax;
 
     public:
         Windows::Storage::Streams::RandomAccessStreamReference ^ GetGraphBitmapStream();

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -228,19 +228,6 @@ public enum class GraphViewChangedReason
             }
         }
 
-        property bool RangeUpdatedBySettings
-        {
-            bool get()
-            {
-                return m_rangeUpdatedBySettings;
-            }
-
-            void set(bool value)
-            {
-                m_rangeUpdatedBySettings = value;
-            }
-        }
-
         void GetDisplayRanges(double* xMin, double* xMax, double* yMin, double* yMax)
         {
             try
@@ -260,14 +247,14 @@ public enum class GraphViewChangedReason
             }
         }
 
-        void SetDisplayRanges(double xMin, double xMax, double yMin, double yMax)
+        void SetDisplayRanges(double xMin, double xMax, double yMin, double yMax, bool isSettings)
         {
             try
             {
                 if (auto render = m_graph->GetRenderer())
                 {
                     render->SetDisplayRanges(xMin, xMax, yMin, yMax);
-                    m_replot = true;
+                    m_rangeUpdatedBySettings = isSettings;
                     if (m_renderMain)
                     {
                         m_renderMain->RunRenderPass();

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -352,7 +352,11 @@ public enum class GraphViewChangedReason
         Windows::UI::Core::CoreCursor ^ m_cachedCursor;
         int m_errorType;
         int m_errorCode;
-        bool m_replot;
+        bool m_resetUsingInitialDisplayRange;
+        double m_initialDisplayRangeXMin;
+        double m_initialDisplayRangeXMax;
+        double m_initialDisplayRangeYMin;
+        double m_initialDisplayRangeYMax;
 
     public:
         Windows::Storage::Streams::RandomAccessStreamReference ^ GetGraphBitmapStream();

--- a/src/GraphingImpl/Mocks/GraphRenderer.h
+++ b/src/GraphingImpl/Mocks/GraphRenderer.h
@@ -98,6 +98,11 @@ namespace MockGraphingImpl
             return S_OK;
         }
 
+        virtual HRESULT PrepareGraph()
+        {
+            return S_OK;
+        }
+
         virtual HRESULT GetBitmap(std::shared_ptr<Graphing::IBitmap>& bitmapOut, bool& hasSomeMissingDataOut)
         {
             bitmapOut = std::make_shared<Bitmap>();

--- a/src/GraphingInterfaces/IGraphRenderer.h
+++ b/src/GraphingInterfaces/IGraphRenderer.h
@@ -23,17 +23,7 @@ namespace Graphing::Renderer
 		virtual HRESULT SetDpi(float dpiX, float dpiY) = 0;
 
 		virtual HRESULT DrawD2D1(ID2D1Factory* pDirect2dFactory, ID2D1RenderTarget* pRenderTarget, bool& hasSomeMissingDataOut) = 0;
-        virtual HRESULT GetClosePointData(
-            double inScreenPointX,
-            double inScreenPointY,
-            int& formulaIdOut,
-            float& xScreenPointOut,
-            float& yScreenPointOut,
-            double& xValueOut,
-            double& yValueOut,
-            double& rhoValueOut,
-            double& thetaValueOut,
-            double& tValueOut) = 0;
+		virtual HRESULT GetClosePointData(double inScreenPointX, double inScreenPointY, int& formulaIdOut, float& xScreenPointOut, float& yScreenPointOut, double& xValueOut, double& yValueOut, double& rhoValueOut, double& thetaValueOut, double& tValueOut) = 0;
 
 		virtual HRESULT ScaleRange(double centerX, double centerY, double scale) = 0;
 		virtual HRESULT ChangeRange(ChangeRangeAction action) = 0;
@@ -41,6 +31,7 @@ namespace Graphing::Renderer
 		virtual HRESULT ResetRange() = 0;
 		virtual HRESULT GetDisplayRanges(double& xMin, double& xMax, double& yMin, double& yMax) = 0;
 		virtual HRESULT SetDisplayRanges(double xMin, double xMax, double yMin, double yMax) = 0;
+		virtual HRESULT PrepareGraph() = 0;
 
 		virtual HRESULT GetBitmap(std::shared_ptr<Graphing::IBitmap>& bitmapOut, bool& hasSomeMissingDataOut) = 0;
 


### PR DESCRIPTION
## Fixes #1187.


### Description of the changes:
- Tracks when we add equations in Manual Adjustment mode
- Conditionally resets using TryPlotGraph or ResetRange depending on whether or not equations were added during Manual Adjustment mode

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manually

