### PR TITLE
Update internals package to 0.0.49

### DIFF
--- a/build/pipelines/templates/build-app-internal.yaml
+++ b/build/pipelines/templates/build-app-internal.yaml
@@ -29,7 +29,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsInboxApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.45
+      vstsPackageVersion: 0.0.49
 
   - template: ./build-single-architecture.yaml
     parameters:

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -80,7 +80,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsInboxApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.45
+      vstsPackageVersion: 0.0.49
 
   - powershell: |
       # Just modify this line to indicate where your en-us PDP file is. Leave the other lines alone.


### PR DESCRIPTION
Update the internals package to 0.0.49. This fixes a build break in the internal GraphingImpl project.