### PR TITLE
Fix the result in wrong number base while leaving and switching back …

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1188,14 +1188,14 @@ void StandardCalculatorViewModel::SetCalculatorType(ViewMode targetState)
     {
     case ViewMode::Standard:
         IsStandard = true;
-        ResetDisplay();
+        ResetRadix();
         SetPrecision(StandardModePrecision);
         UpdateMaxIntDigits();
         break;
 
     case ViewMode::Scientific:
         IsScientific = true;
-        ResetDisplay();
+        ResetRadix();
         SetPrecision(ScientificModePrecision);
         break;
 
@@ -1226,7 +1226,7 @@ String ^ StandardCalculatorViewModel::GetLocalizedStringFormat(String ^ format, 
     return LocalizationStringUtil::GetLocalizedString(format, displayValue);
 }
 
-void StandardCalculatorViewModel::ResetDisplay()
+void StandardCalculatorViewModel::ResetRadix()
 {
     AreHEXButtonsEnabled = false;
     CurrentRadixType = NumberBase::DecBase;

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1201,7 +1201,6 @@ void StandardCalculatorViewModel::SetCalculatorType(ViewMode targetState)
 
     case ViewMode::Programmer:
         IsProgrammer = true;
-        ResetDisplay();
         SetPrecision(ProgrammerModePrecision);
         break;
     }

--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1188,19 +1188,20 @@ void StandardCalculatorViewModel::SetCalculatorType(ViewMode targetState)
     {
     case ViewMode::Standard:
         IsStandard = true;
-        ResetRadix();
+        ResetRadixAndUpdateMemory(true);
         SetPrecision(StandardModePrecision);
         UpdateMaxIntDigits();
         break;
 
     case ViewMode::Scientific:
         IsScientific = true;
-        ResetRadix();
+        ResetRadixAndUpdateMemory(true);
         SetPrecision(ScientificModePrecision);
         break;
 
     case ViewMode::Programmer:
         IsProgrammer = true;
+        ResetRadixAndUpdateMemory(false);
         SetPrecision(ProgrammerModePrecision);
         break;
     }
@@ -1226,11 +1227,18 @@ String ^ StandardCalculatorViewModel::GetLocalizedStringFormat(String ^ format, 
     return LocalizationStringUtil::GetLocalizedString(format, displayValue);
 }
 
-void StandardCalculatorViewModel::ResetRadix()
+void StandardCalculatorViewModel::ResetRadixAndUpdateMemory(bool resetRadix)
 {
-    AreHEXButtonsEnabled = false;
-    CurrentRadixType = NumberBase::DecBase;
-    m_standardCalculatorManager.SetRadix(RadixType::Decimal);
+    if (resetRadix)
+    {
+        AreHEXButtonsEnabled = false;
+        CurrentRadixType = NumberBase::DecBase;
+        m_standardCalculatorManager.SetRadix(RadixType::Decimal);
+    }
+    else
+    {
+        m_standardCalculatorManager.SetMemorizedNumbersString();
+    }
 }
 
 void StandardCalculatorViewModel::SetPrecision(int32_t precision)

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -283,7 +283,7 @@ namespace CalculatorApp
             void Recalculate(bool fromHistory = false);
             bool IsOperator(CalculationManager::Command cmdenum);
             void SetMemorizedNumbersString();   
-            void ResetDisplay();
+            void ResetRadix();
           
             void SetPrecision(int32_t precision);
             void UpdateMaxIntDigits()

--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -283,7 +283,7 @@ namespace CalculatorApp
             void Recalculate(bool fromHistory = false);
             bool IsOperator(CalculationManager::Command cmdenum);
             void SetMemorizedNumbersString();   
-            void ResetRadix();
+            void ResetRadixAndUpdateMemory(bool resetRadix);
           
             void SetPrecision(int32_t precision);
             void UpdateMaxIntDigits()

--- a/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
@@ -42,7 +42,7 @@ namespace CalculatorUnitTests
             viewModel->IsStandard = true;
             viewModel->IsScientific = false;
             viewModel->IsProgrammer = false;
-            viewModel->ResetDisplay();
+            viewModel->ResetRadix();
             viewModel->SetPrecision(StandardModePrecision);
         }
         else if (mode == 1)
@@ -50,7 +50,7 @@ namespace CalculatorUnitTests
             viewModel->IsScientific = true;
             viewModel->IsProgrammer = false;
             viewModel->IsStandard = false;
