### PR TITLE
'Keep on top' button appears last in the tab order (#1339)

### DIFF
--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -142,6 +142,7 @@
                     AutomationProperties.AutomationId="NormalAlwaysOnTopButton"
                     Click="AlwaysOnTopButtonClick"
                     Content="&#xEE49;"
+                    TabIndex="3"
                     Visibility="{x:Bind Model.DisplayNormalAlwaysOnTopOption, Mode=OneWay}">
                 <Button.KeyboardAccelerators>
                     <KeyboardAccelerator Key="Up" Modifiers="Menu"/>


### PR DESCRIPTION
## Fixes #1339.

### Description of the changes:
The 'Keep on top' button did not have the tab ordering set so it was last in the tab order.
- Added TabIndex to AlwaysOnTop button

### How changes were validated:
- Manually tested that the tab order is now correct on the standard calculator mode
- Manually tested that the tab order is unchanged in the other calculator modes