### PR TITLE
Improvements to CI pipeline

### DIFF
--- a/build/pipelines/templates/build-app-internal.yaml
+++ b/build/pipelines/templates/build-app-internal.yaml
@@ -16,11 +16,9 @@ jobs:
   variables:
     BuildConfiguration: Release
     BuildPlatform: ${{ parameters.platform }}
-  workspace:
-    clean: outputs
   steps:
   - checkout: self
-    clean: true
+    fetchDepth: 1
 
   - task: UniversalPackages@0
     displayName: Download internals package

--- a/build/pipelines/templates/build-app-public.yaml
+++ b/build/pipelines/templates/build-app-public.yaml
@@ -14,10 +14,8 @@ jobs:
   variables:
     BuildConfiguration: Release
     BuildPlatform: ${{ parameters.platform }}
-  workspace:
-    clean: outputs
   steps:
   - checkout: self
-    clean: true
+    fetchDepth: 1
   
   - template: ./build-single-architecture.yaml

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -32,7 +32,6 @@ steps:
       msbuildArgs: /bl:$(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\Calculator.binlog /p:OutDir=$(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\ /p:GenerateProjectSpecificOutputFolder=true /p:AppVersion=$(Build.BuildNumber) /t:Publish /p:PublishDir=$(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\publish\ ${{ parameters.extraMsBuildArgs }}
       platform: $(BuildPlatform)
       configuration: $(BuildConfiguration)
-      clean: true
       maximumCpuCount: true
 
   - task: PublishBuildArtifacts@1

--- a/build/pipelines/templates/package-appxbundle.yaml
+++ b/build/pipelines/templates/package-appxbundle.yaml
@@ -19,13 +19,11 @@ jobs:
     ) 
   pool:
     vmImage: windows-2019
-  workspace:
-    clean: outputs
   variables:
     skipComponentGovernanceDetection: true
   steps:
   - checkout: self
-    clean: true
+    fetchDepth: 1
 
   - task: DownloadBuildArtifacts@0
     displayName: Download all .appx artifacts


### PR DESCRIPTION
Various improvements to the CI pipeline

- git shallow fetch, since we only need the latest commit in the pipeline
- don't run the MSBuild 'Clean' target or tell Azure Pipelines to clean up its workspace. Since we build on a fresh VM image every time, this isn't necessary