### PR TITLE
Improved error handing for function analysis for functions in the f(y) format

### DIFF
--- a/build/pipelines/templates/build-app-internal.yaml
+++ b/build/pipelines/templates/build-app-internal.yaml
@@ -29,7 +29,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsInboxApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.49
+      vstsPackageVersion: 0.0.50
 
   - template: ./build-single-architecture.yaml
     parameters:

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -80,7 +80,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsInboxApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.49
+      vstsPackageVersion: 0.0.50
 
   - powershell: |
       # Just modify this line to indicate where your en-us PDP file is. Leave the other lines alone.

--- a/src/CalcViewModel/GraphingCalculator/EquationViewModel.cpp
+++ b/src/CalcViewModel/GraphingCalculator/EquationViewModel.cpp
@@ -63,6 +63,10 @@ namespace CalculatorApp::ViewModel
             {
                 AnalysisErrorString = m_resourceLoader->GetString(L"KGFAnalysisNotSupported");
             }
+            else if (graphEquation->AnalysisError == static_cast<int>(AnalysisErrorType::VariableIsNotX))
+            {
+                AnalysisErrorString = m_resourceLoader->GetString(L"KGFVariableIsNotX");
+            }
             return;
         }
 

--- a/src/CalcViewModel/GraphingCalculatorEnums.h
+++ b/src/CalcViewModel/GraphingCalculatorEnums.h
@@ -23,6 +23,7 @@ namespace CalculatorApp
     {
         NoError,
         AnalysisCouldNotBePerformed,
-        AnalysisNotSupported
+        AnalysisNotSupported,
+        VariableIsNotX
     };
 }

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4071,6 +4071,10 @@
     <value>Analysis is not supported for this function.</value>
     <comment>Error displayed when graph analysis is not supported or had an error.</comment>
   </data>
+    <data name="KGFVariableIsNotX" xml:space="preserve">
+    <value>Analysis is only supported for functions in the f(x) format. Example: y=x</value>
+    <comment>Error displayed when graph analysis detects the function format is not f(x).</comment>
+  </data>
   <data name="Maxima" xml:space="preserve">
     <value>Maxima</value>
     <comment>Title for KeyGraphFeatures Maxima Property</comment>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4071,7 +4071,7 @@
     <value>Analysis is not supported for this function.</value>
     <comment>Error displayed when graph analysis is not supported or had an error.</comment>
   </data>
-    <data name="KGFVariableIsNotX" xml:space="preserve">
+  <data name="KGFVariableIsNotX" xml:space="preserve">
     <value>Analysis is only supported for functions in the f(x) format. Example: y=x</value>
     <comment>Error displayed when graph analysis detects the function format is not f(x).</comment>
   </data>

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -255,12 +255,11 @@ namespace GraphControl
                 equationVector.push_back(equation);
                 UpdateGraphOptions(graph->GetOptions(), equationVector);
                 bool variableIsNotX;
-                if (analyzer->CanFunctionAnalysisBePerformed(variableIsNotX))
+                if (analyzer->CanFunctionAnalysisBePerformed(variableIsNotX) && !variableIsNotX)
                 {
                     if (S_OK
                         == analyzer->PerformFunctionAnalysis(
-                            (Graphing::Analyzer::NativeAnalysisType)Graphing::Analyzer::PerformAnalysisType::PerformAnalysisType_All)
-                        && !variableIsNotX)
+                            (Graphing::Analyzer::NativeAnalysisType)Graphing::Analyzer::PerformAnalysisType::PerformAnalysisType_All))
                     {
                         Graphing::IGraphFunctionAnalysisData functionAnalysisData = m_solver->Analyze(analyzer.get());
                         return KeyGraphFeaturesInfo::Create(functionAnalysisData);

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -254,16 +254,21 @@ namespace GraphControl
                 vector<Equation ^> equationVector;
                 equationVector.push_back(equation);
                 UpdateGraphOptions(graph->GetOptions(), equationVector);
-
-                if (analyzer->CanFunctionAnalysisBePerformed())
+                bool variableIsNotX;
+                if (analyzer->CanFunctionAnalysisBePerformed(variableIsNotX))
                 {
                     if (S_OK
                         == analyzer->PerformFunctionAnalysis(
-                            (Graphing::Analyzer::NativeAnalysisType)Graphing::Analyzer::PerformAnalysisType::PerformAnalysisType_All))
+                            (Graphing::Analyzer::NativeAnalysisType)Graphing::Analyzer::PerformAnalysisType::PerformAnalysisType_All)
+                        && !variableIsNotX)
                     {
                         Graphing::IGraphFunctionAnalysisData functionAnalysisData = m_solver->Analyze(analyzer.get());
                         return KeyGraphFeaturesInfo::Create(functionAnalysisData);
                     }
+                }
+                else if (variableIsNotX)
+                {
+                    return KeyGraphFeaturesInfo::Create(CalculatorApp::AnalysisErrorType::VariableIsNotX);
                 }
                 else
                 {

--- a/src/GraphingInterfaces/IGraphAnalyzer.h
+++ b/src/GraphingInterfaces/IGraphAnalyzer.h
@@ -16,7 +16,7 @@ namespace Graphing::Analyzer
 	struct IGraphAnalyzer : public NonCopyable, public NonMoveable
 	{
 		virtual ~IGraphAnalyzer() = default;
-		virtual bool CanFunctionAnalysisBePerformed() = 0;
+        virtual bool CanFunctionAnalysisBePerformed(bool& variableIsNotX) = 0;
 		virtual HRESULT PerformFunctionAnalysis(NativeAnalysisType analysisType) = 0;
 		virtual HRESULT GetAnalysisTypeCaption(const AnalysisType type, std::wstring& captionOut) const = 0;
 		virtual HRESULT GetMessage(const GraphAnalyzerMessage msg, std::wstring& msgOut) const = 0;

--- a/src/GraphingInterfaces/IGraphAnalyzer.h
+++ b/src/GraphingInterfaces/IGraphAnalyzer.h
@@ -15,10 +15,10 @@ namespace Graphing::Analyzer
 
 	struct IGraphAnalyzer : public NonCopyable, public NonMoveable
 	{
-		virtual ~IGraphAnalyzer() = default;
+        virtual ~IGraphAnalyzer() = default;
         virtual bool CanFunctionAnalysisBePerformed(bool& variableIsNotX) = 0;
-		virtual HRESULT PerformFunctionAnalysis(NativeAnalysisType analysisType) = 0;
-		virtual HRESULT GetAnalysisTypeCaption(const AnalysisType type, std::wstring& captionOut) const = 0;
-		virtual HRESULT GetMessage(const GraphAnalyzerMessage msg, std::wstring& msgOut) const = 0;
+        virtual HRESULT PerformFunctionAnalysis(NativeAnalysisType analysisType) = 0;
+        virtual HRESULT GetAnalysisTypeCaption(const AnalysisType type, std::wstring& captionOut) const = 0;
+        virtual HRESULT GetMessage(const GraphAnalyzerMessage msg, std::wstring& msgOut) const = 0;
 	};
 }


### PR DESCRIPTION
## Fixes #1277.


### Description of the changes:
- Updated the CanFunctionAnalysisBePerformed to use the updated API that returns if the variable is not x
- Added a new error string to inform the user the function is in the incorrect format for function analysis

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually, verified f(x) works as expected, f(x) with variables works as expected, f(y) returns an error with the new string
