### PR TITLE
[C# Calc] Cleanup TODOs: If device's display size (diagonal length) is less than 7 inches then keep the calc always in Portrait mode only

### DIFF
--- a/src/CalcViewModel/Common/Utils.cpp
+++ b/src/CalcViewModel/Common/Utils.cpp
@@ -276,3 +276,10 @@ long long CalculatorApp::ViewModel::Common::Utilities::GetConst_WINEVENT_KEYWORD
     return WINEVENT_KEYWORD_RESPONSE_TIME;
 }
 
+bool CalculatorApp::ViewModel::Common::Utilities::GetIntegratedDisplaySize(double* size)
+{
+    if (SUCCEEDED(::GetIntegratedDisplaySize(size)))
+        return true;
+    return false;
+}
+

--- a/src/CalcViewModel/Common/Utils.h
+++ b/src/CalcViewModel/Common/Utils.h
@@ -719,6 +719,7 @@ namespace CalculatorApp
             static Windows::UI::Xaml::Media::SolidColorBrush ^ GetContrastColor(Windows::UI::Color backgroundColor);
             static int GetWindowId();
             static long long GetConst_WINEVENT_KEYWORD_RESPONSE_TIME();
+            static bool GetIntegratedDisplaySize(double* size);
         };
     }
 }

--- a/src/Calculator/Views/MainPage.xaml.cs
+++ b/src/Calculator/Views/MainPage.xaml.cs
@@ -9,6 +9,7 @@ using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Windows.Foundation;
 using Windows.Foundation.Collections;
+using Windows.Graphics.Display;
 using Windows.Storage;
 using Windows.UI.Core;
 using Windows.UI.ViewManagement;
@@ -39,16 +40,13 @@ namespace CalculatorApp
             m_model.PropertyChanged += OnAppPropertyChanged;
             m_accessibilitySettings = new AccessibilitySettings();
 
-            // CSHARP_MIGRAION: TODO: find another implementation for C#
-            //double sizeInInches = 0.0;
-
-            //if (SUCCEEDED(GetIntegratedDisplaySize(&sizeInInches)))
-            //{
-            //    if (sizeInInches < 7.0) // If device's display size (diagonal length) is less than 7 inches then keep the calc always in Portrait mode only
-            //    {
-            //        DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait | DisplayOrientations.PortraitFlipped;
-            //    }
-            //}
+            if(Utilities.GetIntegratedDisplaySize(out var sizeInInches))
+            {
+                if(sizeInInches < 7.0) // If device's display size (diagonal length) is less than 7 inches then keep the calc always in Portrait mode only
+                {
+                    DisplayInformation.AutoRotationPreferences = DisplayOrientations.Portrait | DisplayOrientations.PortraitFlipped;
+                }
+            }
         }
 
         public CalculatorApp.ViewModel.ApplicationViewModel Model


### PR DESCRIPTION
## [C# Calc] Cleanup TODOs: If device's display size (diagonal length) is less than 7 inches then keep the calc always in Portrait mode only


### Description of the changes:
- Export GetIntegratedDisplaySize() from CalcViewModel since no substitution can be found in C#.


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested Manually
