### PR TITLE
Narrator is not announcing the confirmation after selecting radio button

### DIFF
--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
@@ -29,6 +29,7 @@ namespace CalculatorApp::Common::Automation
         StringReference FunctionRemoved(L"FunctionRemoved");
         StringReference GraphViewBestFitChanged(L"GraphViewBestFitChanged");
         StringReference AlwaysOnTop(L"AlwaysOnTop");
+        StringReference BitShiftRadioButtonContent(L"BitShiftRadioButtonContent");
     }
 }
 
@@ -108,7 +109,10 @@ NarratorAnnouncement ^ CalculatorAnnouncement::GetHistoryClearedAnnouncement(Str
 NarratorAnnouncement ^ CalculatorAnnouncement::GetHistorySlotClearedAnnouncement(String ^ announcement)
 {
     return ref new NarratorAnnouncement(
-        announcement, CalculatorActivityIds::HistorySlotCleared, AutomationNotificationKind::ItemRemoved, AutomationNotificationProcessing::ImportantMostRecent);
+        announcement,
+        CalculatorActivityIds::HistorySlotCleared,
+        AutomationNotificationKind::ItemRemoved,
+        AutomationNotificationProcessing::ImportantMostRecent);
 }
 
 NarratorAnnouncement ^ CalculatorAnnouncement::GetCategoryNameChangedAnnouncement(String ^ announcement)
@@ -174,10 +178,7 @@ NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewChangedAnnouncement(S
 NarratorAnnouncement ^ CalculatorAnnouncement::GetFunctionRemovedAnnouncement(String ^ announcement)
 {
     return ref new NarratorAnnouncement(
-        announcement,
-        CalculatorActivityIds::FunctionRemoved,
-        AutomationNotificationKind::ItemRemoved,
-        AutomationNotificationProcessing::MostRecent);
+        announcement, CalculatorActivityIds::FunctionRemoved, AutomationNotificationKind::ItemRemoved, AutomationNotificationProcessing::MostRecent);
 }
 
 NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewBestFitChangedAnnouncement(Platform::String ^ announcement)
@@ -192,8 +193,14 @@ NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewBestFitChangedAnnounc
 NarratorAnnouncement ^ CalculatorAnnouncement::GetAlwaysOnTopChangedAnnouncement(String ^ announcement)
 {
     return ref new NarratorAnnouncement(
+        announcement, CalculatorActivityIds::AlwaysOnTop, AutomationNotificationKind::ActionCompleted, AutomationNotificationProcessing::ImportantMostRecent);
+}
+
+NarratorAnnouncement ^ CalculatorAnnouncement::GetBitShiftRadioButtonCheckedAnnouncement(String ^ announcement)
+{
+    return ref new NarratorAnnouncement(
         announcement,
-        CalculatorActivityIds::AlwaysOnTop,
+        CalculatorActivityIds::BitShiftRadioButtonContent,
         AutomationNotificationKind::ActionCompleted,
         AutomationNotificationProcessing::ImportantMostRecent);
 }

--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.h
@@ -76,5 +76,7 @@ public
 
         static NarratorAnnouncement ^ GetAlwaysOnTopChangedAnnouncement(Platform::String ^ announcement);
 
