### PR TITLE
switch to use policy manager apis for detecting graphing policy

### DIFF
--- a/src/CalcViewModel/Common/NavCategory.cpp
+++ b/src/CalcViewModel/Common/NavCategory.cpp
@@ -53,22 +53,6 @@ wchar_t* towchar_t(int number)
     return _wcsdup(wstr.c_str());
 }
 
-extern "C"
-{
-    WINADVAPI LSTATUS APIENTRY RegGetValueW(
-        _In_ HKEY hkey,
-        _In_opt_ LPCWSTR lpSubKey,
-        _In_opt_ LPCWSTR lpValue,
-        _In_ DWORD dwFlags,
-        _Out_opt_ LPDWORD pdwType,
-        _When_(
-            (dwFlags & 0x7F) == RRF_RT_REG_SZ || (dwFlags & 0x7F) == RRF_RT_REG_EXPAND_SZ || (dwFlags & 0x7F) == (RRF_RT_REG_SZ | RRF_RT_REG_EXPAND_SZ)
-                || *pdwType == REG_SZ || *pdwType == REG_EXPAND_SZ,
-            _Post_z_) _When_((dwFlags & 0x7F) == RRF_RT_REG_MULTI_SZ || *pdwType == REG_MULTI_SZ, _Post_ _NullNull_terminated_)
-            _Out_writes_bytes_to_opt_(*pcbData, *pcbData) PVOID pvData,
-        _Inout_opt_ LPDWORD pcbData);
-}
-
 bool IsGraphingModeAvailable()
 {
     static bool supportGraph = Windows::Foundation::Metadata::ApiInformation::IsMethodPresent("Windows.UI.Text.RichEditTextDocument", "GetMath");

--- a/src/CalcViewModel/pch.h
+++ b/src/CalcViewModel/pch.h
@@ -41,6 +41,7 @@
 #include "winrt/Windows.System.UserProfile.h"
 #include "winrt/Windows.UI.Xaml.h"
 #include "winrt/Windows.Foundation.Metadata.h"
+#include "winrt/Windows.Management.Policies.h"
 
 // The following namespaces exist as a convenience to resolve
 // ambiguity for Windows types in the Windows::UI::Xaml::Automation::Peers


### PR DESCRIPTION
## Fixes #1425.


### Description of the changes:
- In NavCategory.cpp, update the use the Policy Manager APIs instead of the registry to look up the AllowGraphingCalculator policy.
-Since the AllowGraphingCalculator policy is a user policy, we get the users and look up the policy using the Education area and AllowGraphingCalculator with the GetPolicyFromPathForUser Policy Manager API: https://docs.microsoft.com/en-us/uwp/api/windows.management.policies.namedpolicy.getpolicyfrompathforuser?view=winrt-19041
### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually using Group Policy to validate the new method still picks up the policy value.

