### PR TITLE
Add release appxmanifest

### DIFF
--- a/build/pipelines/azure-pipelines.ci-internal.yaml
+++ b/build/pipelines/azure-pipelines.ci-internal.yaml
@@ -16,19 +16,19 @@ jobs:
 - template: ./templates/build-single-architecture.yaml
   parameters:
     isReleaseBuild: true
-    useTestVersionOfInternalsPackage: true
+    useReleaseAppxManifest: false
     platform: x64
 
 - template: ./templates/build-single-architecture.yaml
   parameters:
     isReleaseBuild: true
-    useTestVersionOfInternalsPackage: true
+    useReleaseAppxManifest: false
     platform: x86
 
 - template: ./templates/build-single-architecture.yaml
   parameters:
     isReleaseBuild: true
-    useTestVersionOfInternalsPackage: true
+    useReleaseAppxManifest: false
     platform: ARM
 
 - template: ./templates/run-ui-tests.yaml
@@ -50,5 +50,3 @@ jobs:
     platform: x86
 
 - template: ./templates/package-appxbundle.yaml
-  parameters:    
-    useTestVersionOfInternalsPackage: true

--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -20,17 +20,20 @@ jobs:
   parameters:
     platform: x64
     isReleaseBuild: true
+    useReleaseAppxmanifest: true
 
 - template: ./templates/build-single-architecture.yaml
   parameters:
     platform: x86
     isReleaseBuild: true
+    useReleaseAppxmanifest: true
     condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
 - template: ./templates/build-single-architecture.yaml
   parameters:
     platform: ARM
     isReleaseBuild: true
+    useReleaseAppxmanifest: true
     condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
 - template: ./templates/run-unit-tests.yaml

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -2,7 +2,7 @@
 
 parameters:
   isReleaseBuild: false
-  useTestVersionOfInternalsPackage: false
+  useReleaseAppxManifest: ${{ parameters.isReleaseBuild }}
   platform: ''
   condition: ''
 
@@ -16,9 +16,15 @@ jobs:
     BuildConfiguration: Release
     BuildPlatform: ${{ parameters.platform }}
     ${{ if eq(parameters.isReleaseBuild, true) }}:
-      ExtraMSBuildArgs: '/p:IsStoreBuild=true'
+      ${{ if eq(parameters.useReleaseAppxManifest, true) }}:
+        ExtraMSBuildArgs: '/p:IsStoreBuild=true /p:UseReleaseAppxManifest=true'
+      ${{ if eq(parameters.useReleaseAppxManifest, false) }}:
+        ExtraMSBuildArgs: '/p:IsStoreBuild=true'
     ${{ if eq(parameters.isReleaseBuild, false) }}:
-      ExtraMSBuildArgs: ''
+      ${{ if eq(parameters.useReleaseAppxManifest, true) }}:
+        ExtraMSBuildArgs: '/p:UseReleaseAppxManifest=true'
+      ${{ if eq(parameters.useReleaseAppxManifest, false) }}:
+        ExtraMSBuildArgs: ''
   steps:
   - checkout: self
     fetchDepth: 1
@@ -31,10 +37,7 @@ jobs:
         downloadDirectory: $(Build.SourcesDirectory)
         vstsFeed: WindowsInboxApps
         vstsFeedPackage: calculator-internals
-        ${{ if eq(parameters.useTestVersionOfInternalsPackage, false) }}:
-          vstsPackageVersion: 0.0.66
-        ${{ if eq(parameters.useTestVersionOfInternalsPackage, true) }}:
-          vstsPackageVersion: 0.0.65
+        vstsPackageVersion: 0.0.66
 
   - task: NuGetToolInstaller@1
     displayName: Use NuGet 5.x

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -2,7 +2,7 @@
 
 parameters:
   isReleaseBuild: false
-  useReleaseAppxManifest: ${{ parameters.isReleaseBuild }}
+  useReleaseAppxManifest: false
   platform: ''
   condition: ''
 

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -37,7 +37,7 @@ jobs:
         downloadDirectory: $(Build.SourcesDirectory)
         vstsFeed: WindowsInboxApps
         vstsFeedPackage: calculator-internals
-        vstsPackageVersion: 0.0.66
+        vstsPackageVersion: 0.0.67
 
   - task: NuGetToolInstaller@1
     displayName: Use NuGet 5.x

--- a/build/pipelines/templates/package-appxbundle.yaml
+++ b/build/pipelines/templates/package-appxbundle.yaml
@@ -43,7 +43,7 @@ jobs:
         downloadDirectory: $(Build.SourcesDirectory)
         vstsFeed: WindowsInboxApps
         vstsFeedPackage: calculator-internals
-        vstsPackageVersion: 0.0.66
+        vstsPackageVersion: 0.0.67
 
   - task: PowerShell@2
     displayName: Generate AppxBundle mapping

