### PR TITLE
Resolves: Add native GitHub security and versioning dependency alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  - package-ecosystem: 'nuget'
+    directory: 'src'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'src/Calculator'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'src/CalculatorUITestFramework'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+  - package-ecosystem: 'nuget'
+    directory: 'src/CalculatorUITests'
+    open-pull-requests-limit: 10
+    schedule:
+      interval: 'daily'
+    # target-branch: 'develop'
+    # assignees:
+    #   - assignee_one
+    # reviewers:
+    #   - reviewer_one
+
+# Built with ❤ by [Pipeline Foundation](https://pipeline.foundation)


### PR DESCRIPTION
- add `dependabot.yml` which automatically enables Dependabot's dependency versioning scanner and dependency update PRs bot by declaring dependency ecosystems and sources in the project. For dependency security vulnerabilities scanner and vulnerable dependency update PRs bot, [enable "Dependabot alerts" and "Dependabot security updates"](https://docs.github.com/en/github/managing-security-vulnerabilities/configuring-dependabot-security-updates)

- use the `target-branch` attribute, if you would like to run Dependabot's scan against a branch other than your default branch (for example if you have a separate development branch)

- should you decide that certain people on your team should take care of the PRs that Dependabot creates, use the two attributes `assignees` and `reviewers` to automatically set personnel respectively.

Resolves #1560 