### PR TITLE
Replot the graph when the user clicks Graph View after manually updating the graph range

### DIFF
--- a/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
+++ b/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
@@ -100,7 +100,7 @@ void GraphingSettingsViewModel::UpdateDisplayRange()
         return;
     }
 
-    m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue, true);
+    m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue);
 
     TraceLogger::GetInstance()->LogGraphSettingsChanged(GraphSettingsType::Grid, L"");
 }

--- a/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
+++ b/src/CalcViewModel/GraphingCalculator/GraphingSettingsViewModel.cpp
@@ -100,7 +100,7 @@ void GraphingSettingsViewModel::UpdateDisplayRange()
         return;
     }
 
-    m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue);
+    m_Graph->SetDisplayRanges(m_XMinValue, m_XMaxValue, m_YMinValue, m_YMaxValue, true);
 
     TraceLogger::GetInstance()->LogGraphSettingsChanged(GraphSettingsType::Grid, L"");
 }

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -120,11 +120,20 @@ namespace GraphControl
         {
             if (auto renderer = m_graph->GetRenderer())
             {
-                if (SUCCEEDED(renderer->ResetRange()))
+                if (m_replot)
+                {
+                    IsKeepCurrentView = false;
+                    m_replot = false;
+                    TryPlotGraph(false, false);
+
+                }
+                else if (SUCCEEDED(renderer->ResetRange()))
                 {
                     m_renderMain->RunRenderPass();
-                    GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
                 }
+
+                GraphViewChangedEvent(this, GraphViewChangedReason::Reset);
+                return;
             }
         }
     }
@@ -1093,10 +1102,13 @@ optional<vector<shared_ptr<Graphing::IEquation>>> Grapher::TryInitializeGraph(bo
         auto initResult = m_graph->TryInitialize(graphingExp);
         m_graph->GetRenderer()->SetDisplayRanges(xMin, xMax, yMin, yMax);
 
+        m_replot = true;
+
         return initResult;
     }
     else
     {
+        m_replot = false;
         return m_graph->TryInitialize(graphingExp);
     }
 }

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -247,13 +247,14 @@ public enum class GraphViewChangedReason
             }
         }
 
-        void SetDisplayRanges(double xMin, double xMax, double yMin, double yMax)
+        void SetDisplayRanges(double xMin, double xMax, double yMin, double yMax, bool shouldReplot)
         {
             try
             {
                 if (auto render = m_graph->GetRenderer())
                 {
                     render->SetDisplayRanges(xMin, xMax, yMin, yMax);
+                    m_replot = shouldReplot;
                     if (m_renderMain)
                     {
                         m_renderMain->RunRenderPass();
@@ -351,6 +352,7 @@ public enum class GraphViewChangedReason
         Windows::UI::Core::CoreCursor ^ m_cachedCursor;
         int m_errorType;
         int m_errorCode;
+        bool m_replot;
 
     public:
         Windows::Storage::Streams::RandomAccessStreamReference ^ GetGraphBitmapStream();

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -247,14 +247,14 @@ public enum class GraphViewChangedReason
             }
         }
 
-        void SetDisplayRanges(double xMin, double xMax, double yMin, double yMax, bool shouldReplot)
+        void SetDisplayRanges(double xMin, double xMax, double yMin, double yMax)
         {
             try
             {
                 if (auto render = m_graph->GetRenderer())
                 {
                     render->SetDisplayRanges(xMin, xMax, yMin, yMax);
-                    m_replot = shouldReplot;
+                    m_replot = true;
                     if (m_renderMain)
                     {
                         m_renderMain->RunRenderPass();


### PR DESCRIPTION
## Temporary solution to issue #1187

### Description of the changes:
- Replots the graph when the user manually updates the range in Reset Grid

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually, add a graph manually move the range (pan, zoom, graph settings), add an equation, click the graph view button. Tested variations of these steps.

