### PR TITLE
Spelling fix in azure-pipelines.ci.yaml

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -1,6 +1,6 @@
 #
 # Continuous Integration (CI)
-# This pipeline builds and validate the app for all supported architecutres, in a public
+# This pipeline builds and validate the app for all supported architectures, in a public
 # configuration. If the build was queued to validate a pull request, we build and test only x64.
 #
 


### PR DESCRIPTION
architecutres -> architectures, as @jogo- [noticed](https://github.com/microsoft/calculator/commit/49f288316bd1fcfc5a6c2779b132c3ad99476dcb#r52689998).