+        static NarratorAnnouncement ^ GetBitShiftRadioButtonCheckedAnnouncement(Platform::String ^ announcement);
+
     };
 }

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -252,8 +252,7 @@ void StandardCalculatorViewModel::SetNoParenAddedNarratorAnnouncement()
 {
     if (m_localizedNoRightParenthesisAddedFormat == nullptr)
     {
-        m_localizedNoRightParenthesisAddedFormat =
-            AppResourceProvider::GetInstance()->GetResourceString(CalculatorResourceKeys::NoParenthesisAdded);
+        m_localizedNoRightParenthesisAddedFormat = AppResourceProvider::GetInstance()->GetResourceString(CalculatorResourceKeys::NoParenthesisAdded);
     }
 
     Announcement = CalculatorAnnouncement::GetNoRightParenthesisAddedAnnouncement(m_localizedNoRightParenthesisAddedFormat);
@@ -1004,8 +1003,8 @@ ButtonInfo StandardCalculatorViewModel::MapCharacterToButtonId(char16 ch)
     {
         if (LocalizationSettings::GetInstance().IsLocalizedDigit(ch))
         {
-            result.buttonId = NumbersAndOperatorsEnum::Zero
-                              + static_cast<NumbersAndOperatorsEnum>(ch - LocalizationSettings::GetInstance().GetDigitSymbolFromEnUsDigit('0'));
+            result.buttonId =
+                NumbersAndOperatorsEnum::Zero + static_cast<NumbersAndOperatorsEnum>(ch - LocalizationSettings::GetInstance().GetDigitSymbolFromEnUsDigit('0'));
             result.canSendNegate = true;
         }
     }
@@ -1469,7 +1468,7 @@ void StandardCalculatorViewModel::Recalculate(bool fromHistory)
 bool StandardCalculatorViewModel::IsOpnd(Command command)
 {
     static constexpr Command opnd[] = { Command::Command0, Command::Command1, Command::Command2, Command::Command3, Command::Command4,  Command::Command5,
-                              Command::Command6, Command::Command7, Command::Command8, Command::Command9, Command::CommandPNT };
+                                        Command::Command6, Command::Command7, Command::Command8, Command::Command9, Command::CommandPNT };
 
     return find(begin(opnd), end(opnd), command) != end(opnd);
 }
@@ -1477,9 +1476,9 @@ bool StandardCalculatorViewModel::IsOpnd(Command command)
 bool StandardCalculatorViewModel::IsUnaryOp(Command command)
 {
     static constexpr Command unaryOp[] = { Command::CommandSQRT,  Command::CommandFAC,  Command::CommandSQR,   Command::CommandLOG,
-                                 Command::CommandPOW10, Command::CommandPOWE, Command::CommandLN,    Command::CommandREC,
-                                 Command::CommandSIGN,  Command::CommandSINH, Command::CommandASINH, Command::CommandCOSH,
-                                 Command::CommandACOSH, Command::CommandTANH, Command::CommandATANH, Command::CommandCUB };
+                                           Command::CommandPOW10, Command::CommandPOWE, Command::CommandLN,    Command::CommandREC,
+                                           Command::CommandSIGN,  Command::CommandSINH, Command::CommandASINH, Command::CommandCOSH,
+                                           Command::CommandACOSH, Command::CommandTANH, Command::CommandATANH, Command::CommandCUB };
 
     if (find(begin(unaryOp), end(unaryOp), command) != end(unaryOp))
     {
@@ -1496,9 +1495,8 @@ bool StandardCalculatorViewModel::IsUnaryOp(Command command)
 
 bool StandardCalculatorViewModel::IsTrigOp(Command command)
 {
-    static constexpr Command trigOp[] = {
-        Command::CommandSIN, Command::CommandCOS, Command::CommandTAN, Command::CommandASIN, Command::CommandACOS, Command::CommandATAN
-    };
+    static constexpr Command trigOp[] = { Command::CommandSIN,  Command::CommandCOS,  Command::CommandTAN,
+                                          Command::CommandASIN, Command::CommandACOS, Command::CommandATAN };
 
     return find(begin(trigOp), end(trigOp), command) != end(trigOp);
 }
@@ -1506,7 +1504,7 @@ bool StandardCalculatorViewModel::IsTrigOp(Command command)
 bool StandardCalculatorViewModel::IsBinOp(Command command)
 {
     static constexpr Command binOp[] = { Command::CommandADD, Command::CommandSUB,  Command::CommandMUL, Command::CommandDIV,
-                               Command::CommandEXP, Command::CommandROOT, Command::CommandMOD, Command::CommandPWR };
+                                         Command::CommandEXP, Command::CommandROOT, Command::CommandMOD, Command::CommandPWR };
 
     return find(begin(binOp), end(binOp), command) != end(binOp);
 }
