### PR TITLE
Cherry-pick: Bumps the major version to 11 (#1698) for release/2109-1

### DIFF
--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -8,9 +8,9 @@ trigger: none
 pr: none
 
 variables:
-  versionMajor: 10
+  versionMajor: 11
   versionMinor: 2109
-  versionBuild: $[counter('10.2109.*', 0)]
+  versionBuild: $[counter('11.2109.*', 0)]
   versionPatch: 0
 
 name: '$(versionMajor).$(versionMinor).$(versionBuild).$(versionPatch)'


### PR DESCRIPTION
## Cherry-pick: Bumps the major version to 11 (#1698) for release/2109-1

> Major version number of Calculator should be bumped to 11
