### PR TITLE
fix: change floppy disk size

### DIFF
--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -822,7 +822,7 @@ void UnitConverterDataLoader::GetConversionData(_In_ unordered_map<ViewMode, uno
                                                    { ViewMode::Data, UnitConverterUnits::Data_Zebibytes, 1180591620717411.303424 },
                                                    { ViewMode::Data, UnitConverterUnits::Data_Yobibits, 151115727451828646.838272 },
                                                    { ViewMode::Data, UnitConverterUnits::Data_Yobibytes, 1208925819614629174.706176 },
-                                                   { ViewMode::Data, UnitConverterUnits::Data_FloppyDisk, 1.509949 },
+                                                   { ViewMode::Data, UnitConverterUnits::Data_FloppyDisk, 1.474560 },
                                                    { ViewMode::Data, UnitConverterUnits::Data_CD, 734.003200 },
                                                    { ViewMode::Data, UnitConverterUnits::Data_DVD, 5046.586573 },
 

--- a/src/CalculatorUnitTests/Test.resw
+++ b/src/CalculatorUnitTests/Test.resw
@@ -262,7 +262,7 @@
         <value>1208925819614629174.706176</value>
     </data>
     <data name="Megabytes-floppy disks">
-        <value>1.509949</value>
+        <value>1.474560</value>
     </data>
     <data name="Megabytes-CDs">
         <value>734.003200</value>


### PR DESCRIPTION
## Fixes #.
Fixed floppy disk size to real. It is 1474560 bytes for standard 3,5' floppy (https://en.wikipedia.org/wiki/Floppy_disk)

### Description of the changes:
-
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

