### PR TITLE
Fixes issue #1404

### DIFF
--- a/src/CalcViewModel/UnitConverterViewModel.h
+++ b/src/CalcViewModel/UnitConverterViewModel.h
@@ -187,7 +187,7 @@ namespace CalculatorApp
                         auto currentCategory = value->GetModelCategory();
                         IsCurrencyCurrentCategory = currentCategory.id == CalculatorApp::Common::NavCategory::Serialize(CalculatorApp::Common::ViewMode::Currency);
                     }
-                    OnPropertyChanged("CurrentCategory");
+                    RaisePropertyChanged("CurrentCategory");
                 }
             }
 


### PR DESCRIPTION
## Fixes #1404 

### Description of the changes:
- When the unit converter's category is changed, the corresponding property setter for the `CurrentCategory` variable mistakenly calls `OnPropertyChanged("CurrentCategory")` instead of `RaisePropertyChanged("CurrentCategory")`. This results in a failure to notify XAML that the `CurrentCategory` variable has changed, resulting in the corresponding UI to not be updated accordingly.

### How changes were validated:
- Manual testing.

