### PR TITLE
Pre-Unit conversion work refactor, replace category with categoryID

### DIFF
--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -109,7 +109,7 @@ CategorySelectionInitializer UnitConverter::SetCurrentCategory(const Category& i
     {
         if (m_currentCategory.id != input.id)
         {
-            for (auto& unit : m_categoryToUnits[m_currentCategory])
+            for (auto& unit : m_categoryToUnits[m_currentCategory.id])
             {
                 unit.isConversionSource = (unit.id == m_fromType.id);
                 unit.isConversionTarget = (unit.id == m_toType.id);
@@ -121,7 +121,7 @@ CategorySelectionInitializer UnitConverter::SetCurrentCategory(const Category& i
             }
         }
 
-        newUnitList = m_categoryToUnits[input];
+        newUnitList = m_categoryToUnits[input.id];
     }
 
     InitializeSelectedUnits();
@@ -283,7 +283,7 @@ void UnitConverter::RestoreUserPreferences(wstring_view userPreferences)
     m_currentCategory = StringToCategory(outerTokens[2]);
 
     // Only restore from the saved units if they are valid in the current available units.
-    auto itr = m_categoryToUnits.find(m_currentCategory);
+    auto itr = m_categoryToUnits.find(m_currentCategory.id);
     if (itr != m_categoryToUnits.end())
     {
         const auto& curUnits = itr->second;
@@ -713,10 +713,8 @@ vector<tuple<wstring, Unit>> UnitConverter::CalculateSuggested()
 /// </summary>
 void UnitConverter::ResetCategoriesAndRatios()
 {
-    m_categories = m_dataLoader->LoadOrderedCategories();
-
     m_switchedActive = false;
-
+    m_categories = m_dataLoader->GetOrderedCategories();
     if (m_categories.empty())
     {
         return;
@@ -738,8 +736,8 @@ void UnitConverter::ResetCategoriesAndRatios()
             continue;
         }
 
-        vector<Unit> units = activeDataLoader->LoadOrderedUnits(category);
-        m_categoryToUnits[category] = units;
+        vector<Unit> units = activeDataLoader->GetOrderedUnits(category);
+        m_categoryToUnits[category.id] = units;
 
         // Just because the units are empty, doesn't mean the user can't select this category,
         // we just want to make sure we don't let an unready category be the default.
@@ -789,7 +787,7 @@ void UnitConverter::InitializeSelectedUnits()
         return;
     }
 
-    auto itr = m_categoryToUnits.find(m_currentCategory);
+    auto itr = m_categoryToUnits.find(m_currentCategory.id);
     if (itr == m_categoryToUnits.end())
     {
         return;

--- a/src/CalcManager/UnitConverter.h
+++ b/src/CalcManager/UnitConverter.h
@@ -119,9 +119,9 @@ namespace UnitConversionManager
     class CategoryHash
     {
     public:
-        size_t operator()(const Category& x) const
+        size_t operator()(const int id) const
         {
-            return x.id;
+            return id;
         }
     };
 
@@ -171,7 +171,7 @@ namespace UnitConversionManager
         std::unordered_map<UnitConversionManager::Unit, UnitConversionManager::ConversionData, UnitConversionManager::UnitHash>,
         UnitConversionManager::UnitHash>
         UnitToUnitToConversionDataMap;
-    typedef std::unordered_map<UnitConversionManager::Category, std::vector<UnitConversionManager::Unit>, UnitConversionManager::CategoryHash>
+    typedef std::unordered_map<int, std::vector<UnitConversionManager::Unit>, UnitConversionManager::CategoryHash>
         CategoryToUnitVectorMap;
 
     class IViewModelCurrencyCallback
@@ -190,8 +190,8 @@ namespace UnitConversionManager
     public:
         virtual ~IConverterDataLoader(){};
         virtual void LoadData() = 0; // prepare data if necessary before calling other functions
-        virtual std::vector<Category> LoadOrderedCategories() = 0;
-        virtual std::vector<Unit> LoadOrderedUnits(const Category& c) = 0;
+        virtual std::vector<Category> GetOrderedCategories() = 0;
+        virtual std::vector<Unit> GetOrderedUnits(const Category& c) = 0;
         virtual std::unordered_map<Unit, ConversionData, UnitHash> LoadOrderedRatios(const Unit& u) = 0;
         virtual bool SupportsCategory(const Category& target) = 0;
     };

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -220,14 +220,13 @@ void CurrencyDataLoader::LoadData()
 };
 #pragma optimize("", on)
 
-vector<UCM::Category> CurrencyDataLoader::LoadOrderedCategories()
+vector<UCM::Category> CurrencyDataLoader::GetOrderedCategories()
 {
     // This function should not be called
     // The model will use the categories from UnitConverterDataLoader
     return vector<UCM::Category>();
 }
-
-vector<UCM::Unit> CurrencyDataLoader::LoadOrderedUnits(const UCM::Category& /*category*/)
+vector<UCM::Unit> CurrencyDataLoader::GetOrderedUnits(const UCM::Category& /*category*/)
 {
     lock_guard<mutex> lock(m_currencyUnitsMutex);
     return m_currencyUnits;

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.h
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 #pragma once
@@ -63,8 +63,8 @@ namespace CalculatorApp
 
             // IConverterDataLoader
             void LoadData() override;
-            std::vector<UCM::Category> LoadOrderedCategories() override;
-            std::vector<UCM::Unit> LoadOrderedUnits(const UCM::Category& category) override;
+            std::vector<UCM::Category> GetOrderedCategories() override;
+            std::vector<UCM::Unit> GetOrderedUnits(const UCM::Category& category) override;
             std::unordered_map<UCM::Unit, UCM::ConversionData, UCM::UnitHash> LoadOrderedRatios(const UCM::Unit& unit) override;
             bool SupportsCategory(const UnitConversionManager::Category& target) override;
             // IConverterDataLoader

--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.h
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.h
@@ -32,7 +32,7 @@ namespace CalculatorApp
             int order;
         };
 
-        struct UnitData
+         struct UnitData
         {
             CalculatorApp::Common::ViewMode categoryId;
             int unitId;
@@ -71,8 +71,8 @@ namespace CalculatorApp
         private:
             // IConverterDataLoader
             void LoadData() override;
-            std::vector<UnitConversionManager::Category> LoadOrderedCategories() override;
-            std::vector<UnitConversionManager::Unit> LoadOrderedUnits(const UnitConversionManager::Category& c) override;
+            std::vector<UnitConversionManager::Category> GetOrderedCategories() override;
+            std::vector<UnitConversionManager::Unit> GetOrderedUnits(const UnitConversionManager::Category& c) override;
             std::unordered_map<UnitConversionManager::Unit, UnitConversionManager::ConversionData, UnitConversionManager::UnitHash>
             LoadOrderedRatios(const UnitConversionManager::Unit& unit) override;
             bool SupportsCategory(const UnitConversionManager::Category& target) override;
@@ -87,7 +87,7 @@ namespace CalculatorApp
             std::wstring GetLocalizedStringName(_In_ Platform::String ^ stringId);
 
             std::shared_ptr<std::vector<UnitConversionManager::Category>> m_categoryList;
-            std::shared_ptr<UnitConversionManager::CategoryToUnitVectorMap> m_categoryToUnits;
+            std::shared_ptr<UnitConversionManager::CategoryToUnitVectorMap> m_categoryIDToUnitCollectionMap;
             std::shared_ptr<UnitConversionManager::UnitToUnitToConversionDataMap> m_ratioMap;
             Platform::String ^ m_currentRegionCode;
         };

--- a/src/CalculatorUnitTests/CurrencyConverterUnitTests.cpp
+++ b/src/CalculatorUnitTests/CurrencyConverterUnitTests.cpp
@@ -404,7 +404,7 @@ TEST_METHOD(Loaded_LoadOrderedUnits)
     VERIFY_IS_TRUE(loader.LoadedFromCache());
     VERIFY_IS_FALSE(loader.LoadedFromWeb());
 
-    vector<UCM::Unit> unitList = loader.LoadOrderedUnits(CURRENCY_CATEGORY);
+    vector<UCM::Unit> unitList = loader.GetOrderedUnits(CURRENCY_CATEGORY);
     VERIFY_ARE_EQUAL(size_t{ 2 }, unitList.size());
 
     const UCM::Unit usdUnit = GetUnit(unitList, L"USD");
@@ -434,7 +434,7 @@ TEST_METHOD(Loaded_LoadOrderedRatios)
     VERIFY_IS_TRUE(loader.LoadedFromCache());
     VERIFY_IS_FALSE(loader.LoadedFromWeb());
 
-    vector<UCM::Unit> unitList = loader.LoadOrderedUnits(CURRENCY_CATEGORY);
+    vector<UCM::Unit> unitList = loader.GetOrderedUnits(CURRENCY_CATEGORY);
     VERIFY_ARE_EQUAL(size_t{ 2 }, unitList.size());
 
     const UCM::Unit usdUnit = GetUnit(unitList, L"USD");
@@ -467,7 +467,7 @@ TEST_METHOD(Loaded_GetCurrencySymbols_Valid)
     VERIFY_IS_TRUE(loader.LoadedFromCache());
     VERIFY_IS_FALSE(loader.LoadedFromWeb());
 
-    vector<UCM::Unit> unitList = loader.LoadOrderedUnits(CURRENCY_CATEGORY);
+    vector<UCM::Unit> unitList = loader.GetOrderedUnits(CURRENCY_CATEGORY);
     VERIFY_ARE_EQUAL(size_t{ 2 }, unitList.size());
 
     const UCM::Unit usdUnit = GetUnit(unitList, L"USD");
@@ -506,7 +506,7 @@ TEST_METHOD(Loaded_GetCurrencySymbols_Invalid)
     VERIFY_ARE_EQUAL(wstring(L""), wstring(symbols.second.c_str()));
 
     // Verify that when only one unit is valid, both symbols return as empty string.
-    vector<UCM::Unit> unitList = loader.LoadOrderedUnits(CURRENCY_CATEGORY);
+    vector<UCM::Unit> unitList = loader.GetOrderedUnits(CURRENCY_CATEGORY);
     VERIFY_ARE_EQUAL(size_t{ 2 }, unitList.size());
 
     const UCM::Unit usdUnit = GetUnit(unitList, L"USD");
@@ -539,7 +539,7 @@ TEST_METHOD(Loaded_GetCurrencyRatioEquality_Valid)
     VERIFY_IS_TRUE(loader.LoadedFromCache());
     VERIFY_IS_FALSE(loader.LoadedFromWeb());
 
-    vector<UCM::Unit> unitList = loader.LoadOrderedUnits(CURRENCY_CATEGORY);
+    vector<UCM::Unit> unitList = loader.GetOrderedUnits(CURRENCY_CATEGORY);
     VERIFY_ARE_EQUAL(size_t{ 2 }, unitList.size());
 
     const UCM::Unit usdUnit = GetUnit(unitList, L"USD");
@@ -577,7 +577,7 @@ TEST_METHOD(Loaded_GetCurrencyRatioEquality_Invalid)
     VERIFY_ARE_EQUAL(wstring(L""), ratio.second);
 
     // Verify that when only one unit is valid, both symbols return as empty string.
-    vector<UCM::Unit> unitList = loader.LoadOrderedUnits(CURRENCY_CATEGORY);
+    vector<UCM::Unit> unitList = loader.GetOrderedUnits(CURRENCY_CATEGORY);
     VERIFY_ARE_EQUAL(size_t{ 2 }, unitList.size());
 
     const UCM::Unit usdUnit = GetUnit(unitList, L"USD");

--- a/src/CalculatorUnitTests/UnitConverterTest.cpp
+++ b/src/CalculatorUnitTests/UnitConverterTest.cpp
@@ -60,8 +60,8 @@ namespace UnitConverterUnitTests
             c2units.push_back(u3);
             c2units.push_back(u4);
 
-            m_units[c1] = c1units;
-            m_units[c2] = c2units;
+            m_units[c1.id] = c1units;
+            m_units[c2.id] = c2units;
 
             unordered_map<Unit, ConversionData, UnitHash> unit1Map = unordered_map<Unit, ConversionData, UnitHash>();
             unordered_map<Unit, ConversionData, UnitHash> unit2Map = unordered_map<Unit, ConversionData, UnitHash>();
@@ -99,14 +99,14 @@ namespace UnitConverterUnitTests
             m_loadDataCallCount++;
         }
 
-        vector<Category> LoadOrderedCategories()
+        vector<Category> GetOrderedCategories()
         {
             return m_categories;
         }
 
-        vector<Unit> LoadOrderedUnits(const Category& c)
+        vector<Unit> GetOrderedUnits(const Category& category)
         {
-            return m_units[c];
+            return m_units[category.id];
         }
 
         unordered_map<Unit, ConversionData, UnitHash> LoadOrderedRatios(const Unit& u)


### PR DESCRIPTION
## Fixes #.
Predecessor to https://github.com/microsoft/calculator/issues/379


### Description of the changes:
Removed category as key in category to unit vector map and replaced with category id to reduce memory footprint.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manual testing
Automated Testing

