### PR TITLE
Disable x86 build and test in PR builds

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -23,6 +23,7 @@ jobs:
 - template: ./templates/build-app-public.yaml
   parameters:
     platform: x86
+    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
 - template: ./templates/build-app-public.yaml
   parameters:


### PR DESCRIPTION
Now that #721 is fixed because VS 16.6 has been deployed to our build machines, we can revert #846 and go back to building and testing only x64 in PR builds.