### PR TITLE
Fixes: GraphingNumber doesn't work correctly

### DIFF
--- a/src/Calculator/App.xaml.cs
+++ b/src/Calculator/App.xaml.cs
@@ -159,7 +159,7 @@ namespace CalculatorApp
             // For very first launch, set the size of the calc as size of the default standard mode
             if (!localSettings.Values.ContainsKey("VeryFirstLaunch"))
             {
-                localSettings.Values.Add("VeryFirstLaunch", false);
+                localSettings.Values["VeryFirstLaunch"] = false;
                 appView.SetPreferredMinSize(minWindowSize);
                 appView.TryResizeView(minWindowSize);
             }

--- a/src/Calculator/Controls/MathRichEditBox.cs
+++ b/src/Calculator/Controls/MathRichEditBox.cs
@@ -137,7 +137,7 @@ namespace CalculatorApp
                 // If the rich edit has content already, then the mathzone will already be created due to mathonly mode being set and the selection will exist inside the
                 // math zone. To handle this, we will force a math zone to be created in teh case of the text being empty and then replacing the text inside of the math
                 // zone with the newly inserted text.
-                if (GetMathTextProperty() == null)
+                if (string.IsNullOrEmpty(GetMathTextProperty()))
                 {
                     SetMathTextProperty("<math xmlns=\"http://www.w3.org/1998/Math/MathML\"><mi>x</mi></math>");
                     TextDocument.Selection.StartPosition = 0;

--- a/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml.cs
+++ b/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml.cs
@@ -129,7 +129,7 @@ namespace CalculatorApp
         {
             string propertyName = isMatchAppTheme ? "IsMatchAppTheme" : "IsAlwaysLightTheme";
             ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
-            localSettings.Values.Add("IsGraphThemeMatchApp", isMatchAppTheme);
+            localSettings.Values["IsGraphThemeMatchApp"] = isMatchAppTheme;
             GraphThemeSettingChanged?.Invoke(this, isMatchAppTheme);
             CalculatorApp.ViewModel.Common.TraceLogger.GetInstance().LogGraphSettingsChanged(GraphSettingsType.Theme, propertyName);
         }

--- a/src/Calculator/Views/MainPage.xaml.cs
+++ b/src/Calculator/Views/MainPage.xaml.cs
@@ -463,8 +463,8 @@ namespace CalculatorApp
             if (m_model.IsAlwaysOnTop)
             {
                 ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
-                localSettings.Values.Add(ApplicationViewModel.WidthLocalSettings, ActualWidth);
-                localSettings.Values.Add(ApplicationViewModel.HeightLocalSettings, ActualHeight);
+                localSettings.Values[ApplicationViewModel.WidthLocalSettings] = ActualWidth;
+                localSettings.Values[ApplicationViewModel.HeightLocalSettings] = ActualHeight;
             }
         }
 


### PR DESCRIPTION
## Fixes: GraphingNumber doesn't work correctly
Problem: The expressions input from number pad doesn't work.

### Description of the changes:
- Checks out on null or empty for the retval of GetMathTextProperty()

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested manually

