### PR TITLE
Update CI trigger to point at release/* branches

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -6,11 +6,11 @@
 
 trigger:
 - master
-- servicing/*
+- release/*
 - feature/*
 pr:
 - master
-- servicing/*
+- release/*
 - feature/*
 
 name: 0.$(Date:yyMM).$(DayOfMonth)$(Rev:rr).0


### PR DESCRIPTION
The servicing/* branches in this repository have been renamed to release/*.

"release" is a better name because we use these branches mostly for stabilizing a release before shipping. Using these branches for "servicing" (patching) releases that have already shipped is less common. Also, we think "release" will be more widely understood.

Update CI builds to trigger on check-ins to release/* branches.