### PR TITLE
Fixes: calculator doesn't remember its previous mode

### DIFF
--- a/src/Calculator/Views/MainPage.xaml.cs
+++ b/src/Calculator/Views/MainPage.xaml.cs
@@ -134,13 +134,11 @@ namespace CalculatorApp
         protected override void OnNavigatedTo(NavigationEventArgs e)
         {
             ViewMode initialMode = ViewMode.Standard;
-            if (e.Parameter != null)
+
+            string stringParameter = (e.Parameter as string);
+            if (!string.IsNullOrEmpty(stringParameter))
             {
-                string stringParameter = (e.Parameter as string);
-                if (!string.IsNullOrEmpty(stringParameter))
-                {
-                    initialMode = (ViewMode)Convert.ToInt32(stringParameter);
-                }
+                initialMode = (ViewMode)Convert.ToInt32(stringParameter);
             }
             else
             {


### PR DESCRIPTION
## Fixes: calculator doesn't remember its previous mode
NavigationEventArgs.Parameter is not null but empty string in C# runtime.

### Description of the changes:
- Check if NavigationEventArgs.Parameter is null or empty string

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested manually

