### PR TITLE
Fix tracing button not receiving focus after the 'esc' key is used to exit tracing mode

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml.cpp
@@ -635,6 +635,7 @@ void CalculatorApp::GraphingCalculator::ActiveTracing_KeyUp(Windows::UI::Core::C
     if (args->VirtualKey == VirtualKey::Escape)
     {
         GraphingControl->ActiveTracing = false;
+        ActiveTracing->Focus(::FocusState::Programmatic);
         args->Handled = true;
     }
 }


### PR DESCRIPTION
## Fixes #1170


### Description of the changes:
Fix tracing button not receiving focus after the 'esc' key is used to exit tracing mode

### How changes were validated:
Manual tests

