### PR TITLE
A11Y: [Screen Reader - Currency Converter] : Incorrect role as 'link' is defined for 'Update rates' button.

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3119,6 +3119,10 @@
     <value>Update rates</value>
     <comment>The text displayed for a hyperlink button that refreshes currency converter ratios.</comment>
   </data>
+  <data name="RefreshButtonText.[using:Windows.UI.Xaml.Automation]AutomationProperties.LocalizedControlType" xml:space="preserve" >
+    <value>Button</value>
+    <comment>Makes Narrator to read this hyperlink as a button control.</comment>
+  </data>
   <data name="DataChargesMayApply" xml:space="preserve">
     <value>Data charges may apply.</value>
     <comment>The text displayed when users are on a metered connection and using currency converter.</comment>


### PR DESCRIPTION
## Fixes Bug 35566197: [Screen Reader - Currency Converter] : Incorrect role as 'link' is defined for 'Update rates' button.


### Description of the changes:
- Adds `AutomationProperties.LocalizedControlType` for x:Uid(RefreshButtonText)

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested manually.