@@ -1695,12 +1693,11 @@ NarratorAnnouncement ^ StandardCalculatorViewModel::GetDisplayUpdatedNarratorAnn
     {
         if (m_localizedButtonPressFeedbackAutomationFormat == nullptr)
         {
-            m_localizedButtonPressFeedbackAutomationFormat = AppResourceProvider::GetInstance()->GetResourceString(CalculatorResourceKeys::ButtonPressFeedbackFormat);
+            m_localizedButtonPressFeedbackAutomationFormat =
+                AppResourceProvider::GetInstance()->GetResourceString(CalculatorResourceKeys::ButtonPressFeedbackFormat);
         }
         announcement = LocalizationStringUtil::GetLocalizedString(
-            m_localizedButtonPressFeedbackAutomationFormat,
-            m_CalculationResultAutomationName,
-            m_feedbackForButtonPress);
+            m_localizedButtonPressFeedbackAutomationFormat, m_CalculationResultAutomationName, m_feedbackForButtonPress);
     }
 
     // Make sure we don't accidentally repeat an announcement.
@@ -1766,4 +1763,9 @@ void StandardCalculatorViewModel::ResetCalcManager(bool clearMemory)
 void StandardCalculatorViewModel::SendCommandToCalcManager(int commandId)
 {
     m_standardCalculatorManager.SendCommand(static_cast<Command>(commandId));
+}
+
+void StandardCalculatorViewModel::SetBitshiftRadioButtonCheckedAnnouncement(Platform::String ^ announcement)
+{
+    Announcement = CalculatorAnnouncement::GetBitShiftRadioButtonCheckedAnnouncement(announcement);
 }

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -267,6 +267,7 @@ namespace CalculatorApp
             void OnMaxDigitsReached();
             void OnBinaryOperatorReceived();
             void OnMemoryItemChanged(unsigned int indexOfMemory);
+            void SetBitshiftRadioButtonCheckedAnnouncement(Platform::String ^ announcement);
 
             Platform::String ^ GetLocalizedStringFormat(Platform::String ^ format, Platform::String ^ displayValue);
             void OnPropertyChanged(Platform::String ^ propertyname);

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4727,4 +4727,20 @@
     <value>Calculator back to full view</value>
     <comment>Announcement to indicate calculator window is now back to full view.</comment>
   </data>
+  <data name="arithmeticShiftButtonSelected" xml:space="preserve">
+    <value>Arithmetic Shift selected</value>
+    <comment>Label for a radio button that toggles arithmetic shift behavior for the shift operations.</comment>
+  </data>
+  <data name="logicalShiftButtonSelected" xml:space="preserve">
+    <value>Logical Shift selected</value>
+    <comment>Label for a radio button that toggles logical shift behavior for the shift operations.</comment>
+  </data>
+  <data name="rotateCircularButtonSelected" xml:space="preserve">
+    <value>Rotate Circular Shift selected</value>
+    <comment>Label for a radio button that toggles rotate circular behavior for the shift operations.</comment>
+  </data>
+  <data name="rotateCarryShiftButtonSelected" xml:space="preserve">
+    <value>Rotate Through Carry Circular Shift selected</value>
+    <comment>Label for a radio button that toggles rotate circular with carry behavior for the shift operations.</comment>
+  </data>
 </root>

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.cpp
@@ -11,6 +11,7 @@
 #include "Controls/CalculatorButton.h"
 #include "Converters/BooleanToVisibilityConverter.h"
 #include "Views/NumberPad.xaml.h"
+#include <CalcViewModel\Common\AppResourceProvider.h>
 
 using namespace std;
 using namespace CalculatorApp;
