### PR TITLE
Fixing TestHistoryClearCommand Test

### DIFF
--- a/src/CalculatorUnitTests/HistoryTests.cpp
+++ b/src/CalculatorUnitTests/HistoryTests.cpp
@@ -56,18 +56,6 @@ namespace CalculatorFunctionalTests
             m_standardViewModel->ResetCalcManager(false);
         }
 
-        bool IsHistoryContainerEmpty(_In_ String ^ historyContainerKey)
-        {
-            ApplicationDataContainer ^ localSettings = ApplicationData::Current->LocalSettings;
-            return !(localSettings->Containers->HasKey(historyContainerKey));
-        }
-
-        String^ GetHistoryContainerKeyHelper(CalculationManager::CalculatorMode cMode)
-        {
-            ValueType^ modeValue = static_cast<int>(cMode);
-            return String::Concat(modeValue->ToString(), L"_History");
-        }
-
         void AddSingleHistoryItem()
         {
             Initialize();
@@ -189,8 +177,6 @@ namespace CalculatorFunctionalTests
             m_standardViewModel->SendCommandToCalcManager(static_cast<int>(Command::CommandEQU));
             m_historyViewModel->OnClearCommand(nullptr);
             VERIFY_ARE_EQUAL(0, m_historyViewModel->ItemsCount);
-            VERIFY_IS_TRUE(IsHistoryContainerEmpty(GetHistoryContainerKeyHelper(CalculatorMode::Standard)));
-            VERIFY_IS_TRUE(IsHistoryContainerEmpty(GetHistoryContainerKeyHelper(CalculatorMode::Scientific)));
             Cleanup();
         }
 


### PR DESCRIPTION
## Fixes #.


### Description of the changes:
We removed a bunch of unused history code and persistence settings logic which these tests were calling into their own implementation and consuming. This was causing a failing test _**TestHistoryClearCommand**_  in x86, however if you were to wipe out your settings file, you can't repro the test failure.

Essentially this is test debt at this point which causes failed runs with certain settings files.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Automated testing
