### PR TITLE
Now that Bug 23811901 has been fixed, adding Test Method 'KeyboardInp…

### DIFF
--- a/src/CalculatorUITests/StandardModeFunctionalTests.cs
+++ b/src/CalculatorUITests/StandardModeFunctionalTests.cs
@@ -362,6 +362,31 @@ namespace CalculatorUITests
             Assert.IsNotNull(WinAppDriver.Instance.CalculatorSession.FindElementByAccessibilityId("MemoryPaneEmpty")); //verifies the Memory panel's memory clear button hotkey
         }
 
+        [TestMethod]
+        [Priority(1)]
+        public void KeyboardInput_HistoryHotkeys()
+        {
+            //Verifies history buttons
+            CalculatorApp.EnsureCalculatorHasFocus();
+            CalculatorApp.Window.SendKeys("4");
+            CalculatorApp.Window.SendKeys(Keys.Multiply);
+            CalculatorApp.Window.SendKeys("5");
+            CalculatorApp.Window.SendKeys(Keys.Divide);
+            CalculatorApp.Window.SendKeys("6");
+            CalculatorApp.Window.SendKeys(Keys.Equal);
+            page.HistoryPanel.ResizeWindowToDisplayHistoryButton();
+            CalculatorApp.Window.SendKeys(Keys.Control + "h" + Keys.Control);
+            var historyFlyoutItems = page.HistoryPanel.GetAllHistoryFlyoutListViewItems();
+            Assert.IsTrue(historyFlyoutItems[0].GetValue().Equals("3.333333333333333", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
+            Assert.IsTrue(historyFlyoutItems[0].GetExpression().Equals("4   ×   5   ÷   6 =", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
+            page.HistoryPanel.ResizeWindowToDisplayHistoryLabel();
+            var historyItems = page.HistoryPanel.GetAllHistoryListViewItems();
+            Assert.IsTrue(historyItems[0].GetValue().Equals("3.333333333333333", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems[0].GetExpression().Equals("4   ×   5   ÷   6 =", StringComparison.InvariantCultureIgnoreCase));
+            CalculatorApp.Window.SendKeys(Keys.Shift + Keys.Control + "d" + Keys.Control + Keys.Shift);
+            Assert.IsNotNull(WinAppDriver.Instance.CalculatorSession.FindElementByAccessibilityId("HistoryEmpty")); //verifies the History panel's clear history button hotkeys
+        }
+
         #endregion
 
         #region Arithmetic Operators Functionality via Mixed Input

--- a/src/CalculatorUITests/StandardModeFunctionalTests.cs
+++ b/src/CalculatorUITests/StandardModeFunctionalTests.cs
@@ -5,6 +5,7 @@ using CalculatorUITestFramework;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OpenQA.Selenium;
 using System;
+using System.Text.RegularExpressions;
 
 namespace CalculatorUITests
 {
@@ -372,17 +373,18 @@ namespace CalculatorUITests
             CalculatorApp.Window.SendKeys(Keys.Multiply);
             CalculatorApp.Window.SendKeys("5");
             CalculatorApp.Window.SendKeys(Keys.Divide);
-            CalculatorApp.Window.SendKeys("6");
+            CalculatorApp.Window.SendKeys("2");
             CalculatorApp.Window.SendKeys(Keys.Equal);
             page.HistoryPanel.ResizeWindowToDisplayHistoryButton();
             CalculatorApp.Window.SendKeys(Keys.Control + "h" + Keys.Control);
             var historyFlyoutItems = page.HistoryPanel.GetAllHistoryFlyoutListViewItems();
-            Assert.IsTrue(historyFlyoutItems[0].GetValue().Equals("3.333333333333333", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
-            Assert.IsTrue(historyFlyoutItems[0].GetExpression().Equals("4   ×   5   ÷   6 =", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
+            var historyExpression = Regex.Replace(historyFlyoutItems[0].GetExpression(), @"\s", string.Empty);
+            Assert.IsTrue(historyFlyoutItems[0].GetValue().Equals("10", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
+            Assert.IsTrue(historyExpression.Equals("4×5÷2=", StringComparison.InvariantCultureIgnoreCase)); //verifies History button hotkeys
             page.HistoryPanel.ResizeWindowToDisplayHistoryLabel();
             var historyItems = page.HistoryPanel.GetAllHistoryListViewItems();
-            Assert.IsTrue(historyItems[0].GetValue().Equals("3.333333333333333", StringComparison.InvariantCultureIgnoreCase));
-            Assert.IsTrue(historyItems[0].GetExpression().Equals("4   ×   5   ÷   6 =", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems[0].GetValue().Equals("10", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyExpression.Equals("4×5÷2=", StringComparison.InvariantCultureIgnoreCase));
             CalculatorApp.Window.SendKeys(Keys.Shift + Keys.Control + "d" + Keys.Control + Keys.Shift);
             Assert.IsNotNull(WinAppDriver.Instance.CalculatorSession.FindElementByAccessibilityId("HistoryEmpty")); //verifies the History panel's clear history button hotkeys
         }


### PR DESCRIPTION
Now that #744 has been fixed, I'm adding Test Method "KeyboardInput_HistoryHotkeys" to test the functionality of history hotkeys such as [Shift] + [Ctrl] + [D] to help prevent a regression or a break.

### Description of the changes:
- Added Test Method "KeyboardInput_HistoryHotkeys" to the "Basic Calculator Functionality via Keyboard Input Tests" region in StandardModeFunctionalTests.cs

### How changes were validated:
I ran the test a few times, and it passed

