### PR TITLE
Use NuGet 5.x

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -16,7 +16,7 @@ steps:
     displayName: NuGet restore src/Calculator.sln
     inputs:
       command: custom
-      arguments: restore src/Calculator.sln -Verbosity Detailed -NonInteractive
+      arguments: restore src/Calculator.sln -Verbosity Detailed
 
   - task: PowerShell@2
     displayName: Set version number in AppxManifest

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -5,7 +5,7 @@ parameters:
   extraMsBuildArgs: ''
 
 steps:
-  - task: NuGetToolInstaller@0
+  - task: NuGetToolInstaller@1
     displayName: Use NuGet 5.x
     inputs:
       versionSpec: 5.x

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -6,10 +6,9 @@ parameters:
 
 steps:
   - task: NuGetToolInstaller@0
-    displayName: Use NuGet 5.0.2
+    displayName: Use NuGet 5.x
     inputs:
-      versionSpec: 5.0.2
-      checkLatest: true
+      versionSpec: 5.x
 
   # In most accounts, you can just use 'NuGetCommand' instead of this GUID.
   # In the microsoft.visualstudio.com account, NuGetCommand is ambiguous so the GUID is needed.

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -39,7 +39,7 @@ jobs:
     env:
       XES_DISABLEPROV: true
 
-  - task: NuGetToolInstaller@0
+  - task: NuGetToolInstaller@1
     displayName: Use NuGet 5.x
     inputs:
       versionSpec: 5.x

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -40,10 +40,9 @@ jobs:
       XES_DISABLEPROV: true
 
   - task: NuGetToolInstaller@0
-    displayName: Use NuGet 4.7.1
+    displayName: Use NuGet 5.x
     inputs:
-      versionSpec: 4.7.1
-      checkLatest: true
+      versionSpec: 5.x
 
   - task: DownloadBuildArtifacts@0
     displayName: Download appxBundle artifact


### PR DESCRIPTION
Improve Calculator's use of the NuGetToolInstaller task.

Previously, checkLatest was set to true, so the task would check online for the latest version of NuGet which met the requirements. But we didn't specify a wildcard version, so it always downloaded the exact version we specified anyway.

Instead, just use whatever 5.x version is available on the build agent, as the [documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/tool/nuget?view=azure-devops#arguments) suggests. This should improve performance since the build will spend less time downloading nuget.exe. We are generally cautious about using wildcards to specify versions of our dependencies, but NuGet minor version updates are a relatively small factor in build reproducibility so we'll allow it in this case.