### PR TITLE
Excessive check for the max value is removed

### DIFF
--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -331,12 +331,6 @@ bool CopyPasteManager::ExpressionRegExMatch(
                     expMatched = false;
                     break;
                 }
-
-                if (operandAsULL->Value > maxOperandLengthAndValue.maxValue)
-                {
-                    expMatched = false;
-                    break;
-                }
             }
         }
 

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -15,6 +15,13 @@ namespace CalculatorUnitTests
 
 namespace CalculatorApp
 {
+public
+    value struct CopyPasteMaxOperandLengthAndValue
+    {
+        unsigned int maxLength;
+        unsigned long long maxValue;
+    };
+
     public ref class CopyPasteManager sealed
     {
     public:
@@ -90,7 +97,7 @@ namespace CalculatorApp
                 CalculatorApp::Common::CategoryGroupType modeType,
                 CalculatorApp::Common::NumberBase programmerNumberBase,
                 CalculatorApp::Common::BitLength bitLengthType);
-        static unsigned int GetMaxOperandLength(
+        static CopyPasteMaxOperandLengthAndValue GetMaxOperandLengthAndValue(
             CalculatorApp::Common::ViewMode mode,
             CalculatorApp::Common::CategoryGroupType modeType,
             CalculatorApp::Common::NumberBase programmerNumberBase,

--- a/src/CalcViewModel/Common/CopyPasteManager.h
+++ b/src/CalcViewModel/Common/CopyPasteManager.h
@@ -15,13 +15,6 @@ namespace CalculatorUnitTests
 
 namespace CalculatorApp
 {
-public
-    value struct CopyPasteMaxOperandLengthAndValue
-    {
-        unsigned int maxLength;
-        unsigned long long maxValue;
-    };
-
     public ref class CopyPasteManager sealed
     {
     public:
@@ -97,7 +90,7 @@ public
                 CalculatorApp::Common::CategoryGroupType modeType,
                 CalculatorApp::Common::NumberBase programmerNumberBase,
                 CalculatorApp::Common::BitLength bitLengthType);
-        static CopyPasteMaxOperandLengthAndValue GetMaxOperandLengthAndValue(
+        static unsigned int GetMaxOperandLength(
             CalculatorApp::Common::ViewMode mode,
             CalculatorApp::Common::CategoryGroupType modeType,
             CalculatorApp::Common::NumberBase programmerNumberBase,

--- a/src/CalculatorUITestFramework/CalculatorResults.cs
+++ b/src/CalculatorUITestFramework/CalculatorResults.cs
@@ -3,6 +3,7 @@
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium.Appium.Windows;
 using System;
+using OpenQA.Selenium.Interactions;
 
 namespace CalculatorUITestFramework
 {
@@ -12,6 +13,8 @@ namespace CalculatorUITestFramework
         private WindowsElement CalculatorAlwaysOnTopResults => this.session.TryFindElementByAccessibilityId("CalculatorAlwaysOnTopResults");
         private WindowsElement CalculatorResult => this.session.TryFindElementByAccessibilityId("CalculatorResults");
         private WindowsElement CalculatorExpression => this.session.TryFindElementByAccessibilityId("CalculatorExpression");
+        private WindowsElement MenuItemCopy => this.session.TryFindElementByAccessibilityId("CopyMenuItem");
+        private WindowsElement MenuItemPaste => this.session.TryFindElementByAccessibilityId("PasteMenuItem");
 
         /// <summary>
         /// Gets the text from the display control in AoT mode and removes the narrator text that is not displayed in the UI.
@@ -60,6 +63,34 @@ namespace CalculatorUITestFramework
             {
                 throw new Exception("The Calculator Expression is not clear");
             }
+        }
+
+        /// <summary>
+        /// Opens the context menu in order to be able to click its items
+        /// </summary>
+        private void OpenContextMenu()
+        {
+            Actions actions = new Actions(CalculatorResult.WrappedDriver);
+            // It is important to move not to the centre in order to avoid click on the text
+            actions.MoveToElement(CalculatorResult, 1,1).ContextClick().Perform();
+        }
+
+        /// <summary>
+        /// Opens the context menu and clicks the "Copy" item there
+        /// </summary>
+        public void ContextMenuItemCopyClick()
+        {
+            OpenContextMenu();
+            MenuItemCopy.Click();
+        }
+
+        /// <summary>
+        /// Opens the context menu and clicks the "Paste" item there
+        /// </summary>
+        public void ContextMenuItemPasteClick()
+        {
+            OpenContextMenu();
+            MenuItemPaste.Click();
         }
     }
 }

--- a/src/CalculatorUITests/ProgrammerModeFunctionalTests.cs
+++ b/src/CalculatorUITests/ProgrammerModeFunctionalTests.cs
@@ -4,9 +4,7 @@
 using CalculatorUITestFramework;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
-using OpenQA.Selenium.Appium.Windows;
 using System;
-using System.Collections.Generic;
 
 namespace CalculatorUITests
 {
@@ -888,6 +886,96 @@ namespace CalculatorUITests
             page.ProgrammerOperators.RoRCarryButton.Click();
             page.StandardOperators.EqualButton.Click();
             Assert.AreEqual("8 0 8", page.CalculatorResults.GetCalculatorResultText());
+        }
+        #endregion
+
+        /// <summary>
+        /// Copy and Paste the numbers into/from the calculator
+        /// </summary>
+        #region Copy-Paste operations
+        [TestMethod]
+        [Priority(1)]
+        public void Copy_And_Paste_Simple_Number()
+        {
+            page.ProgrammerOperators.BitFlip.Click();
+            page.ProgrammerOperators.Bit1.Click();
+            page.CalculatorResults.ContextMenuItemCopyClick();
+            page.ProgrammerOperators.FullKeypad.Click();
+            page.StandardOperators.ClearEntryButton.Click();
+            page.CalculatorResults.ContextMenuItemPasteClick();
+            Assert.AreEqual("2", page.CalculatorResults.GetCalculatorResultText());
+        }
+
+        [TestMethod]
+        [Priority(1)]
+        public void Copy_And_Paste_Invalid_Number()
+        {
+            page.ProgrammerOperators.BitFlip.Click();
+            page.ProgrammerOperators.Bit63.Click();
+            page.CalculatorResults.ContextMenuItemCopyClick();
+            page.ProgrammerOperators.FullKeypad.Click();
+            page.StandardOperators.ClearEntryButton.Click();
+            page.ProgrammerOperators.QWordButton.Click();
+            page.CalculatorResults.ContextMenuItemPasteClick();
+            Assert.AreEqual("Invalid input", page.CalculatorResults.GetCalculatorResultText());
+        }
+
+        [TestMethod]
+        [Priority(1)]
+        public void Copy_And_Paste_Big_QWord_Number()
+        {
+            page.ProgrammerOperators.BitFlip.Click();
+            page.ProgrammerOperators.Bit63.Click();
+            page.CalculatorResults.ContextMenuItemCopyClick();
+            page.ProgrammerOperators.FullKeypad.Click();
+            page.StandardOperators.ClearEntryButton.Click();
+            page.CalculatorResults.ContextMenuItemPasteClick();
+            Assert.AreEqual("-9,223,372,036,854,775,808", page.CalculatorResults.GetCalculatorResultText());
+        }
+
+        [TestMethod]
+        [Priority(1)]
+        public void Copy_And_Paste_Big_DWord_Number()
+        {
+            page.ProgrammerOperators.QWordButton.Click();
+            page.ProgrammerOperators.BitFlip.Click();
+            page.ProgrammerOperators.Bit31.Click();
+            page.CalculatorResults.ContextMenuItemCopyClick();
+            page.ProgrammerOperators.FullKeypad.Click();
+            page.StandardOperators.ClearEntryButton.Click();
+            page.CalculatorResults.ContextMenuItemPasteClick();
+            Assert.AreEqual("-2,147,483,648", page.CalculatorResults.GetCalculatorResultText());
+        }
+
+        [TestMethod]
+        [Priority(1)]
+        public void Copy_And_Paste_Big_Word_Number()
+        {
+            page.ProgrammerOperators.QWordButton.Click();
+            page.ProgrammerOperators.DWordButton.Click();
+            page.ProgrammerOperators.BitFlip.Click();
+            page.ProgrammerOperators.Bit15.Click();
+            page.CalculatorResults.ContextMenuItemCopyClick();
+            page.ProgrammerOperators.FullKeypad.Click();
+            page.StandardOperators.ClearEntryButton.Click();
+            page.CalculatorResults.ContextMenuItemPasteClick();
+            Assert.AreEqual("-32,768", page.CalculatorResults.GetCalculatorResultText());
+        }
+
+        [TestMethod]
+        [Priority(1)]
+        public void Copy_And_Paste_Big_Byte_Number()
+        {
+            page.ProgrammerOperators.QWordButton.Click();
+            page.ProgrammerOperators.DWordButton.Click();
+            page.ProgrammerOperators.WordButton.Click();
+            page.ProgrammerOperators.BitFlip.Click();
+            page.ProgrammerOperators.Bit7.Click();
+            page.CalculatorResults.ContextMenuItemCopyClick();
+            page.ProgrammerOperators.FullKeypad.Click();
+            page.StandardOperators.ClearEntryButton.Click();
+            page.CalculatorResults.ContextMenuItemPasteClick();
+            Assert.AreEqual("-128", page.CalculatorResults.GetCalculatorResultText());
         }
         #endregion
     }


### PR DESCRIPTION
## Fixes #1301 .
It reproduces both for QWORD numbers (as mentioned in the report) and for WORD numbers (e.g. -32768).

The root cause of the issue has been an incorrect validation of the pasted data.
When user is trying to insert quite a big negative number, the validator `CopyPasteManager::ExpressionRegExMatch` calculates both the maximum bits length and the maximum unsigned long value for it.
However, casting signed negative long to the unsigned long by this check leads to exceeding of the maximum value.

### Description of the changes:
I have removed the check for the maximum value since there are already precedence checks for the maximum bits length `OperandLength(...) > maxOperandLength` and `TryOperandToULL(...) != nullptr` which throw the error if "the operand was empty, received invalid_argument, or received out_of_range".

### How changes were validated:
- The changes were tested by manual testing on 4 types of numbers: QWORD, DWORD, WORD, BYTE.
- Additional unit tests have been written to cover these scenarios. Now there are automatic tests for the copy/paste context menu which were absent by the moment.
