### PR TITLE
fix bug: No confirmation is announced by the narrator after activating 'Remove equation' button #1386

### DIFF
--- a/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
+++ b/src/CalcViewModel/Common/Automation/NarratorAnnouncement.cpp
@@ -178,7 +178,7 @@ NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewChangedAnnouncement(S
 NarratorAnnouncement ^ CalculatorAnnouncement::GetFunctionRemovedAnnouncement(String ^ announcement)
 {
     return ref new NarratorAnnouncement(
-        announcement, CalculatorActivityIds::FunctionRemoved, AutomationNotificationKind::ItemRemoved, AutomationNotificationProcessing::MostRecent);
+        announcement, CalculatorActivityIds::FunctionRemoved, AutomationNotificationKind::ItemRemoved, AutomationNotificationProcessing::ImportantMostRecent);
 }
 
 NarratorAnnouncement ^ CalculatorAnnouncement::GetGraphViewBestFitChangedAnnouncement(Platform::String ^ announcement)


### PR DESCRIPTION
## Fixes #1386 .
Changing AutomationNotificationProcessing from `MostRecent` to `ImportantMostRecent` to prevent this confirmation messages being superseded by the incoming announcement requests.

Target issue: #1386

### Description of the changes:
- Uses `ImportantMostRecent` instead of `MostRecent` for function removing announcement.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
1. Launch Calculator app.
1. Turn on the narrator.
1. Navigate Open navigation button and activate it.
1. Navigate to graphing calculator list item and activate it.
1. Navigate to Enter a expression edit box.
1. Enter any expression say "7+8".
1. Now open context menu and activate "Remove equation" button.
1. Check that the confirmation - 'Function Removed' - is announced by Narrator.

