### PR TITLE
Fixes a regression: use the correct manifest to update version

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -25,6 +25,10 @@ jobs:
         ExtraMSBuildArgs: '/p:UseReleaseAppxManifest=true'
       ${{ if eq(parameters.useReleaseAppxManifest, false) }}:
         ExtraMSBuildArgs: ''
+    ${{ if eq(parameters.useReleaseAppxManifest, false) }}:
+      ManifestFileName: 'Package.appxmanifest'
+    ${{ if eq(parameters.useReleaseAppxManifest, true) }}:
+      ManifestFileName: 'Package.Release.appxmanifest'
   steps:
   - checkout: self
     fetchDepth: 1
@@ -56,7 +60,7 @@ jobs:
     displayName: Set version number in AppxManifest
     inputs:
       filePath: $(Build.SourcesDirectory)\build\scripts\UpdateAppxManifestVersion.ps1
-      arguments: '-AppxManifest $(Build.SourcesDirectory)\src\Calculator\Package.appxmanifest -Version $(Build.BuildNumber)'
+      arguments: '-AppxManifest $(Build.SourcesDirectory)\src\Calculator\$(ManifestFileName) -Version $(Build.BuildNumber)'
 
   - task: VSBuild@1
     displayName: 'Build solution src/Calculator.sln'


### PR DESCRIPTION
## Fixes a regression: use the correct manifest to update version
Calculator's version is being frozen at 10.1604.27012.0. This is a regression related to PR #1682.

### Description of the changes:
- Add a variable in pipeline config to help decide which manifest should be used to update version.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested with below pipeline runs:
  1. Release run [11.2109.2.0](https://dev.azure.com/microsoft/Apps/_build/results?buildId=39507387&view=results)
  1. Internal CI run [0.2109.2601.0](https://dev.azure.com/microsoft/Apps/_build/results?buildId=39508163&view=results)
  1. PR/CI run [0.2109.2603.0](https://dev.azure.com/ms/calculator/_build/results?buildId=225410&view=results)

