### PR TITLE
Disable Mica before close the window to resolve a crash

### DIFF
--- a/src/Calculator/App.xaml.cs
+++ b/src/Calculator/App.xaml.cs
@@ -440,6 +440,10 @@ namespace CalculatorApp
 
             mainPage.UnregisterEventHandlers();
 
+            // TODO, remove this workaround after Mica fix
+            // Workaround app crash caused by Mica in multi-view case.
+            Microsoft.UI.Xaml.Controls.BackdropMaterial.SetApplyToRootOrPageBackground(mainPage, false);
+
             await frameService.HandleViewRelease();
             await Task.Run(() =>
             {


### PR DESCRIPTION
### Description of the changes:
Disable Mica before closing window to resolve the crash in multi-view case.

### How changes were validated:
Manually tested.

