### PR TITLE
Check for valid input in min/max/step fields

### DIFF
--- a/src/CalcViewModel/GraphingCalculator/VariableViewModel.h
+++ b/src/CalcViewModel/GraphingCalculator/VariableViewModel.h
@@ -9,6 +9,9 @@
 
 namespace CalculatorApp::ViewModel
 {
+
+inline constexpr int DefaultMinMaxRange = 10;
+
 public
     value struct VariableChangedEventArgs sealed
     {
@@ -40,6 +43,12 @@ public
             {
                 if (m_variable->Min != value)
                 {
+                    if (value >= m_variable->Max)
+                    {
+                        m_variable->Max = value + DefaultMinMaxRange;
+                        RaisePropertyChanged("Max");
+                    }
+
                     m_variable->Min = value;
                     RaisePropertyChanged("Min");
                 }
@@ -72,6 +81,12 @@ public
             {
                 if (m_variable->Max != value)
                 {
+                    if (value <= m_variable->Min)
+                    {
+                        m_variable->Min = value - DefaultMinMaxRange;
+                        RaisePropertyChanged("Min");
+                    }
+
                     m_variable->Max = value;
                     RaisePropertyChanged("Max");
                 }

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -402,6 +402,7 @@ void EquationInputArea::SubmitTextbox(TextBox ^ sender)
     else if (sender->Name == "MinTextBox")
     {
         val = validateDouble(sender->Text, variableViewModel->Min);
+
         variableViewModel->Min = val;
         TraceLogger::GetInstance()->LogVariableSettingsChanged(L"MinTextBox");
     }

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -414,6 +414,13 @@ void EquationInputArea::SubmitTextbox(TextBox ^ sender)
     else if (sender->Name == "StepTextBox")
     {
         val = validateDouble(sender->Text, variableViewModel->Step);
+
+        // Don't allow a value less than or equal to 0 as the step
+        if (val <= 0)
+        {
+            val = variableViewModel->Step;
+        }
+
         variableViewModel->Step = val;
         TraceLogger::GetInstance()->LogVariableSettingsChanged(L"StepTextBox");
     }


### PR DESCRIPTION
## Fixes #1269 and Fixes #1268


### Description of the changes:
- Prevents a value in the step field from being <= 0
- If a value in the min field is greater than the value in max, max changes to the new min value + 10
- If a value in the max field is less than the value in the min field, min changes to the new max value - 10

### How changes were validated:
Manual tests
