### PR TITLE
Fix copy-pasting result computed by the calculator gives "Invalid input"

### DIFF
--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -502,23 +502,32 @@ ULONG32 CopyPasteManager::StandardScientificOperandLength(Platform::String ^ ope
 {
     auto operandWstring = wstring(operand->Data());
     const bool hasDecimal = operandWstring.find('.') != wstring::npos;
+    auto length = operandWstring.length();
 
     if (hasDecimal)
     {
-        if (operandWstring.length() >= 2)
+        if (length >= 2)
         {
             if ((operandWstring[0] == L'0') && (operandWstring[1] == L'.'))
             {
-                return static_cast<ULONG32>(operandWstring.length() - 2);
+                length -= 2;
             }
             else
             {
-                return static_cast<ULONG32>(operandWstring.length() - 1);
+                length -= 1;
             }
         }
     }
 
-    return static_cast<ULONG32>(operandWstring.length());
+    auto exponentPos = operandWstring.find('e');
+    const bool hasExponent = exponentPos != wstring::npos;
+    if (hasExponent)
+    {
+        auto expLength = operandWstring.substr(exponentPos).length();
+        length -= expLength;
+    }
+
+    return static_cast<ULONG32>(length);
 }
 
 ULONG32 CopyPasteManager::ProgrammerOperandLength(Platform::String ^ operand, NumberBase numberBase)

--- a/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
+++ b/src/CalculatorUnitTests/CopyPasteManagerTest.cpp
@@ -825,9 +825,13 @@ namespace CalculatorUnitTests
                                      L"12^2",
                                      L"-12.12^-2",
                                      L"61%99"
-                                     L"-6.1%99" };
+                                     L"-6.1%99",
+                                     L"1.1111111111111111111111111111111e+1142" };
         String
             ^ negativeInput[] = { L"abcdef", L"xyz",   L"ABab", L"e+234", L"123456789123456781234567890123456" /*boundary condition: greater than 32 digits*/,
+                                  L"11.1111111111111111111111111111111e+1142",
+                                  L"1.1e+10001", /*boundary condition: exponent greater than 5 digits*/
+                                  L"0.11111111111111111111111111111111111e+111111" /*boundary condition: both exponent and non exponent exceed limits*/
                                   L"SIN(2)", L"2+2==", L"2=+2" };
 
         ASSERT_POSITIVE_TESTCASES(ValidateScientificPasteExpression, positiveInput);


### PR DESCRIPTION
## Fixes #1407 
This pull request fixes copy paste issue with exponential numbers. 

The root cause of the issue has been an incorrect validation of the pasted data.
When a user tries to enter a big exponential number (eg. 1.1111111111111111111111111111111e+1142). The length of entire number is compared with maximum operand length. Only the length of mantissa should be compared with max operand length.

### Description of the changes:
- While calculating operand length for standard and scientific modes, if the operand contains exponent then subtract exponent string length from operand length.

### How changes were validated:
- Application was manually tested with inputs having exponential component
- Additional positive and negative unit test inputs have been added to CopyPasteManagerTest.cpp