### PR TITLE
Changed output of GetCurrentRadix to uint32_t match the variable type of m_radix

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -1045,7 +1045,7 @@ bool CCalcEngine::IsCurrentTooBigForTrig()
     return m_currentVal >= m_maxTrigonometricNum;
 }
 
-int CCalcEngine::GetCurrentRadix()
+uint32_t CCalcEngine::GetCurrentRadix()
 {
     return m_radix;
 }

--- a/src/CalcManager/CalculatorManager.cpp
+++ b/src/CalcManager/CalculatorManager.cpp
@@ -534,7 +534,7 @@ namespace CalculationManager
         vector<wstring> resultVector;
         for (auto const& memoryItem : m_memorizedNumbers)
         {
-            int radix = m_currentCalculatorEngine->GetCurrentRadix();
+            auto radix = m_currentCalculatorEngine->GetCurrentRadix();
             wstring stringValue = m_currentCalculatorEngine->GetStringForDisplay(memoryItem, radix);
 
             if (!stringValue.empty())

--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -77,7 +77,7 @@ public:
     }
     void SettingsChanged();
     bool IsCurrentTooBigForTrig();
-    int GetCurrentRadix();
+    uint32_t GetCurrentRadix();
     std::wstring GetCurrentResultForRadix(uint32_t radix, int32_t precision, bool groupDigitsPerRadix);
     void ChangePrecision(int32_t precision)
     {


### PR DESCRIPTION
## Fixes #.
The m_radix variable in the CCalcEngine class is a uint32_t variable. However, it is returned as an int, despite the only cases of this variable being used expect the variable to be a uint32_t. Because of this, I changed the return type of GetCurrentRadix() to be uint32_t.

### Description of the changes:
- Changed GetCurrentRadix() to be uint32_t
- Changed variable being assigned the returned value of GetCurrentRadix to auto
- Changed the function prototype to match the above as well

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual testing
- Passed all tests

