### PR TITLE
Fix accent colour mouse-over

### DIFF
--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -956,7 +956,7 @@
                 <controls:CalculatorButton x:Name="SquareRootButton"
                                            x:Uid="squareRootButton"
                                            Grid.Row="1"
-                                           Style="{StaticResource EmphasizedCalcButtonStyle}"
+                                           Style="{StaticResource SymbolOperatorButtonStyle}"
                                            AutomationProperties.AutomationId="squareRootButton"
                                            ButtonId="Sqrt"
                                            Content="&#xF899;"/>

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -1006,7 +1006,7 @@
                 </Grid.RowDefinitions>
                 <controls:CalculatorButton x:Name="XPower3Button"
                                            x:Uid="xpower3Button"
-                                           Style="{StaticResource SymbolOperatorButtonStyle}"
+                                           Style="{StaticResource EmphasizedCalcButtonStyle}"
                                            AutomationProperties.AutomationId="xpower3Button"
                                            ButtonId="Cube"
                                            Click="ShiftButton_Uncheck"

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
@@ -1001,7 +1001,7 @@
                     <controls:CalculatorButton x:Name="SquareRootButton"
                                                x:Uid="squareRootButton"
                                                Grid.Row="1"
-                                               Style="{StaticResource EmphasizedCalcButtonStyle}"
+                                               Style="{StaticResource SymbolOperatorButtonStyle}"
                                                AutomationProperties.AutomationId="squareRootButton"
                                                ButtonId="Sqrt"
                                                Click="Button_Clicked"
@@ -1062,7 +1062,7 @@
 
                     <controls:CalculatorButton x:Name="XPower3Button"
                                                x:Uid="xpower3Button"
-                                               Style="{StaticResource SymbolOperatorButtonStyle}"
+                                               Style="{StaticResource EmphasizedCalcButtonStyle}"
                                                AutomationProperties.AutomationId="xpower3Button"
                                                ButtonId="Cube"
                                                Click="ShiftButton_Uncheck"


### PR DESCRIPTION
## Fixes #1314.


### Description of the changes:
- Fix the style of the sqrt button from `EmphasizedCalcButtonStyle` to `SymbolOperatorButtonStyle` for constsancy.
![Scientific Mode Squrt](https://user-images.githubusercontent.com/47545798/87624448-a74a7180-c6dc-11ea-8944-78a4ee85fc96.jpg)
_Before_
![Scientific Mode Squrt Fixed](https://user-images.githubusercontent.com/47545798/87624460-b16c7000-c6dc-11ea-9a88-a4592b7477b8.jpg)
_After_

### How changes were validated:
-Manual 
