### PR TITLE
Link to GitHub Repository

### DIFF
--- a/src/Calculator/AboutFlyout.xaml
+++ b/src/Calculator/AboutFlyout.xaml
@@ -38,8 +38,20 @@
                     <Run x:Name="AboutFlyoutVersion"/>
                     <LineBreak/>
                     <Run x:Name="AboutControlCopyrightRun"/>
+                    <LineBreak/>
+                    <LineBreak/>
+                    <Run x:Uid="AboutMITLicense" FontSize="{ThemeResource BodyFontSize}"/>
                 </Paragraph>
             </RichTextBlock>
+
+            <HyperlinkButton x:Name="AboutFlyoutGitHub"
+                             Margin="12,0,12,6"
+                             NavigateUri="https://github.com/microsoft/calculator"
+                             ToolTipService.ToolTip="https://github.com/microsoft/calculator">
+                <TextBlock x:Uid="AboutFlyoutGithub"
+                           FontSize="{ThemeResource BodyFontSize}"
+                           TextWrapping="Wrap"/>
+            </HyperlinkButton>
             <HyperlinkButton x:Name="AboutFlyoutEULA"
                              Margin="12,0,12,6"
                              NavigateUri="https://go.microsoft.com/fwlink/?LinkID=529064"

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4715,4 +4715,12 @@
     <value>Memory list</value>
     <comment>Automation name for the group of controls for memory list.</comment>
   </data>
+  <data name="AboutMITLicense.Text" xml:space="preserve">
+    <value>Windows Calculator is made avaliable under the MIT License. To learn more and contribute, click on the GitHub link below:</value>
+    <comment>Notice of MIT license in about flyout. {Locked="GitHub"}</comment>
+  </data>
+  <data name="AboutFlyoutGithub.Text" xml:space="preserve">
+    <value>The repository on GitHub</value>
+    <comment>{Locked="GitHub"} Link text to GitHub repo</comment>
+  </data>
 </root>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4716,7 +4716,7 @@
     <comment>Automation name for the group of controls for memory list.</comment>
   </data>
   <data name="AboutMITLicense.Text" xml:space="preserve">
-    <value>Windows Calculator is made avaliable under the MIT License. To learn more and contribute, click on the GitHub link below:</value>
+    <value>Windows Calculator is made available under the MIT License. To learn more and contribute, click on the GitHub link below:</value>
     <comment>Notice of MIT license in about flyout. {Locked="GitHub"}</comment>
   </data>
   <data name="AboutFlyoutGithub.Text" xml:space="preserve">


### PR DESCRIPTION
## Fixes #582.
 
I can't put the link in the sentence because of localization (Right to Left languages). I did, however, put it in two different ones? Maybe that works? Also, I'm aware that @karna98 is working on it but that was October 2019.

### Description of the changes:
- A sentence at the top below the copyright statement: "Windows Calculator is made available under the MIT License. To learn more and contribute, click on the GitHub link below:"
- Add a hyperlink button: "[The repository on GitHub](https://github.com/microsoft/calculator)"

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual

P. S. Is there any legal stuff? I mean the name GitHub is probably registered and copyrighted. 