### PR TITLE
[C# Calc] Fixes: Keep the value away from getting rounded in Graphing Mode

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cs
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cs
@@ -476,8 +476,7 @@ namespace CalculatorApp
 
         private double validateDouble(string value, double defaultValue)
         {
-            double resultValue = 0;
-            if (double.TryParse(value, out resultValue))
+            if (double.TryParse(value, out var resultValue))
             {
                 return resultValue;
             }
@@ -544,7 +543,7 @@ namespace CalculatorApp
                 return;
             }
 
-            sender.Text = val.ToString("G", System.Globalization.CultureInfo.InvariantCulture);
+            sender.Text = val.ToString("G6", System.Globalization.CultureInfo.InvariantCulture);
         }
 
         private void VariableAreaClicked(object sender, RoutedEventArgs e)

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cs
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml.cs
@@ -544,9 +544,7 @@ namespace CalculatorApp
                 return;
             }
 
-            // CSHARP_MIGRATION: TODO:
-            // Due to different culture, some regions use comma instead of dot as the decimal point
-            sender.Text = val.ToString("0", System.Globalization.CultureInfo.InvariantCulture);
+            sender.Text = val.ToString("G", System.Globalization.CultureInfo.InvariantCulture);
         }
 
         private void VariableAreaClicked(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Fixes: Keep the value away from getting rounded in Graphing Mode


### Description of the changes:
- Uses "G" instead of "0" as the format-specifier, which works equivalently to `std::noshowpoint`.


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested manually
