### PR TITLE
Add headers missing for compilation with GCC

### DIFF
--- a/src/CalcManager/CEngine/History.cpp
+++ b/src/CalcManager/CEngine/History.cpp
@@ -4,6 +4,7 @@
 #include "Header Files/CalcEngine.h"
 #include "Command.h"
 #include "ExpressionCommand.h"
+#include "winerror_cross_platform.h"
 
 constexpr int ASCII_0 = 48;
 

--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -13,7 +13,9 @@
 * Author:
 \****************************************************************************/
 
+#include <iomanip>
 #include <string>
+#include <sstream>
 #include "Header Files/CalcEngine.h"
 #include "Header Files/CalcUtils.h"
 #include "NumberFormattingUtils.h"

--- a/src/CalcManager/CEngine/scifunc.cpp
+++ b/src/CalcManager/CEngine/scifunc.cpp
@@ -17,6 +17,7 @@
 /***                                                                    ***/
 /**************************************************************************/
 #include "Header Files/CalcEngine.h"
+#include "winerror_cross_platform.h"
 
 using namespace std;
 using namespace CalcEngine;

--- a/src/CalcManager/ExpressionCommandInterface.h
+++ b/src/CalcManager/ExpressionCommandInterface.h
@@ -6,6 +6,7 @@
 #include <memory> // for std::shared_ptr
 #include <vector>
 #include "Command.h"
+#include "sal_cross_platform.h"
 
 class ISerializeCommandVisitor;
 

--- a/src/CalcManager/NumberFormattingUtils.h
+++ b/src/CalcManager/NumberFormattingUtils.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <string>
+#include "sal_cross_platform.h"
 
 namespace CalcManager::NumberFormattingUtils
 {


### PR DESCRIPTION
Things that required such update included:
* `wstringstream`
* `setprecision`
* `SCODE_CODE`, `E_BOUNDS`
* Various SAL macros