@@ -27,6 +28,16 @@ CalculatorProgrammerRadixOperators::CalculatorProgrammerRadixOperators()
     : m_isErrorVisualState(false)
 {
     InitializeComponent();
+    LoadResourceStrings();
+}
+
+void CalculatorProgrammerRadixOperators::LoadResourceStrings()
+{
+    auto resProvider = AppResourceProvider::GetInstance();
+    m_arithmeticShiftButtonContent = resProvider->GetResourceString(L"arithmeticShiftButtonSelected");
+    m_logicalShiftButtonContent = resProvider->GetResourceString(L"logicalShiftButtonSelected");
+    m_rotateCircularButtonContent = resProvider->GetResourceString(L"rotateCircularButtonSelected");
+    m_rotateCarryShiftButtonContent = resProvider->GetResourceString(L"rotateCarryShiftButtonSelected");
 }
 
 void CalculatorProgrammerRadixOperators::FlyoutButton_Clicked(_In_ Platform::Object ^ /*sender*/, _In_ Windows::UI::Xaml::RoutedEventArgs ^ /*e*/)
@@ -63,6 +74,7 @@ void CalculatorProgrammerRadixOperators::BitshiftFlyout_Checked(Platform::Object
     CollapseBitshiftButtons();
 
     auto radioButton = static_cast<RadioButton ^>(sender);
+    Platform::String ^ announcementString = L"";
 
     if (radioButton == ArithmeticShiftButton)
     {
@@ -70,6 +82,7 @@ void CalculatorProgrammerRadixOperators::BitshiftFlyout_Checked(Platform::Object
         RshButton->Visibility = ::Visibility::Visible;
         LshButton->IsEnabled = true;
         RshButton->IsEnabled = true;
+        announcementString = m_arithmeticShiftButtonContent;
     }
     else if (radioButton == LogicalShiftButton)
     {
@@ -77,6 +90,7 @@ void CalculatorProgrammerRadixOperators::BitshiftFlyout_Checked(Platform::Object
         RshLogicalButton->Visibility = ::Visibility::Visible;
         LshLogicalButton->IsEnabled = true;
         RshLogicalButton->IsEnabled = true;
+        announcementString = m_logicalShiftButtonContent;
     }
     else if (radioButton == RotateCircularButton)
     {
@@ -84,6 +98,7 @@ void CalculatorProgrammerRadixOperators::BitshiftFlyout_Checked(Platform::Object
         RorButton->Visibility = ::Visibility::Visible;
         RolButton->IsEnabled = true;
         RorButton->IsEnabled = true;
+        announcementString = m_rotateCircularButtonContent;
     }
     else if (radioButton == RotateCarryShiftButton)
     {
@@ -91,9 +106,11 @@ void CalculatorProgrammerRadixOperators::BitshiftFlyout_Checked(Platform::Object
         RorCarryButton->Visibility = ::Visibility::Visible;
         RolCarryButton->IsEnabled = true;
         RorCarryButton->IsEnabled = true;
+        announcementString = m_rotateCarryShiftButtonContent;
     }
 
     this->BitShiftFlyout->Hide();
+    Model->SetBitshiftRadioButtonCheckedAnnouncement(announcementString);
 }
 
 void CalculatorProgrammerRadixOperators::CollapseBitshiftButtons()

--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml.h
@@ -36,10 +36,15 @@ namespace CalculatorApp
         void BitshiftFlyout_Checked(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void FlyoutButton_Clicked(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);
         void CollapseBitshiftButtons();
+        void LoadResourceStrings();
 
         bool m_isErrorVisualState;
         void OpenParenthesisButton_GotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void ClearEntryButton_LostFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
         void ClearButton_LostFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+        Platform::String ^ m_arithmeticShiftButtonContent;
+        Platform::String ^ m_logicalShiftButtonContent;
+        Platform::String ^ m_rotateCircularButtonContent;
+        Platform::String ^ m_rotateCarryShiftButtonContent;
     };
 }


### PR DESCRIPTION
## Fixes #962 .


### Description of the changes:
- Added Resource strings for each radio button in Bit Shift flyout
- Loaded resource strings as part of CalculatorProgrammerRadixOperators construction
- Based on radio button selected, the relevant resource string is passed over to the view model to make the announcement.
- The Announcement property is set in the View Model which being an observed property causes the Narrator announcement.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual testing via Narrator.  Announcements corresponding to the radio button are announced when selected.
-
-

