### PR TITLE
Handle Space and Enter KeyDown event for About button

### DIFF
--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -177,6 +177,7 @@
                 <muxc:NavigationViewItem x:Name="AboutButton"
                                          x:Uid="AboutButton"
                                          Style="{StaticResource NavViewItemStyle}"
+                                         KeyDown="OnAboutButtonKeyDown"
                                          Tapped="OnAboutButtonClick">
                     <muxc:NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource CalculatorFontFamily}" Glyph="&#xe946;"/>

--- a/src/Calculator/Views/MainPage.xaml.cpp
+++ b/src/Calculator/Views/MainPage.xaml.cpp
@@ -432,6 +432,14 @@ void MainPage::OnAboutButtonClick(Object ^ sender, ItemClickEventArgs ^ e)
     ShowAboutPage();
 }
 
+void MainPage::OnAboutButtonKeyDown(Object ^ sender, KeyRoutedEventArgs ^ e)
+{
+    if (e->Key == VirtualKey::Space || e->Key == VirtualKey::Enter)
+    {
+        ShowAboutPage();
+    }
+}
+
 void MainPage::OnAboutFlyoutOpened(_In_ Object ^ sender, _In_ Object ^ e)
 {
     // Keep Ignoring Escape till the About page flyout is opened

--- a/src/Calculator/Views/MainPage.xaml.h
+++ b/src/Calculator/Views/MainPage.xaml.h
@@ -55,6 +55,7 @@ public
             _In_ Microsoft::UI::Xaml::Controls::NavigationViewItemInvokedEventArgs ^ e);
 
         void OnAboutButtonClick(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::Controls::ItemClickEventArgs ^ e);
+        void OnAboutButtonKeyDown(_In_ Platform::Object ^ sender, _In_ Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e);
         void OnAboutFlyoutOpened(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e);
         void OnAboutFlyoutClosed(_In_ Platform::Object ^ sender, _In_ Platform::Object ^ e);
         void AlwaysOnTopButtonClick(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);


### PR DESCRIPTION
## Fixes #1461: ‘About’ menu item is not getting activated via keyboard using Enter or Space key


### Description of the changes:
- Add `OnKeyDown` event handler to open about flyout when clicking Enter or Space with AboutButton selected

### How changes were validated:
Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually tested

