### PR TITLE
Turn off DFS in internal build system

### DIFF
--- a/build/pipelines/templates/prepare-release-internalonly.yaml
+++ b/build/pipelines/templates/prepare-release-internalonly.yaml
@@ -34,6 +34,7 @@ jobs:
     inputs:
       productName: Calculator
       disableWorkspace: true
+      useDfs: false
     env:
       XES_DISABLEPROV: true
 


### PR DESCRIPTION
Configure the internal build system to avoid doing unnecessary work during the Calculator release pipeline.