### PR TITLE
Fixed the display issue in AOT mode

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -333,7 +333,6 @@
 
             <FontFamily x:Key="CalculatorFontFamily">ms-appx:///Assets/CalculatorIcons.ttf#Calculator Fluent Icons</FontFamily>
 
-            <x:Double x:Key="SplitViewOpenPaneLength">256</x:Double>
             <Thickness x:Key="PivotPortraitThemePadding">0,1,0,0</Thickness>
             <x:Double x:Key="PivotHeaderItemFontSize">14</x:Double>
             <FontWeight x:Key="PivotHeaderItemThemeFontWeight">Normal</FontWeight>

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -333,6 +333,7 @@
 
             <FontFamily x:Key="CalculatorFontFamily">ms-appx:///Assets/CalculatorIcons.ttf#Calculator Fluent Icons</FontFamily>
 
+            <x:Double x:Key="SplitViewOpenPaneLength">256</x:Double>
             <Thickness x:Key="PivotPortraitThemePadding">0,1,0,0</Thickness>
             <x:Double x:Key="PivotHeaderItemFontSize">14</x:Double>
             <FontWeight x:Key="PivotHeaderItemThemeFontWeight">Normal</FontWeight>

--- a/src/Calculator/Views/MainPage.xaml
+++ b/src/Calculator/Views/MainPage.xaml
@@ -101,7 +101,7 @@
                              ItemInvoked="OnNavItemInvoked"
                              Loaded="OnNavLoaded"
                              MenuItemsSource="{x:Bind CreateUIElementsForCategories(Model.Categories), Mode=OneWay}"
-                             OpenPaneLength="{StaticResource SplitViewOpenPaneLength}"
+                             OpenPaneLength="{x:Bind NavigationViewOpenPaneLength(Model.IsAlwaysOnTop), Mode=OneWay}"
                              PaneClosed="OnNavPaneClosed"
                              PaneOpened="OnNavPaneOpened"
                              SelectionChanged="OnNavSelectionChanged"

--- a/src/Calculator/Views/MainPage.xaml.cs
+++ b/src/Calculator/Views/MainPage.xaml.cs
@@ -604,6 +604,11 @@ namespace CalculatorApp
             }
         }
 
+        private double NavigationViewOpenPaneLength(bool isAlwaysOnTop)
+        {
+            return isAlwaysOnTop ? 0 : 256;
+        }
+
         private CalculatorApp.Calculator m_calculator;
         private GraphingCalculator m_graphingCalculator;
         private CalculatorApp.UnitConverter m_converter;

--- a/src/Calculator/Views/MainPage.xaml.cs
+++ b/src/Calculator/Views/MainPage.xaml.cs
@@ -606,7 +606,7 @@ namespace CalculatorApp
 
         private double NavigationViewOpenPaneLength(bool isAlwaysOnTop)
         {
-            return isAlwaysOnTop ? 0 : 256;
+            return isAlwaysOnTop ? 0 : (double)Application.Current.Resources["SplitViewOpenPaneLength"];
         }
 
         private CalculatorApp.Calculator m_calculator;


### PR DESCRIPTION
### Description of the issue:
After Calculator enters AOT mode, it looks good to change the window size with the UI controls’ size changed coordinately when the window size is large. However, if we keep decreasing the window size, we will see the UI control’s height is always automatically adapted to the window size while the width stops adapting to smaller size at a certain point. 

### Description of the changes:
This issue is caused by the WinUI 2.6 NavigationView. A workaround is to set the OpenPaneLength to be smaller than the minimum window width in AOT mode.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Passed the build and manually tested different window size in AOT mode.

