### PR TITLE
fixes up bug: Narrator is not reading the already entered equation when focus lands on Enter an equation edit box.

### DIFF
--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -115,7 +115,7 @@ void MathRichEditBox::SetMathTextProperty(String ^ newValue)
 
 void MathRichEditBox::OnGotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e)
 {
-    // bug: https://dev.azure.com/microsoft/OS/_workitems/edit/28498627
+    // [BUG 28498627][GithubIssue #1380]
     // below directives on Selection are going to engage Narrator to announce the content of this richedit
     // this is a workaround since richedit doesn't announce its content automatically.
     this->Document->Selection->EndKey(TextRangeUnit::Line, false);

--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -133,7 +133,6 @@ void MathRichEditBox::OnLosingFocus(UIElement ^ sender, LosingFocusEventArgs ^ a
     SubmitEquation(EquationSubmissionSource::FOCUS_LOST);
 }
 
-
 void MathRichEditBox::OnKeyUp(Object ^ sender, KeyRoutedEventArgs ^ e)
 {
     if (!this->IsReadOnly && e->Key == VirtualKey::Enter)

--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -12,6 +12,7 @@ using namespace std;
 using namespace Windows::ApplicationModel;
 using namespace Windows::UI::Core;
 using namespace Windows::UI::Xaml;
+using namespace Windows::UI::Xaml::Automation::Peers;
 using namespace Windows::UI::Xaml::Input;
 using namespace Windows::UI::Xaml::Controls;
 using namespace Windows::UI::Text;
@@ -118,9 +119,12 @@ void MathRichEditBox::OnGotFocus(Platform::Object ^ sender, Windows::UI::Xaml::R
     // [BUG 28498627][GithubIssue #1380]
     // below directives on Selection are going to engage Narrator to announce the content of this richedit
     // this is a workaround since richedit doesn't announce its content automatically.
-    this->Document->Selection->EndKey(TextRangeUnit::Line, false);
-    this->Document->Selection->HomeKey(TextRangeUnit::Line, false);
-    this->Document->Selection->MoveLeft(TextRangeUnit::Character, 1, false);
+    if (IsUIAccessibilityVoiceOverRunning())
+    {
+        this->Document->Selection->EndKey(TextRangeUnit::Line, false);
+        this->Document->Selection->HomeKey(TextRangeUnit::Line, false);
+        this->Document->Selection->MoveLeft(TextRangeUnit::Character, 1, false);
+    }
 }
 
 void MathRichEditBox::OnLosingFocus(UIElement ^ sender, LosingFocusEventArgs ^ args)
@@ -237,4 +241,9 @@ void MathRichEditBox::SubmitEquation(EquationSubmissionSource source)
     {
         EquationSubmitted(this, ref new MathRichEditBoxSubmission(false, source));
     }
+}
+
+bool MathRichEditBox::IsUIAccessibilityVoiceOverRunning() const
+{
+    return AutomationPeer::ListenerExists(AutomationEvents::PropertyChanged);
 }

--- a/src/Calculator/Controls/MathRichEditBox.cpp
+++ b/src/Calculator/Controls/MathRichEditBox.cpp
@@ -72,6 +72,7 @@ MathRichEditBox::MathRichEditBox()
     {
         throw Exception::CreateException(hr);
     }
+    this->GotFocus += ref new RoutedEventHandler(this, &MathRichEditBox::OnGotFocus);
     this->LosingFocus += ref new TypedEventHandler<UIElement ^,LosingFocusEventArgs ^>(this, &MathRichEditBox::OnLosingFocus);
     this->KeyUp += ref new KeyEventHandler(this, &MathRichEditBox::OnKeyUp);
 }
@@ -112,6 +113,16 @@ void MathRichEditBox::SetMathTextProperty(String ^ newValue)
     this->IsReadOnly = readOnlyState;
 }
 
+void MathRichEditBox::OnGotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e)
+{
+    // bug: https://dev.azure.com/microsoft/OS/_workitems/edit/28498627
+    // below directives on Selection are going to engage Narrator to announce the content of this richedit
+    // this is a workaround since richedit doesn't announce its content automatically.
+    this->Document->Selection->EndKey(TextRangeUnit::Line, false);
+    this->Document->Selection->HomeKey(TextRangeUnit::Line, false);
+    this->Document->Selection->MoveLeft(TextRangeUnit::Character, 1, false);
+}
+
 void MathRichEditBox::OnLosingFocus(UIElement ^ sender, LosingFocusEventArgs ^ args)
 {
     if (this->IsReadOnly || this->ContextFlyout->IsOpen)
@@ -121,6 +132,7 @@ void MathRichEditBox::OnLosingFocus(UIElement ^ sender, LosingFocusEventArgs ^ a
 
     SubmitEquation(EquationSubmissionSource::FOCUS_LOST);
 }
+
 
 void MathRichEditBox::OnKeyUp(Object ^ sender, KeyRoutedEventArgs ^ e)
 {

--- a/src/Calculator/Controls/MathRichEditBox.h
+++ b/src/Calculator/Controls/MathRichEditBox.h
@@ -67,8 +67,8 @@ namespace CalculatorApp
             Platform::String ^ GetMathTextProperty();
             void SetMathTextProperty(Platform::String ^ newValue);
 
-            void OnLosingFocus(Windows::UI::Xaml::UIElement ^ sender, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ args);
             void OnGotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
+            void OnLosingFocus(Windows::UI::Xaml::UIElement ^ sender, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ args);
             void OnKeyUp(Platform::Object ^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e);
         };
     }

--- a/src/Calculator/Controls/MathRichEditBox.h
+++ b/src/Calculator/Controls/MathRichEditBox.h
@@ -70,6 +70,8 @@ namespace CalculatorApp
             void OnGotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
             void OnLosingFocus(Windows::UI::Xaml::UIElement ^ sender, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ args);
             void OnKeyUp(Platform::Object ^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e);
+
+            bool IsUIAccessibilityVoiceOverRunning() const;
         };
     }
 }

--- a/src/Calculator/Controls/MathRichEditBox.h
+++ b/src/Calculator/Controls/MathRichEditBox.h
@@ -68,6 +68,7 @@ namespace CalculatorApp
             void SetMathTextProperty(Platform::String ^ newValue);
 
             void OnLosingFocus(Windows::UI::Xaml::UIElement ^ sender, Windows::UI::Xaml::Input::LosingFocusEventArgs ^ args);
+            void OnGotFocus(Platform::Object ^ sender, Windows::UI::Xaml::RoutedEventArgs ^ e);
             void OnKeyUp(Platform::Object ^ sender, Windows::UI::Xaml::Input::KeyRoutedEventArgs ^ e);
         };
     }


### PR DESCRIPTION
Target Issue: #1380 Narrator is not reading the already entered equation when focus lands on Enter a equation edit box.

## Fixes #
Once there's focus landed on equation text box, engage Narrator to announce the equation by jumping the insertion position back and forth ending with a left arrow key action.


### Description of the changes:
- Added an event handler listening to [GotFocus event](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.gotfocus?view=winrt-19041)
- When equation edit box got focus:
  1. Set insertion position to the end of line.
  2. Set insertion position to the start of line.
  3. execute a left-arrow command.


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
1. Launched 'Calculator' and turn on narrator.
1. Home screen displayed.​
1. Navigated Open navigation button and activate it.
1. Navigated to graphing calculator list item and activate it.
1. Navigated to Enter a equation edit box.
1. Checked that the equation content has been announced.

