### PR TITLE
Fixed a graphing calculator "permissions" bug caused by PR #1426

### DIFF
--- a/src/CalcViewModel/Common/NavCategory.cpp
+++ b/src/CalcViewModel/Common/NavCategory.cpp
@@ -60,7 +60,7 @@ bool IsGraphingModeAvailable()
 }
 
 Box<bool> ^ _isGraphingModeEnabledCached = nullptr;
-bool IsGraphingModeEnabled(User ^ firstUser = nullptr)
+bool IsGraphingModeEnabled(User ^ currentUser = nullptr)
 {
     if (!IsGraphingModeAvailable())
     {
@@ -72,12 +72,12 @@ bool IsGraphingModeEnabled(User ^ firstUser = nullptr)
         return _isGraphingModeEnabledCached->Value;
     }
 
-    if (!firstUser)
+    if (!currentUser)
     {
-        return false;
+        return true;
     }
 
-    auto namedPolicyData = NamedPolicy::GetPolicyFromPathForUser(firstUser, L"Education", L"AllowGraphingCalculator");
+    auto namedPolicyData = NamedPolicy::GetPolicyFromPathForUser(currentUser, L"Education", L"AllowGraphingCalculator");
     _isGraphingModeEnabledCached = namedPolicyData->GetBoolean() == true;
 
     return _isGraphingModeEnabledCached->Value;
@@ -280,9 +280,21 @@ static list<NavCategoryInitializer> s_categoryManifest = [] {
 
 void NavCategory::InitializeCategoryManifest(User ^ user)
 {
-    auto navCatInit = s_categoryManifest.begin();
-    std::advance(navCatInit, 2);
-    (*navCatInit).isEnabled = IsGraphingModeEnabled(user);
+    int i = 0;
+    for (NavCategoryInitializer category : s_categoryManifest)
+    {
+        if (category.viewMode == ViewMode::Graphing)
+        {
+            auto navCatInit = s_categoryManifest.begin();
+            std::advance(navCatInit, i);
+            (*navCatInit).isEnabled = IsGraphingModeEnabled(user);
+            break;
+        }
+        else
+        {
+            i++;
+        }
+    }
  }
 
 // This function should only be used when storing the mode to app data.

--- a/src/CalcViewModel/Common/NavCategory.h
+++ b/src/CalcViewModel/Common/NavCategory.h
@@ -59,15 +59,15 @@ namespace CalculatorApp
     private
         struct NavCategoryInitializer
         {
-            NavCategoryInitializer(
+            constexpr NavCategoryInitializer(
                 ViewMode mode,
                 int id,
-                wchar_t * name,
-                wchar_t * nameKey,
-                wchar_t * glyph,
+                wchar_t const* name,
+                wchar_t const* nameKey,
+                wchar_t const* glyph,
                 CategoryGroupType group,
                 MyVirtualKey vKey,
-                wchar_t * aKey,
+                wchar_t const* aKey,
                 bool categorySupportsNegative,
                 bool enabled)
                 : viewMode(mode)
@@ -83,22 +83,22 @@ namespace CalculatorApp
             {
             }
 
-            ViewMode viewMode;
-            int serializationId;
-            wchar_t* friendlyName;
-            wchar_t* nameResourceKey;
-            wchar_t* glyph;
-            CategoryGroupType groupType;
-            MyVirtualKey virtualKey;
-            wchar_t* accessKey;
-            bool supportsNegative;
+            const ViewMode viewMode;
+            const int serializationId;
+            const wchar_t* const friendlyName;
+            const wchar_t* const nameResourceKey;
+            const wchar_t* const glyph;
+            const CategoryGroupType groupType;
+            const MyVirtualKey virtualKey;
+            const wchar_t* const accessKey;
+            const bool supportsNegative;
             bool isEnabled;
         };
 
     private
         struct NavCategoryGroupInitializer
         {
-            NavCategoryGroupInitializer(CategoryGroupType t, wchar_t * h, wchar_t * n, wchar_t * a)
+            constexpr NavCategoryGroupInitializer(CategoryGroupType t, wchar_t const* h, wchar_t const* n, wchar_t const* a)
                 : type(t)
                 , headerResourceKey(h)
                 , modeResourceKey(n)
@@ -106,10 +106,10 @@ namespace CalculatorApp
             {
             }
 
-            CategoryGroupType type;
-            wchar_t* headerResourceKey;
-            wchar_t* modeResourceKey;
-            wchar_t* automationResourceKey;
+            const CategoryGroupType type;
+            const wchar_t* headerResourceKey;
+            const wchar_t* modeResourceKey;
+            const wchar_t* automationResourceKey;
         };
 
         [Windows::UI::Xaml::Data::Bindable] public ref class NavCategory sealed : public Windows::UI::Xaml::Data::INotifyPropertyChanged
@@ -140,7 +140,7 @@ namespace CalculatorApp
             static bool IsDateCalculatorViewMode(ViewMode mode);
             static bool IsConverterViewMode(ViewMode mode);
 
-            static void CreateCategoryManifest(Windows::System::User ^ user);
+            static void InitializeCategoryManifest(Windows::System::User ^ user);
 
             static Platform::String ^ GetFriendlyName(ViewMode mode);
             static Platform::String ^ GetNameResourceKey(ViewMode mode);

--- a/src/CalcViewModel/Common/NavCategory.h
+++ b/src/CalcViewModel/Common/NavCategory.h
@@ -59,15 +59,15 @@ namespace CalculatorApp
     private
         struct NavCategoryInitializer
         {
-            constexpr NavCategoryInitializer(
+            NavCategoryInitializer(
                 ViewMode mode,
                 int id,
-                wchar_t const* name,
-                wchar_t const* nameKey,
-                wchar_t const* glyph,
+                wchar_t * name,
+                wchar_t * nameKey,
+                wchar_t * glyph,
                 CategoryGroupType group,
                 MyVirtualKey vKey,
-                wchar_t const* aKey,
+                wchar_t * aKey,
                 bool categorySupportsNegative,
                 bool enabled)
                 : viewMode(mode)
@@ -83,22 +83,22 @@ namespace CalculatorApp
             {
             }
 
-            const ViewMode viewMode;
-            const int serializationId;
-            const wchar_t* const friendlyName;
-            const wchar_t* const nameResourceKey;
-            const wchar_t* const glyph;
-            const CategoryGroupType groupType;
-            const MyVirtualKey virtualKey;
-            const wchar_t* const accessKey;
-            const bool supportsNegative;
-            const bool isEnabled;
+            ViewMode viewMode;
+            int serializationId;
+            wchar_t* friendlyName;
+            wchar_t* nameResourceKey;
+            wchar_t* glyph;
+            CategoryGroupType groupType;
+            MyVirtualKey virtualKey;
+            wchar_t* accessKey;
+            bool supportsNegative;
+            bool isEnabled;
         };
 
     private
         struct NavCategoryGroupInitializer
         {
-            constexpr NavCategoryGroupInitializer(CategoryGroupType t, wchar_t const* h, wchar_t const* n, wchar_t const* a)
+            NavCategoryGroupInitializer(CategoryGroupType t, wchar_t * h, wchar_t * n, wchar_t * a)
                 : type(t)
                 , headerResourceKey(h)
                 , modeResourceKey(n)
@@ -106,10 +106,10 @@ namespace CalculatorApp
             {
             }
 
-            const CategoryGroupType type;
-            const wchar_t* headerResourceKey;
-            const wchar_t* modeResourceKey;
-            const wchar_t* automationResourceKey;
+            CategoryGroupType type;
+            wchar_t* headerResourceKey;
+            wchar_t* modeResourceKey;
+            wchar_t* automationResourceKey;
         };
 
         [Windows::UI::Xaml::Data::Bindable] public ref class NavCategory sealed : public Windows::UI::Xaml::Data::INotifyPropertyChanged
@@ -139,6 +139,8 @@ namespace CalculatorApp
             static bool IsGraphingCalculatorViewMode(ViewMode mode);
             static bool IsDateCalculatorViewMode(ViewMode mode);
             static bool IsConverterViewMode(ViewMode mode);
+
+            static void CreateCategoryManifest(Windows::System::User ^ user);
 
             static Platform::String ^ GetFriendlyName(ViewMode mode);
             static Platform::String ^ GetNameResourceKey(ViewMode mode);

--- a/src/Calculator/App.xaml.cpp
+++ b/src/Calculator/App.xaml.cpp
@@ -198,12 +198,12 @@ void App::OnLaunched(LaunchActivatedEventArgs ^ args)
         // If the app got pre-launch activated, then save that state in a flag
         m_preLaunched = true;
     }
+    NavCategory::CreateCategoryManifest(args->User);
     OnAppLaunch(args, args->Arguments);
 }
 
 void App::OnAppLaunch(IActivatedEventArgs ^ args, String ^ argument)
 {
-
     // Uncomment the following lines to display frame-rate and per-frame CPU usage info.
     //#if _DEBUG
     //    if (IsDebuggerPresent())

--- a/src/Calculator/App.xaml.cpp
+++ b/src/Calculator/App.xaml.cpp
@@ -198,7 +198,7 @@ void App::OnLaunched(LaunchActivatedEventArgs ^ args)
         // If the app got pre-launch activated, then save that state in a flag
         m_preLaunched = true;
     }
-    NavCategory::CreateCategoryManifest(args->User);
+    NavCategory::InitializeCategoryManifest(args->User);
     OnAppLaunch(args, args->Arguments);
 }
 


### PR DESCRIPTION
## Fixes a bug caused by https://github.com/microsoft/calculator/pull/1426#.


### Description of the changes:
- The PR #1426 can cause a crash when no users are returned via `User::FindAllAsync(UserType::LocalUser)` when subsequently trying to access the first user. The existing code also does not guarantee that the returned user is the currently active user.
- This fix retrieves the user that opened the app and passes this user into a function to check if this user has the proper permissions to access the graphing mode. This makes sense since the active user is indistinguishable (at least from the app's perspective) to the user who opened the app. This user's permissions are then propagated downwards to properly set up the navigation menu of the app.
- Implementation detail worth pointing out: `s_categoryManifest` is what is used to populate the navigation menu of the app, but this variable is static by design, so a separate function was written to override the appropriate `isEnabled` value in `s_categoryManifest`. This function is called by `onLaunched`.

### How changes were validated:
- Manual testing

