### PR TITLE
Label 'Line Thickness' is not associated with it's edit combo box.

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingSettings.xaml
@@ -213,12 +213,14 @@
                              IsChecked="{x:Bind ViewModel.TrigModeGradians, Mode=TwoWay}"/>
             </StackPanel>
 
-            <TextBlock x:Uid="LineThicknessBoxHeading"
+            <TextBlock x:Name="LineThicknessBoxHeading"
+                       x:Uid="LineThicknessBoxHeading"
                        Margin="0,16,0,6"
                        Style="{StaticResource SubTitleTextBoxStyle}"
                        AutomationProperties.HeadingLevel="Level2"/>
             <ComboBox MinWidth="200"
                       HorizontalAlignment="Stretch"
+                      AutomationProperties.LabeledBy="{Binding ElementName=LineThicknessBoxHeading}"
                       SelectedItem="{x:Bind ViewModel.Graph.LineWidth, Mode=TwoWay}">
                 <ComboBox.Items>
                     <x:Double>1.0</x:Double>


### PR DESCRIPTION
## Fixes #1672

### Description of the changes:
- Associate the combo-box with its label - 'Line thickness'

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested manually

