### PR TITLE
Add link to GitHub repo on about flyout

### DIFF
--- a/src/Calculator/AboutFlyout.xaml
+++ b/src/Calculator/AboutFlyout.xaml
@@ -76,7 +76,7 @@
         <RichTextBlock x:Name="AboutFlyoutContribute"
                        Grid.Row="2"
                        Grid.ColumnSpan="2"
-                       Margin="12,10,12,6"
+                       Margin="12,18,12,6"
                        HorizontalAlignment="Left"
                        Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
                        FontSize="{ThemeResource BodyFontSize}"

--- a/src/Calculator/AboutFlyout.xaml
+++ b/src/Calculator/AboutFlyout.xaml
@@ -14,6 +14,7 @@
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto"/>
@@ -72,5 +73,21 @@
                     Click="FeedbackButton_Click"/>
 
         </StackPanel>
+        <RichTextBlock x:Name="AboutFlyoutContribute"
+                       Grid.Row="2"
+                       Grid.ColumnSpan="2"
+                       Margin="12,10,12,6"
+                       HorizontalAlignment="Left"
+                       Foreground="{ThemeResource SystemControlPageTextBaseHighBrush}"
+                       FontSize="{ThemeResource BodyFontSize}"
+                       TextWrapping="Wrap">
+            <Paragraph>
+                <Run x:Name="ContributeRunBeforeLink"/><Hyperlink NavigateUri="https://go.microsoft.com/fwlink/?linkid=2099939"
+                           TextDecorations="None"
+                           ToolTipService.ToolTip="https://go.microsoft.com/fwlink/?linkid=2099939">
+                    <Run x:Name="ContributeRunLink"/>
+                </Hyperlink><Run x:Name="ContributeRunAfterLink"/>
+            </Paragraph>
+        </RichTextBlock>
     </Grid>
 </UserControl>

--- a/src/Calculator/AboutFlyout.xaml.cpp
+++ b/src/Calculator/AboutFlyout.xaml.cpp
@@ -40,6 +40,8 @@ AboutFlyout::AboutFlyout()
     auto copyrightText =
         LocalizationStringUtil::GetLocalizedString(resourceLoader->GetResourceString("AboutControlCopyright"), StringReference(to_wstring(BUILD_YEAR).c_str()));
     AboutControlCopyrightRun->Text = copyrightText;
+
+    InitializeContributeTextBlock();
 }
 
 void AboutFlyout::FeedbackButton_Click(_In_ Object ^ sender, _In_ RoutedEventArgs ^ e)
@@ -60,4 +62,31 @@ void AboutFlyout::SetVersionString()
 void AboutFlyout::SetDefaultFocus()
 {
     AboutFlyoutEULA->Focus(::FocusState::Programmatic);
+}
+
+void AboutFlyout::InitializeContributeTextBlock()
+{
+    auto resProvider = AppResourceProvider::GetInstance();
+    std::wstring contributeHyperlinkText = resProvider->GetResourceString(L"AboutFlyoutContribute")->Data();
+
+    // The resource string has the 'GitHub' hyperlink wrapped with '%HL%'.
+    // Break the string and assign pieces appropriately.
+    static const std::wstring delimiter{ L"%HL%" };
+    static const size_t delimiterLength{ delimiter.length() };
+
+    // Find the delimiters.
+    size_t firstSplitPosition = contributeHyperlinkText.find(delimiter, 0);
+    assert(firstSplitPosition != std::wstring::npos);
+    size_t secondSplitPosition = contributeHyperlinkText.find(delimiter, firstSplitPosition + 1);
+    assert(secondSplitPosition != std::wstring::npos);
+    size_t hyperlinkTextLength = secondSplitPosition - (firstSplitPosition + delimiterLength);
+
+    // Assign pieces.
+    auto contributeTextBeforeHyperlink = ref new String(contributeHyperlinkText.substr(0, firstSplitPosition).c_str());
+    auto contributeTextLink = ref new String(contributeHyperlinkText.substr(firstSplitPosition + delimiterLength, hyperlinkTextLength).c_str());
+    auto contributeTextAfterHyperlink = ref new String(contributeHyperlinkText.substr(secondSplitPosition + delimiterLength).c_str());
+
+    ContributeRunBeforeLink->Text = contributeTextBeforeHyperlink;
+    ContributeRunLink->Text = contributeTextLink;
+    ContributeRunAfterLink->Text = contributeTextAfterHyperlink;
 }

