### PR TITLE
Fix title bar string trimming issue and right-to-left display issue

### DIFF
--- a/src/Calculator/Views/TitleBar.xaml
+++ b/src/Calculator/Views/TitleBar.xaml
@@ -66,13 +66,12 @@
                 <Grid x:Name="TitleHolder">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="Auto"/>
-                        <ColumnDefinition Width="Auto"/>
                         <ColumnDefinition Width="*"/>
                     </Grid.ColumnDefinitions>
 
                     <Image x:Name="AppIcon"
-                           Width="16"
-                           Height="16"
+                           Width="20"
+                           Height="20"
                            Margin="16,0,0,0"
                            VerticalAlignment="Center"
                            AutomationProperties.AccessibilityView="Raw"
@@ -80,7 +79,7 @@
                     <TextBlock x:Name="AppName"
                                x:Uid="AppName"
                                Grid.Column="1"
-                               Margin="16,0,16,0"
+                               Margin="12,0,0,0"
                                HorizontalAlignment="Left"
                                VerticalAlignment="Center"
                                FontSize="12"

--- a/src/Calculator/Views/TitleBar.xaml.cs
+++ b/src/Calculator/Views/TitleBar.xaml.cs
@@ -154,7 +154,7 @@ namespace CalculatorApp
             else
             {
                 leftAddition = m_coreTitleBar.SystemOverlayRightInset;
-                leftAddition = m_coreTitleBar.SystemOverlayLeftInset;
+                rightAddition = m_coreTitleBar.SystemOverlayLeftInset;
             }
 
             LayoutRoot.Padding = new Thickness(leftAddition, 0, rightAddition, 0);


### PR DESCRIPTION
Issue 1: Title bar string is not trimmed properly in small window size.
Issue 2: Title bar is overlapped by system caption buttons in right-to-left language.

### Description of the changes:
- To fix issue 1, remove the redundant column in title bar and correct the column width of AppName to be "*" instead of "Auto".
- To fix issue 2, correct the leftAddition to rightAddition in right-to-left flow direction.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Passed build and manually tested.
