### PR TITLE
Fixes a UI test case: AoT_ButtonOnlyInStandard

### DIFF
--- a/src/CalculatorUITests/StandardModeFunctionalTests.cs
+++ b/src/CalculatorUITests/StandardModeFunctionalTests.cs
@@ -732,7 +732,7 @@ namespace CalculatorUITests
 
             CalculatorApp.EnsureCalculatorHasFocus();
             page.NavigationMenu.ChangeCalculatorMode(CalculatorMode.DateCalculator);
-            Assert.AreEqual("Date Calculation", CalculatorApp.GetCalculatorHeaderText());
+            Assert.AreEqual("Date calculation", CalculatorApp.GetCalculatorHeaderText());
             page.StandardAoTCalculatorPage.GetAoTPresence();
             Assert.AreEqual("False", page.StandardAoTCalculatorPage.GetAoTPresence());
 


### PR DESCRIPTION
## Fixes a UI test case: AoT_ButtonOnlyInStandard
The test case failed with error: `Assert.AreEqual failed. Expected:<Date Calculation>. Actual:<Date calculation>.`
This is related to the changes in PR #1687.
![image](https://user-images.githubusercontent.com/60599517/134833343-aaee0363-d2d7-4877-8343-868f1a840eda.png)

### Description of the changes:
- Adjusts the out-of-date string in the test case.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manually tested.

