### PR TITLE
Context Flyout fix for Calculation results

### DIFF
--- a/src/Calculator/Controls/CalculationResult.cpp
+++ b/src/Calculator/Controls/CalculationResult.cpp
@@ -127,6 +127,7 @@ void CalculationResult::OnApplyTemplate()
         m_textBlock = dynamic_cast<TextBlock ^>(GetTemplateChild("NormalOutput"));
         if (m_textBlock)
         {
+            m_textBlock->ContextMenuOpening += ref new ContextMenuOpeningEventHandler(this, &CalculationResult::OnContextMenuOpening);
             m_textBlock->Visibility = ::Visibility::Visible;
             m_textBlockSizeChangedToken = m_textBlock->SizeChanged += ref new SizeChangedEventHandler(this, &CalculationResult::OnTextBlockSizeChanged);
         }
@@ -416,4 +417,9 @@ void CalculationResult::OnTextContainerOnViewChanged(Object ^ /*sender*/, Scroll
 void CalculationResult::OnTextBlockSizeChanged(Object ^ /*sender*/, SizeChangedEventArgs ^ /*e*/)
 {
     UpdateScrollButtons();
+}
+
+void CalculationResult::OnContextMenuOpening(Platform::Object ^ sender, Windows::UI::Xaml::Controls::ContextMenuEventArgs ^ e)
+{
+    e->Handled = true;
 }

--- a/src/Calculator/Controls/CalculationResult.h
+++ b/src/Calculator/Controls/CalculationResult.h
@@ -59,6 +59,7 @@ namespace CalculatorApp
             void OnPointerEntered(Platform::Object ^ sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs ^ e);
             void OnPointerExited(Platform::Object ^ sender, Windows::UI::Xaml::Input::PointerRoutedEventArgs ^ e);
             void ModifyFontAndMargin(Windows::UI::Xaml::Controls::TextBlock ^ textBlock, double fontChange);
+            void OnContextMenuOpening(Platform::Object ^ sender, Windows::UI::Xaml::Controls::ContextMenuEventArgs ^ e);
             void UpdateScrollButtons();
             void ScrollLeft();
             void ScrollRight();


### PR DESCRIPTION
## Fixes #1534.


### Description of the changes:
- Removed to right click flyout for the internal `TextBlock` as the default behavior of the `Copy` in rest of the `CalculationResult` right click flyout is the same. 
- The other reason to remove the `TextBlock`'s right-click flyout was the style was inconsistent with the rest of the app.

### The style of the right-click flyout for the internal `TextBlock`.
![image](https://user-images.githubusercontent.com/22786016/118315876-b627cd80-b513-11eb-91fe-5290571e0bcd.png)

### The style for rest of the flyouts in the app.
![image](https://user-images.githubusercontent.com/22786016/118316068-fc7d2c80-b513-11eb-947a-ebb64caa5d34.png)


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually Tested.

This solution tackles the issue by removing the `Select All` flyout functionality.
