### PR TITLE
Fix equations not getting focus after being removed

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cpp
@@ -236,6 +236,13 @@ void EquationInputArea::EquationTextBox_RemoveButtonClicked(Object ^ sender, Rou
         }
 
         Equations->GetAt(lastIndex)->FunctionLabelIndex = m_lastFunctionLabelIndex;
+
+        // Focus the next equation after the one we just removed. There should always be at least one ghost equation,
+        // but check to make sure that there is an equation we can focus in the index where we just removed an equation.
+        if (index < Equations->Size)
+        {
+            FocusEquationTextBox(Equations->GetAt(index));
+        }
     }
 }
 


### PR DESCRIPTION
## Fixes #1123


### Description of the changes:
When an equation is removed, the new equation that now occupies that index gains focus

### How changes were validated:
Manual tests

