### PR TITLE
Fixed an issue where keyboard focus navigates twice at Domain value

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
+++ b/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
@@ -177,7 +177,9 @@
                                         <ColumnDefinition Width="Auto" MinWidth="64"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <controls:MathRichEditBox Style="{StaticResource KGF_RichEditBoxStyle}" MathText="{x:Bind Expression}"/>
+                                    <controls:MathRichEditBox Style="{StaticResource KGF_RichEditBoxStyle}"
+                                                              IsTabStop="False"
+                                                              MathText="{x:Bind Expression}"/>
                                     <TextBlock Grid.Column="1"
                                                Margin="0,-2,0,0"
                                                HorizontalAlignment="Left"

--- a/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
+++ b/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
@@ -169,7 +169,7 @@
                     <TextBlock x:Name="TitleTextBlock"
                                Style="{StaticResource KGF_TitleTextBlockStyle}"
                                Text="{x:Bind Title, Mode=OneWay}"/>
-                    <ItemsControl ItemsSource="{x:Bind GridItems, Mode=OneWay}" UseSystemFocusVisuals="True">
+                    <ItemsControl ItemsSource="{x:Bind GridItems, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="vm:GridDisplayItems">
                                 <Grid VerticalAlignment="Center">
@@ -177,9 +177,7 @@
                                         <ColumnDefinition Width="Auto" MinWidth="64"/>
                                         <ColumnDefinition Width="Auto"/>
                                     </Grid.ColumnDefinitions>
-                                    <controls:MathRichEditBox Style="{StaticResource KGF_RichEditBoxStyle}"
-                                                              IsTabStop="False"
-                                                              MathText="{x:Bind Expression}"/>
+                                    <controls:MathRichEditBox Style="{StaticResource KGF_RichEditBoxStyle}" MathText="{x:Bind Expression}"/>
                                     <TextBlock Grid.Column="1"
                                                Margin="0,-2,0,0"
                                                HorizontalAlignment="Left"


### PR DESCRIPTION
## Fixes #1389.


### Description of the changes:
- This change sets the `UseSystemFocusVisuals` property to false in the KeyGraphFeaturesControls template.

### How changes were validated:
Unfortunately, I was not able to get the KeyGraphFeaturesControl to show up in debug mode, but after looking at the XAML, I am fairly sure this change will fix the issue.
