### PR TITLE
Switch agent pool for internal releases

### DIFF
--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -12,7 +12,7 @@ jobs:
 - job: WindowsInternalRelease
   dependsOn: Package
   pool:
-    name: Package ES Lab E
+    name: Package ES Standard Build
   workspace:
     clean: outputs
   variables:


### PR DESCRIPTION
Switch the "WindowsInternalRelease" job to run on a newer internal pool with more capacity.