### PR TITLE
Narrator reads incorrect information as “History and Memory list” in Programmer Calculator #1174

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4707,4 +4707,12 @@
     <value>Graph Options</value>
     <comment>Screen reader prompt for the graph options panel</comment>
   </data>
+  <data name="DockPanel_HistoryMemoryLists" xml:space="preserve">
+    <value>History and Memory lists</value>
+    <comment>Automation name for the group of controls for history and memory lists.</comment>
+  </data>
+  <data name="DockPanel_MemoryList" xml:space="preserve">
+    <value>Memory list</value>
+    <comment>Automation name for the group of controls for memory list.</comment>
+  </data>
 </root>

--- a/src/Calculator/Views/Calculator.xaml.cpp
+++ b/src/Calculator/Views/Calculator.xaml.cpp
@@ -71,8 +71,11 @@ void Calculator::LoadResourceStrings()
     m_closeMemoryFlyoutAutomationName = resProvider->GetResourceString(L"MemoryButton_Close");
     m_openHistoryFlyoutAutomationName = resProvider->GetResourceString(L"HistoryButton_Open");
     m_closeHistoryFlyoutAutomationName = resProvider->GetResourceString(L"HistoryButton_Close");
+    m_dockPanelHistoryMemoryLists = resProvider->GetResourceString(L"DockPanel_HistoryMemoryLists");
+    m_dockPanelMemoryList = resProvider->GetResourceString(L"DockPanel_MemoryList");
     AutomationProperties::SetName(MemoryButton, m_openMemoryFlyoutAutomationName);
     AutomationProperties::SetName(HistoryButton, m_openHistoryFlyoutAutomationName);
+    AutomationProperties::SetName(DockPanel, m_dockPanelHistoryMemoryLists);
 }
 
 void Calculator::InitializeHistoryView(_In_ HistoryViewModel ^ historyVM)
@@ -342,6 +345,14 @@ void Calculator::OnModeVisualStateCompleted(_In_ Object ^ sender, _In_ Object ^ 
         {
             AnimateWithoutResult->Begin();
         }
+    }
+    if (IsProgrammer)
+    {
+        AutomationProperties::SetName(DockPanel, m_dockPanelMemoryList);
+    }
+    else
+    {
+        AutomationProperties::SetName(DockPanel, m_dockPanelHistoryMemoryLists);
     }
 }
 

--- a/src/Calculator/Views/Calculator.xaml.h
+++ b/src/Calculator/Views/Calculator.xaml.h
@@ -116,6 +116,8 @@ public
         Platform::String ^ m_closeMemoryFlyoutAutomationName;
         Platform::String ^ m_openHistoryFlyoutAutomationName;
         Platform::String ^ m_closeHistoryFlyoutAutomationName;
+        Platform::String ^ m_dockPanelHistoryMemoryLists;
+        Platform::String ^ m_dockPanelMemoryList;
 
         Windows::UI::Xaml::Controls::PivotItem ^ m_pivotItem;
         bool m_IsDigit = false;


### PR DESCRIPTION

## Fixes #1174 .


### Description of the changes:
- Added 2 string resources.  One for when History and memory lists are both available and another when only memory lists are.
- Loaded the string resources during calculator initialization
- While mode is changed to Programmer, I change the automation name of the Dock panel to "Memory List" as only Memory tab is present in Programmer mode.
- By default the automation name will be "History and Memory lists" to retain current behavior and "Memory list" when switching to Programmer mode.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual testing.  Switched to Programmer mode via Narrator and observed that "Memory list" announcement is made.
- Verified via Inspect that accessible names are changing according to the current mode.


