### PR TITLE
fixed titlebar

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -19,7 +19,6 @@
                     <Color x:Key="OperatorPanelScrollButtonBackgroundColor">#FF858585</Color>
                     <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="{StaticResource AltHighColor}"/>
                     <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumLowBrush" Color="{StaticResource ChromeMediumLowColor}"/>
-                    <SolidColorBrush x:Key="TitleBarForegroundBaseHighBrush" Color="{StaticResource SystemBaseHighColor}"/>
                     <SolidColorBrush x:Key="SystemControlBackgroundTransparentBrush" Color="Transparent"/>
                     <SolidColorBrush x:Key="SystemControlHighlightTransparentBrush" Color="Transparent"/>
                     <SolidColorBrush x:Key="AppBackgroundAltMediumLowBrush" Color="{ThemeResource SystemAltMediumLowColor}"/>
@@ -94,7 +93,6 @@
                     <Color x:Key="OperatorPanelScrollButtonBackgroundColor">#FF858585</Color>
                     <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="{StaticResource SystemAltHighColor}"/>
                     <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumLowBrush" Color="{StaticResource ChromeMediumLowColor}"/>
-                    <SolidColorBrush x:Key="TitleBarForegroundBaseHighBrush" Color="{StaticResource SystemBaseHighColor}"/>
                     <SolidColorBrush x:Key="SystemControlBackgroundTransparentBrush" Color="Transparent"/>
                     <SolidColorBrush x:Key="SystemControlHighlightTransparentBrush" Color="Transparent"/>
                     <SolidColorBrush x:Key="AppBackgroundAltMediumLowBrush" Color="{ThemeResource SystemAltMediumLowColor}"/>
@@ -170,7 +168,6 @@
                     <x:Double x:Key="HighContrastStrokeThickness">2</x:Double>
                     <SolidColorBrush x:Key="SystemControlBackgroundAltHighBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
                     <SolidColorBrush x:Key="SystemControlBackgroundChromeMediumLowBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
-                    <SolidColorBrush x:Key="TitleBarForegroundBaseHighBrush" Color="{ThemeResource SystemColorCaptionTextColor}"/>
                     <SolidColorBrush x:Key="SystemControlBackgroundTransparentBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>
                     <SolidColorBrush x:Key="SystemControlHighlightTransparentBrush" Color="{ThemeResource SystemColorHighlightColor}"/>
                     <SolidColorBrush x:Key="AppBackgroundAltMediumLowBrush" Color="{ThemeResource SystemColorButtonFaceColor}"/>

--- a/src/Calculator/Views/TitleBar.xaml
+++ b/src/Calculator/Views/TitleBar.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="CalculatorApp.TitleBar"
+<UserControl x:Class="CalculatorApp.TitleBar"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -10,11 +10,7 @@
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup x:Name="WindowFocusStates">
                 <VisualState x:Name="WindowFocused"/>
-                <VisualState x:Name="WindowNotFocused">
-                    <VisualState.Setters>
-                        <Setter Target="AppName.Foreground" Value="{ThemeResource SystemControlForegroundChromeDisabledLowBrush}"/>
-                    </VisualState.Setters>
-                </VisualState>
+                <VisualState x:Name="WindowNotFocused"/>
             </VisualStateGroup>
             <VisualStateGroup x:Name="AOTStates">
                 <VisualState x:Name="AOTNormalState"/>
@@ -32,7 +28,6 @@
                        Margin="12,0,12,0"
                        HorizontalAlignment="Left"
                        VerticalAlignment="Center"
-                       Foreground="{ThemeResource TitleBarForegroundBaseHighBrush}"
                        FontSize="12"
                        TextTrimming="CharacterEllipsis"/>
         </Grid>


### PR DESCRIPTION
What?
When active, Calc title bar is impossible to read in Night Sky theme

Updated:
- Cal title bar is visible in Night Sky theme
- Remove the foreground and clean up the code


