### PR TITLE
Simple fix for the omitted multiplication sign before a left parenthesis

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -519,6 +519,12 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
 
         if (wParam == IDC_OPENP)
         {
+            // if there's an omitted multiplication sign 
+            if (IsDigitOpCode(m_nLastCom) || m_nLastCom == IDC_PNT || m_nLastCom == IDC_CLOSEP)
+            {
+                ProcessCommand(IDC_MUL);
+            }
+
             CheckAndAddLastBinOpToHistory();
             m_HistoryCollector.AddOpenBraceToHistory();
 

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -633,16 +633,16 @@ namespace CalculatorManagerTest
 
         Command commands3[] = { Command::Command1,      Command::Command2,     Command::CommandCLOSEP,
                                 Command::CommandCLOSEP, Command::CommandOPENP, Command::CommandNULL };
-        TestDriver::Test(L"12", L"(", commands3, true, true);
+        TestDriver::Test(L"12", L"12 \x00D7 (", commands3, true, true);
 
         Command commands4[] = {
             Command::Command2, Command::CommandOPENP, Command::Command2, Command::CommandCLOSEP, Command::CommandADD, Command::CommandNULL
         };
-        TestDriver::Test(L"2", L"(2) + ", commands4, true, true);
+        TestDriver::Test(L"4", L"2 \x00D7 (2) + ", commands4, true, true);
 
         Command commands5[] = { Command::Command2,   Command::CommandOPENP, Command::Command2,   Command::CommandCLOSEP,
                                 Command::CommandADD, Command::CommandEQU,   Command::CommandNULL };
-        TestDriver::Test(L"4", L"(2) + 2=", commands5, true, true);
+        TestDriver::Test(L"8", L"2 \x00D7 (2) + 4=", commands5, true, true);
     }
 
     void CalculatorManagerTest::CalculatorManagerTestScientificError()


### PR DESCRIPTION
## Simple fix for the omitted multiplication sign before a left parenthesis
Attempts to fix the problem reported in issue #1498 which minimum changes.

### Description of the changes:
- Checks if there's an omitted multiplication sign while a left parenthesis command is being processed.
- Corrects the correlated unit-test cases.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested manually.
- UT passed locally
- Example: after typing characters **_2 ( 1 + 1 ) =_**, the result will be 4 while it would be 2 before.
