### PR TITLE
Enable nightly flighting

### DIFF
--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -4,6 +4,13 @@
 # Store and the Windows image. This pipeline relies on Microsoft-internal resources to run.
 #
 
+schedules:
+- cron: "0 7 * * *"
+  displayName: Daily midnight build
+  branches:
+    include:
+    - master
+
 trigger: none
 pr: none
 

--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -134,6 +134,8 @@ jobs:
       skipPolling: true
       targetPublishMode: Immediate
       logPath: '$(SBLogPath)'
+      deletePackages: true
+      numberOfPackagesToKeep: 0
 
   - task: PkgESStoreBrokerAeroUpload@10
     displayName: Upload to Aero flighting dashboard


### PR DESCRIPTION
Update release pipeline to include a nightly schedule and to delete previous packages (so that we can avoid having to update the stub version for each flight) when flighting to the team ring.