### PR TITLE
Revert accidental changes to UITest projects

### DIFF
--- a/src/CalculatorUITestFramework/CalculatorUITestFramework.csproj
+++ b/src/CalculatorUITestFramework/CalculatorUITestFramework.csproj
@@ -1,8 +1,6 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <UpgradeBackupLocation>C:\Users\v-dapark\Source\Repos\Daniel-Parker\calculator\src\Backup\CalculatorUITestFramework\</UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Appium.WebDriver" Version="4.0.0.6-beta" />

--- a/src/CalculatorUITests/CalculatorUITests.csproj
+++ b/src/CalculatorUITests/CalculatorUITests.csproj
@@ -1,9 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="Current">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <IsPackable>false</IsPackable>
-    <UpgradeBackupLocation>C:\Users\v-dapark\Source\Repos\Daniel-Parker\calculator\src\Backup\CalculatorUITests\</UpgradeBackupLocation>
-    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />


### PR DESCRIPTION
#779 included accidental changes to the UITest project files, presumably from migrating the solution locally in Visual Studio. These should not be checked in to the repo.