-            viewModel->ResetDisplay();
+            viewModel->ResetRadix();
             viewModel->SetPrecision(ScientificModePrecision);
         }
         else if (mode == 2)
@@ -58,7 +58,6 @@ namespace CalculatorUnitTests
             viewModel->IsProgrammer = true;
             viewModel->IsScientific = false;
             viewModel->IsStandard = false;
-            viewModel->ResetDisplay();
             viewModel->SetPrecision(ProgrammerModePrecision);
         }
     }

--- a/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
@@ -803,6 +803,14 @@ namespace CalculatorUnitTests
             MemoryItemViewModel ^ memorySlotScientific = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
             VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001.1"), memorySlotScientific->Value);
             ChangeMode(m_viewModel, 2 /*Programmer*/);
+            TESTITEM items2[] = {
+                { NumbersAndOperatorsEnum::One, L"1", L"" },          { NumbersAndOperatorsEnum::Zero, L"10", L"" },
+                { NumbersAndOperatorsEnum::Zero, L"100", L"" },       { NumbersAndOperatorsEnum::One, L"1,001", L"" },
+                { NumbersAndOperatorsEnum::None, L"", L"" },
+            };
+            ValidateViewModelByCommands(m_viewModel, items2, true);
+            m_viewModel->OnMemoryButtonPressed();
+            m_viewModel->OnMemoryItemPressed(ref new Platform::Box<int>(0));
             MemoryItemViewModel ^ memorySlotProgrammer = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
             VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001"), memorySlotProgrammer->Value);
         }

--- a/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
+++ b/src/CalculatorUnitTests/StandardViewModelUnitTests.cpp
@@ -42,7 +42,7 @@ namespace CalculatorUnitTests
             viewModel->IsStandard = true;
             viewModel->IsScientific = false;
             viewModel->IsProgrammer = false;
-            viewModel->ResetRadix();
+            viewModel->ResetRadixAndUpdateMemory(true);
             viewModel->SetPrecision(StandardModePrecision);
         }
         else if (mode == 1)
@@ -50,7 +50,7 @@ namespace CalculatorUnitTests
             viewModel->IsScientific = true;
             viewModel->IsProgrammer = false;
             viewModel->IsStandard = false;
-            viewModel->ResetRadix();
+            viewModel->ResetRadixAndUpdateMemory(true);
             viewModel->SetPrecision(ScientificModePrecision);
         }
         else if (mode == 2)
@@ -58,6 +58,7 @@ namespace CalculatorUnitTests
             viewModel->IsProgrammer = true;
             viewModel->IsScientific = false;
             viewModel->IsStandard = false;
+            viewModel->ResetRadixAndUpdateMemory(false);
             viewModel->SetPrecision(ProgrammerModePrecision);
         }
     }
@@ -803,14 +804,6 @@ namespace CalculatorUnitTests
             MemoryItemViewModel ^ memorySlotScientific = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
             VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001.1"), memorySlotScientific->Value);
             ChangeMode(m_viewModel, 2 /*Programmer*/);
-            TESTITEM items2[] = {
-                { NumbersAndOperatorsEnum::One, L"1", L"" },          { NumbersAndOperatorsEnum::Zero, L"10", L"" },
-                { NumbersAndOperatorsEnum::Zero, L"100", L"" },       { NumbersAndOperatorsEnum::One, L"1,001", L"" },
-                { NumbersAndOperatorsEnum::None, L"", L"" },
-            };
-            ValidateViewModelByCommands(m_viewModel, items2, true);
-            m_viewModel->OnMemoryButtonPressed();
-            m_viewModel->OnMemoryItemPressed(ref new Platform::Box<int>(0));
             MemoryItemViewModel ^ memorySlotProgrammer = (MemoryItemViewModel ^) m_viewModel->MemorizedNumbers->GetAt(0);
             VERIFY_ARE_EQUAL(Platform::StringReference(L"1,001"), memorySlotProgrammer->Value);
         }


### PR DESCRIPTION
…to Programmer

Issue: When switching from programmer to graphing/date/converters and switching back, 
1) the hex buttons are disabled even HEX in selection;
2) the number base selection is the same as when leaving but the result value is always in DEC;
3) the memory values are always displayed in DEC even the number base is not DEC when leaving programmer.

### Description of the changes:
Rename ResetDisplay() to ResetRadixAndUpdateMemory(). Reset radix to DEC for standard and scientific modes, and only update memory for programmer mode.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Passed the unit tests and manually tested.