--- a/build/pipelines/templates/package-appxbundle.yaml
+++ b/build/pipelines/templates/package-appxbundle.yaml
@@ -4,7 +4,7 @@
 
 parameters:
   signBundle: false
-  useTestVersionOfInternalsPackage: false
+  createStoreBrokerPackages: false
 
 jobs:
 - job: Package
@@ -44,16 +44,6 @@ jobs:
         vstsFeed: WindowsInboxApps
         vstsFeedPackage: calculator-internals
         vstsPackageVersion: 0.0.66
-
-  - ${{ if eq(parameters.useTestVersionOfInternalsPackage, true) }}:
-    - task: UniversalPackages@0
-      displayName: Download internals package
-      inputs:
-        command: download
-        downloadDirectory: $(Build.SourcesDirectory)
-        vstsFeed: WindowsInboxApps
-        vstsFeedPackage: calculator-internals
-        vstsPackageVersion: 0.0.65
 
   - task: PowerShell@2
     displayName: Generate AppxBundle mapping

--- a/src/Calculator/Calculator.csproj
+++ b/src/Calculator/Calculator.csproj
@@ -249,7 +249,12 @@
     </Compile>
     <Compile Include="WindowFrameService.cs" />
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(UseReleaseAppxManifest)' == 'True'">
+    <AppxManifest Include="Package.Release.appxmanifest">
+      <SubType>Designer</SubType>
+    </AppxManifest>
+  </ItemGroup>
+  <ItemGroup Condition="'$(UseReleaseAppxManifest)' != 'True'">
     <AppxManifest Include="Package.appxmanifest">
       <SubType>Designer</SubType>
     </AppxManifest>

--- a/src/Calculator/Package.Release.appxmanifest
+++ b/src/Calculator/Package.Release.appxmanifest
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5" IgnorableNamespaces="uap uap5 mp">
+    <Identity Name="Microsoft.WindowsCalculator" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" Version="10.1604.27012.0" />
+    <mp:PhoneIdentity PhoneProductId="b58171c6-c70c-4266-a2e8-8f9c994f4456" PhonePublisherId="95d94207-0c7c-47ed-82db-d75c81153c35" />
+    <Properties>
+        <DisplayName>ms-resource:AppStoreName</DisplayName>
+        <PublisherDisplayName>Microsoft Corporation</PublisherDisplayName>
+        <Logo>Assets\CalculatorStoreLogo.png</Logo>
+    </Properties>
+    <Dependencies>
+        <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.22000.0" MaxVersionTested="10.0.22000.0" />
+    </Dependencies>
+    <Resources>
+        <Resource Language="x-generate" />
+    </Resources>
+    <Applications>
+        <Application Id="App" Executable="$targetnametoken$.exe" EntryPoint="Calculator.App">
+            <uap:VisualElements DisplayName="ms-resource:AppName" Square150x150Logo="Assets\CalculatorMedTile.png" Square44x44Logo="Assets\CalculatorAppList.png" Description="ms-resource:AppDescription" BackgroundColor="#0078D4">
+                <uap:DefaultTile ShortName="ms-resource:AppName" Square310x310Logo="Assets\CalculatorLargeTile.png" Wide310x150Logo="Assets\CalculatorWideTile.png" Square71x71Logo="Assets\CalculatorSmallTile.png">
+                    <uap:ShowNameOnTiles>
+                        <uap:ShowOn Tile="square150x150Logo" />
+                        <uap:ShowOn Tile="wide310x150Logo" />
+                        <uap:ShowOn Tile="square310x310Logo" />
+                    </uap:ShowNameOnTiles>
+                </uap:DefaultTile>
+                <uap:SplashScreen Image="Assets\CalculatorSplashScreen.png" uap5:Optional="true" BackgroundColor="#0078D4" />
+            </uap:VisualElements>
+            <Extensions>
+                <uap:Extension Category="windows.protocol">
+                    <uap:Protocol Name="calculator">
+                        <uap:Logo>Assets\CalculatorAppList.png</uap:Logo>
+                    </uap:Protocol>
+                </uap:Extension>
+                <uap:Extension Category="windows.protocol">
+                    <uap:Protocol Name="ms-calculator">
+                        <uap:Logo>Assets\CalculatorAppList.png</uap:Logo>
+                    </uap:Protocol>
+                </uap:Extension>
+            </Extensions>
+        </Application>
+    </Applications>
+    <Capabilities>
+        <Capability Name="internetClient" />
+    </Capabilities>
+</Package>


### PR DESCRIPTION
Currently, the copy of Package.appxmanifest in this repo is overwritten with a copy from an internal repo during release builds. This change adds the release version of Package.appxmanifest to this repo, to make it easier to maintain and keep it in sync with the copy used during development.