### PR TITLE
[Cherry-Pick] Temporarily disable PGO NuGet package (#1510)

### DIFF
--- a/src/Calculator/packages.config
+++ b/src/Calculator/packages.config
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.UI.Xaml" version="2.4.3" targetFramework="native" />
-  <package id="Microsoft.WindowsCalculator.PGO" version="1.0.2" targetFramework="native" />
 </packages>

--- a/src/nuget.config
+++ b/src/nuget.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="EEApps" value="https://eeapps.blob.core.windows.net/eeapps/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
## [Cherry-Pick] Temporarily disable PGO NuGet package (#1510)
> Temporarily disable the build configuration which pulls down a NuGet package containing .pgd files. This enables the project to use a single upstream feed for NuGet.

> Fixing PGO settings longer-term is tracked by #1435.

Cherry-picking this PR can unblock the internal ci pipeline fails for branch *feature/UICSharpCalculator*