### PR TITLE
UI tests should use CI runsettings in internal CI builds

### DIFF
--- a/build/pipelines/azure-pipelines.ci-internal.yaml
+++ b/build/pipelines/azure-pipelines.ci-internal.yaml
@@ -34,12 +34,12 @@ jobs:
 - template: ./templates/run-ui-tests.yaml
   parameters:
     platform: x64
-    runsettingsFileName: CalculatorUITests.ci.runsettings
+    runsettingsFileName: CalculatorUITests.ci-internal.runsettings
 
 - template: ./templates/run-ui-tests.yaml
   parameters:
     platform: x86
-    runsettingsFileName: CalculatorUITests.ci.runsettings
+    runsettingsFileName: CalculatorUITests.ci-internal.runsettings
 
 - template: ./templates/run-unit-tests.yaml
   parameters:

--- a/build/pipelines/azure-pipelines.ci-internal.yaml
+++ b/build/pipelines/azure-pipelines.ci-internal.yaml
@@ -34,12 +34,12 @@ jobs:
 - template: ./templates/run-ui-tests.yaml
   parameters:
     platform: x64
-    runsettingsFileName: CalculatorUITests.release.runsettings
+    runsettingsFileName: CalculatorUITests.ci.runsettings
 
 - template: ./templates/run-ui-tests.yaml
   parameters:
     platform: x86
-    runsettingsFileName: CalculatorUITests.release.runsettings
+    runsettingsFileName: CalculatorUITests.ci.runsettings
 
 - template: ./templates/run-unit-tests.yaml
   parameters:

--- a/src/CalculatorUITests/CalculatorUITests.ci-internal.runsettings
+++ b/src/CalculatorUITests/CalculatorUITests.ci-internal.runsettings
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RunSettings>
+    <DataCollectionRunSettings>
+        <DataCollectors>
+            <DataCollector uri="datacollector://microsoft/VideoRecorder/1.0" assemblyQualifiedName="Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder.VideoRecorderDataCollector, Microsoft.VisualStudio.TestTools.DataCollection.VideoRecorder, Version=15.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" friendlyName="Screen and Voice Recorder">
+            </DataCollector>
+        </DataCollectors>
+    </DataCollectionRunSettings>
+    <TestRunParameters>
+        <Parameter Name="AppId" Value="Microsoft.WindowsCalculator.Dev_8wekyb3d8bbwe!App" />
+        <Parameter Name="CurrencyWith3FractionalDigits" Value="Jordan - Dinar" />
+        <Parameter Name="CurrencyWithoutFractionalDigits" Value="Japan - Yen" />
+    </TestRunParameters>
+</RunSettings>

--- a/src/CalculatorUITests/CalculatorUITests.csproj
+++ b/src/CalculatorUITests/CalculatorUITests.csproj
@@ -13,6 +13,9 @@
     <ProjectReference Include="..\CalculatorUITestFramework\CalculatorUITestFramework.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <None Update="CalculatorUITests.ci-internal.runsettings">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="CalculatorUITests.release.runsettings">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
After the change in #1682, the internal CI build uses the .Dev app identity. Use the runsettings for UI tests that has the .Dev app identity.