### PR TITLE
Disabled focus for 2nd button in Scientific Mode

### DIFF
--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -866,7 +866,9 @@
                       Checked="ShiftButton_Check"
                       Content="&#xF897;"
                       IsEnabledChanged="ShiftButton_IsEnabledChanged"
-                      Unchecked="ShiftButton_Check"/>
+                      Unchecked="ShiftButton_Check"
+                      AllowFocusOnInteraction="False"
+                      />
 
         <controls:CalculatorButton x:Name="PiButton"
                                    x:Uid="piButton"


### PR DESCRIPTION
### Fixes #1503 .


### Description of the changes:
- Added a `AllowFocusOnInteraction` property for `ShiftButton`. 

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually Tested

