### PR TITLE
Fixes an issue around line style

### DIFF
--- a/src/Calculator/EquationStylePanelControl.xaml.cs
+++ b/src/Calculator/EquationStylePanelControl.xaml.cs
@@ -17,6 +17,13 @@ namespace CalculatorApp
         public EquationStylePanelControl()
         {
             InitializeComponent();
+
+            var allStyles = new List<EquationLineStyle>();
+            allStyles.Add(EquationLineStyle.Solid);
+            allStyles.Add(EquationLineStyle.Dash);
+            allStyles.Add(EquationLineStyle.Dot);
+
+            StyleChooserBox.ItemsSource = allStyles;
         }
 
         public Windows.UI.Color SelectedColor
@@ -85,11 +92,11 @@ namespace CalculatorApp
             switch (lineStyle)
             {
                 case EquationLineStyle.Dot:
-                    linePattern.Append(1);
+                    linePattern.Add(1);
                     break;
                 case EquationLineStyle.Dash:
-                    linePattern.Append(2);
-                    linePattern.Append(1);
+                    linePattern.Add(2);
+                    linePattern.Add(1);
                     break;
                 default:
                     break;
@@ -285,7 +292,7 @@ namespace CalculatorApp
                 var style = ((EquationLineStyle)item);
                 var comboBoxItem = (StyleChooserBox.ContainerFromItem(style) as ComboBoxItem);
 
-                if (comboBoxItem != null)
+                if (comboBoxItem == null)
                 {
                     continue;
                 }


### PR DESCRIPTION
## Fixes an issue around line style (Graphing Mode)
Problem: Line Style doesn't show up in the combo box

### Description of the changes:
- Addes built-in line styles.
- Changes `DoubleCollection.Append()` into `DoubleCollection.Add()`

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested manually

