### PR TITLE
Enable keyboard entry in bit-toggling mode #478

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -132,7 +132,7 @@ StandardCalculatorViewModel::StandardCalculatorViewModel()
     IsOperandEnabled = true;
     IsNegateEnabled = true;
     IsDecimalEnabled = true;
-    AreProgrammerRadixOperatorsEnabled = false;
+    AreProgrammerRadixOperatorsVisible = false;
 }
 
 String ^ StandardCalculatorViewModel::LocalizeDisplayValue(_In_ wstring const& displayValue)

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -76,7 +76,7 @@ namespace CalculatorApp
             OBSERVABLE_PROPERTY_R(CalculatorApp::Common::NumberBase, CurrentRadixType);
             OBSERVABLE_PROPERTY_R(bool, AreTokensUpdated);
             OBSERVABLE_PROPERTY_R(bool, AreAlwaysOnTopResultsUpdated);
-            OBSERVABLE_PROPERTY_R(bool, AreProgrammerRadixOperatorsEnabled);
+            OBSERVABLE_PROPERTY_R(bool, AreProgrammerRadixOperatorsVisible);
             OBSERVABLE_PROPERTY_R(bool, IsInputEmpty);
             OBSERVABLE_PROPERTY_R(CalculatorApp::Common::Automation::NarratorAnnouncement ^, Announcement);
             OBSERVABLE_PROPERTY_R(unsigned int, OpenParenthesisCount);
@@ -103,7 +103,7 @@ namespace CalculatorApp
                     {
                         m_isBitFlipChecked = value;
                         IsBinaryBitFlippingEnabled = IsProgrammer && m_isBitFlipChecked;
-                        AreProgrammerRadixOperatorsEnabled = IsProgrammer && !m_isBitFlipChecked;
+                        AreProgrammerRadixOperatorsVisible = IsProgrammer && !m_isBitFlipChecked;
                         RaisePropertyChanged(L"IsBitFlipChecked");
                     }
                 }
@@ -178,7 +178,7 @@ namespace CalculatorApp
                             IsBitFlipChecked = false;
                         }
                         IsBinaryBitFlippingEnabled = m_isProgrammer && IsBitFlipChecked;
-                        AreProgrammerRadixOperatorsEnabled = m_isProgrammer && !IsBitFlipChecked;
+                        AreProgrammerRadixOperatorsVisible = m_isProgrammer && !IsBitFlipChecked;
                         if (value)
                         {
                             IsStandard = false;

--- a/src/Calculator/Views/OperatorsPanel.xaml
+++ b/src/Calculator/Views/OperatorsPanel.xaml
@@ -27,8 +27,8 @@
 
         <local:CalculatorProgrammerRadixOperators x:Name="ProgrammerRadixOperators"
                                                   TabIndex="16"
-                                                  Visibility="{x:Bind Model.AreProgrammerRadixOperatorsEnabled, Mode=OneWay}"
-                                                  IsEnabled="{x:Bind Model.AreProgrammerRadixOperatorsEnabled, Mode=OneWay}"
+                                                  Visibility="{x:Bind Model.AreProgrammerRadixOperatorsVisible, Mode=OneWay}"
+                                                  IsEnabled="{x:Bind Model.IsProgrammer, Mode=OneWay}"
                                                   x:Load="False"/>
 
     </Grid>


### PR DESCRIPTION
## Fixes #478.


### Description of the changes:
The programmer radix buttons were being disabled when the bit flip panel was selected, causing the appropriate keyboard events to be ignored.
They should actually only be hidden in bit flip mode but still enabled.

- Corrected programmer radix buttons to continue being enabled just hidden when the programmer calculator is in bit flip mode.
- Renamed AreProgrammerRadixOperatorsEnabled property to the more appropriate AreProgrammerRadixOperatorsVisible.

### How changes were validated:
- Manually tested each of the keyboard shortcuts from the programmer radix buttons while in bit-toggling mode, made sure to test that the dynamically disabled buttons (e.g. A,B,C.. etc in non-hex mode) behaviour is consistent when non in bit-toggling mode.