--- a/src/Calculator/AboutFlyout.xaml.h
+++ b/src/Calculator/AboutFlyout.xaml.h
@@ -18,5 +18,6 @@ public
     private:
         void FeedbackButton_Click(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::RoutedEventArgs ^ e);
         void SetVersionString();
+        void InitializeContributeTextBlock();
     };
 } /* namespace CalculatorApp */

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -2718,7 +2718,7 @@
     <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutFlyoutContribute" xml:space="preserve">
-    <value>Windows Calculator is made available under the MIT license. To learn more and contribute, check out the project on %HL%GitHub%HL%.</value>
+    <value>To learn how you can contribute to Windows Calculator, check out the project on %HL%GitHub%HL%.</value>
     <comment>{Locked="%HL%GitHub%HL%"}. GitHub link, Displayed on the About panel</comment>
   </data>
   <data name="AboutButton.Content" xml:space="preserve">

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -2717,6 +2717,10 @@
     <value>© %1 Microsoft. All rights reserved.</value>
     <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
+  <data name="AboutFlyoutContribute" xml:space="preserve">
+    <value>Windows Calculator is made available under the MIT license. To learn more and contribute, check out the project on %HL%GitHub%HL%.</value>
+    <comment>{Locked="%HL%GitHub%HL%"}. GitHub link, Displayed on the About panel</comment>
+  </data>
   <data name="AboutButton.Content" xml:space="preserve">
     <value>About</value>
     <comment>The text that shows in the dropdown navigation control to open About panel</comment>

--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -28,6 +28,7 @@
         <Style x:Key="AboutFlyoutPresenterStyle" TargetType="FlyoutPresenter">
             <Setter Property="IsTabStop" Value="False"/>
             <Setter Property="AutomationProperties.AccessibilityView" Value="Raw"/>
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled"/>
         </Style>
         <Style x:Key="NavViewItemStyle" TargetType="muxc:NavigationViewItem">
             <Setter Property="KeyTipPlacementMode" Value="Right"/>
@@ -174,18 +175,18 @@
 
             <muxc:NavigationView.PaneFooter>
                 <muxc:NavigationViewItem x:Name="AboutButton"
-                                                     x:Uid="AboutButton"
-                                                     Style="{StaticResource NavViewItemStyle}"
-                                             Tapped="OnAboutButtonClick">
+                                         x:Uid="AboutButton"
+                                         Style="{StaticResource NavViewItemStyle}"
+                                         Tapped="OnAboutButtonClick">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xe946;"/>
                     </muxc:NavigationViewItem.Icon>
                     <FlyoutBase.AttachedFlyout>
                         <Flyout x:Name="AboutPageFlyout"
-                                            x:Uid="AboutPageFlyout"
-                                            Closed="OnAboutFlyoutClosed"
-                                            FlyoutPresenterStyle="{StaticResource AboutFlyoutPresenterStyle}"
-                                            Opened="OnAboutFlyoutOpened">
+                                x:Uid="AboutPageFlyout"
+                                Closed="OnAboutFlyoutClosed"
+                                FlyoutPresenterStyle="{StaticResource AboutFlyoutPresenterStyle}"
+                                Opened="OnAboutFlyoutOpened">
                             <local:AboutFlyout x:Name="AboutPage" x:Load="False"/>
                         </Flyout>
                     </FlyoutBase.AttachedFlyout>


### PR DESCRIPTION
## Fixes #582
Display link to the GitHub repo on the about flyout. Implementation is similar to link shown in currency converter mode when application is offline. (Offline. Please check your%HL%Network Settings%HL%)

### Description of the changes:
- Add  learn more and contribute string in en-us resource.
- Display link below feedback button in About Flyout.
- Disable ScrollViewer.HorizontalScrollBarVisibility so that text wraps properly.

<img src="https://user-images.githubusercontent.com/10975439/101289507-e2079000-37ca-11eb-8475-10f6ce170f2e.png" alt="About Page" width="400">

### How changes were validated:
- Manually tested.