### PR TITLE
Fix how we calculate the precision in Unit converter and update GetNumberDigitsWholeNumberPart 

### DIFF
--- a/src/CalcManager/NumberFormattingUtils.cpp
+++ b/src/CalcManager/NumberFormattingUtils.cpp
@@ -50,15 +50,15 @@ namespace CalcManager::NumberFormattingUtils
     /// <param name="value">the number</param>
     unsigned int GetNumberDigitsWholeNumberPart(double value)
     {
-        return value == 0 ? 1 : (1 + static_cast<unsigned int>(log10(abs(value))));
+        return value == 0 ? 1u : static_cast<unsigned int>(1 + max(0.0, log10(abs(value))));
     }
 
     /// <summary>
     /// Rounds the given double to the given number of significant digits
     /// </summary>
     /// <param name="num">input double</param>
-    /// <param name="numSignificant">unsigned int number of significant digits to round to</param>
-    wstring RoundSignificantDigits(double num, unsigned int numSignificant)
+    /// <param name="numSignificant">int number of significant digits to round to</param>
+    wstring RoundSignificantDigits(double num, int numSignificant)
     {
         wstringstream out(wstringstream::out);
         out << fixed;

--- a/src/CalcManager/NumberFormattingUtils.cpp
+++ b/src/CalcManager/NumberFormattingUtils.cpp
@@ -57,8 +57,8 @@ namespace CalcManager::NumberFormattingUtils
     /// Rounds the given double to the given number of significant digits
     /// </summary>
     /// <param name="num">input double</param>
-    /// <param name="numSignificant">int number of significant digits to round to</param>
-    wstring RoundSignificantDigits(double num, int numSignificant)
+    /// <param name="numSignificant">unsigned int number of significant digits to round to</param>
+    wstring RoundSignificantDigits(double num, unsigned int numSignificant)
     {
         wstringstream out(wstringstream::out);
         out << fixed;

--- a/src/CalcManager/NumberFormattingUtils.h
+++ b/src/CalcManager/NumberFormattingUtils.h
@@ -10,6 +10,6 @@ namespace CalcManager::NumberFormattingUtils
     void TrimTrailingZeros(_Inout_ std::wstring& input);
     unsigned int GetNumberDigits(std::wstring value);
     unsigned int GetNumberDigitsWholeNumberPart(double value);
-    std::wstring RoundSignificantDigits(double value, int numberSignificantDigits);
+    std::wstring RoundSignificantDigits(double value, unsigned int numberSignificantDigits);
     std::wstring ToScientificNumber(double number);
 }

--- a/src/CalcManager/NumberFormattingUtils.h
+++ b/src/CalcManager/NumberFormattingUtils.h
@@ -10,6 +10,6 @@ namespace CalcManager::NumberFormattingUtils
     void TrimTrailingZeros(_Inout_ std::wstring& input);
     unsigned int GetNumberDigits(std::wstring value);
     unsigned int GetNumberDigitsWholeNumberPart(double value);
-    std::wstring RoundSignificantDigits(double value, unsigned int numberSignificantDigits);
+    std::wstring RoundSignificantDigits(double value, int numberSignificantDigits);
     std::wstring ToScientificNumber(double number);
 }

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -24,7 +24,7 @@ static constexpr uint32_t OPTIMALDIGITSALLOWED = 7U;
 static constexpr wchar_t LEFTESCAPECHAR = L'{';
 static constexpr wchar_t RIGHTESCAPECHAR = L'}';
 
-static const double OPTIMALDECIMALALLOWED = 1e-6; // pow(10, -1 * (OPTIMALDIGITSALLOWED - 1));
+static const double OPTIMALDECIMALALLOWED = 1e-6;  // pow(10, -1 * (OPTIMALDIGITSALLOWED - 1));
 static const double MINIMUMDECIMALALLOWED = 1e-14; // pow(10, -1 * (MAXIMUMDIGITSALLOWED - 1));
 
 unordered_map<wchar_t, wstring> quoteConversions;
@@ -896,7 +896,7 @@ void UnitConverter::Calculate()
             else
             {
                 const unsigned int currentNumberSignificantDigits = GetNumberDigits(m_currentDisplay);
-                int precision;
+                unsigned int precision;
                 if (abs(returnValue) < OPTIMALDECIMALALLOWED)
                 {
                     precision = MAXIMUMDIGITSALLOWED;
@@ -905,7 +905,8 @@ void UnitConverter::Calculate()
                 {
                     // Fewer digits are needed following the decimal if the number is large,
                     // we calculate the number of decimals necessary based on the number of digits in the integer part.
-                    precision = max(0U, max(OPTIMALDIGITSALLOWED, min(MAXIMUMDIGITSALLOWED, currentNumberSignificantDigits)) - numPreDecimal);
+                    auto numberDigits = max(OPTIMALDIGITSALLOWED, min(MAXIMUMDIGITSALLOWED, currentNumberSignificantDigits));
+                    precision = numberDigits > numPreDecimal ? numberDigits - numPreDecimal : 0;
                 }
 
                 m_returnDisplay = RoundSignificantDigits(returnValue, precision);

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -896,7 +896,7 @@ void UnitConverter::Calculate()
             else
             {
                 const unsigned int currentNumberSignificantDigits = GetNumberDigits(m_currentDisplay);
-                unsigned int precision;
+                int precision;
                 if (abs(returnValue) < OPTIMALDECIMALALLOWED)
                 {
                     precision = MAXIMUMDIGITSALLOWED;

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -24,7 +24,7 @@ static constexpr uint32_t OPTIMALDIGITSALLOWED = 7U;
 static constexpr wchar_t LEFTESCAPECHAR = L'{';
 static constexpr wchar_t RIGHTESCAPECHAR = L'}';
 
-static const double OPTIMALDECIMALALLOWED = 1e-6;  // pow(10, -1 * (OPTIMALDIGITSALLOWED - 1));
+static const double OPTIMALDECIMALALLOWED = 1e-6; // pow(10, -1 * (OPTIMALDIGITSALLOWED - 1));
 static const double MINIMUMDECIMALALLOWED = 1e-14; // pow(10, -1 * (MAXIMUMDIGITSALLOWED - 1));
 
 unordered_map<wchar_t, wstring> quoteConversions;

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -970,6 +970,10 @@ namespace CalculatorManagerTest
         VERIFY_ARE_EQUAL(digitsCount, 15);
         digitsCount = GetNumberDigitsWholeNumberPart(324328412837382.232213214324234);
         VERIFY_ARE_EQUAL(digitsCount, 15);
+        digitsCount = GetNumberDigitsWholeNumberPart(0.032);
+        VERIFY_ARE_EQUAL(digitsCount, 1);
+        digitsCount = GetNumberDigitsWholeNumberPart(0.00000000000000000001);
+        VERIFY_ARE_EQUAL(digitsCount, 1);
     }
 
     void CalculatorManagerTest::CalculatorManagerNumberFormattingUtils_RoundSignificantDigits()


### PR DESCRIPTION
## Fixes #1255 


### Description of the changes:
- Fix GetNumberDigitsWholeNumberPart with small numbers (0.0000001 for example)
- Fix how we calculate the precision in Calculate (the unsigned int overflowed when the number was too high and the precision negative)

### How changes were validated:
- manually

