### PR TITLE
Fix the inconsistent behavior between narrator and keyboard focus

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
+++ b/src/Calculator/Views/GraphingCalculator/KeyGraphFeaturesPanel.xaml
@@ -143,22 +143,22 @@
             </Style>
 
             <Style x:Name="KGF_ListViewItemContainerStyle" TargetType="ListViewItem">
-                <Setter Property="IsTabStop" Value="False"/>
                 <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                <Setter Property="AutomationProperties.AccessibilityView" Value="Raw"/>
                 <Setter Property="Padding" Value="0,10"/>
             </Style>
 
             <DataTemplate x:Key="KGFRichEditDataTemplate" x:DataType="vm:KeyGraphFeaturesItem">
-                <StackPanel>
+                <StackPanel AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
                     <TextBlock x:Name="TitleTextBlock"
                                Style="{StaticResource KGF_TitleTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind Title, Mode=OneWay}"/>
-                    <ItemsControl ItemsSource="{x:Bind DisplayItems, Mode=OneWay}" UseSystemFocusVisuals="True">
+                    <ItemsControl IsTabStop="False" ItemsSource="{x:Bind DisplayItems, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="x:String">
-                                <controls:MathRichEditBox Style="{StaticResource KGF_RichEditBoxStyle}" MathText="{x:Bind}"/>
+                                <controls:MathRichEditBox Style="{StaticResource KGF_RichEditBoxStyle}"
+                                                          IsTabStop="False"
+                                                          MathText="{x:Bind}"/>
                             </DataTemplate>
                         </ItemsControl.ItemTemplate>
                     </ItemsControl>
@@ -194,12 +194,12 @@
             </DataTemplate>
 
             <DataTemplate x:Key="KGFTextBlockDataTemplate" x:DataType="vm:KeyGraphFeaturesItem">
-                <StackPanel>
+                <StackPanel AutomationProperties.Name="{x:Bind Title, Mode=OneWay}">
                     <TextBlock x:Name="TitleTextBlock"
                                Style="{StaticResource KGF_TitleTextBlockStyle}"
                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
                                Text="{x:Bind Title, Mode=OneWay}"/>
-                    <ItemsControl ItemsSource="{x:Bind DisplayItems, Mode=OneWay}" UseSystemFocusVisuals="True">
+                    <ItemsControl IsTabStop="False" ItemsSource="{x:Bind DisplayItems, Mode=OneWay}">
                         <ItemsControl.ItemTemplate>
                             <DataTemplate x:DataType="x:String">
                                 <TextBlock Style="{StaticResource KGF_TextBlockStyle}" Text="{x:Bind}"/>


### PR DESCRIPTION
### Description of the changes:
In the function analysis of graphing mode, some controls use system focus visuals for keyboard focus while the UIA is not set up. In this case, the narrator will focus on the last UIA control when the keyboard focus on a control with UIA not available.

Update the keyboard focus and UIA on the ListView to align their behavior.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Passed the unit test as well as UI test, and manually tested.
