### PR TITLE
[C# Calc]Reverts some changes for Currency constants

### DIFF
--- a/src/CalcViewModel/DataLoaders/CurrencyHttpClient.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyHttpClient.cpp
@@ -10,6 +10,7 @@
 #include "DataLoaderConstants.h"
 #endif
 
+using namespace CalculatorApp::DataLoaders;
 using namespace CalculatorApp::ViewModel::DataLoaders;
 using namespace Platform;
 using namespace std;

--- a/src/CalcViewModel/DataLoaders/DataLoaderMockConstants.h
+++ b/src/CalcViewModel/DataLoaders/DataLoaderMockConstants.h
@@ -5,7 +5,7 @@
 
 namespace CalculatorApp
 {
-    namespace ViewModel::DataLoaders
+    namespace DataLoaders
     {
         static constexpr auto sc_MetadataUriLocalizeFor = L"https://go.microsoft.com/fwlink/?linkid=2091028&localizeFor=";
         static constexpr auto sc_RatiosUriRelativeTo = L"https://go.microsoft.com/fwlink/?linkid=2091307&localCurrency=";


### PR DESCRIPTION
## Reverts some changes for Currency constants

### Description of the changes:
- Put some constants of DataLoader back to their original namespace

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested manually

