### PR TITLE
Always run loc pipeline

### DIFF
--- a/build/pipelines/azure-pipelines.loc.yaml
+++ b/build/pipelines/azure-pipelines.loc.yaml
@@ -13,6 +13,7 @@ schedules:
   branches:
     include:
     - master
+  always: true
 
 trigger: none
 pr: none


### PR DESCRIPTION
Add `always: true` so the loc pipeline runs even when there have not been any changes in git, to ensure we're checking for new translations continuously.