### PR TITLE
Cherry-pick: Use the correct manifest to update version (#1701) for release/2109-1

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -25,6 +25,10 @@ jobs:
         ExtraMSBuildArgs: '/p:UseReleaseAppxManifest=true'
       ${{ if eq(parameters.useReleaseAppxManifest, false) }}:
         ExtraMSBuildArgs: ''
+    ${{ if eq(parameters.useReleaseAppxManifest, false) }}:
+      ManifestFileName: 'Package.appxmanifest'
+    ${{ if eq(parameters.useReleaseAppxManifest, true) }}:
+      ManifestFileName: 'Package.Release.appxmanifest'
   steps:
   - checkout: self
     fetchDepth: 1
@@ -56,7 +60,7 @@ jobs:
     displayName: Set version number in AppxManifest
     inputs:
       filePath: $(Build.SourcesDirectory)\build\scripts\UpdateAppxManifestVersion.ps1
-      arguments: '-AppxManifest $(Build.SourcesDirectory)\src\Calculator\Package.appxmanifest -Version $(Build.BuildNumber)'
+      arguments: '-AppxManifest $(Build.SourcesDirectory)\src\Calculator\$(ManifestFileName) -Version $(Build.BuildNumber)'
 
   - task: VSBuild@1
     displayName: 'Build solution src/Calculator.sln'


### PR DESCRIPTION
## Cherry-pick: Use the correct manifest to update version (#1701) for release/2109-1

> ## Fixes a regression: use the correct manifest to update version
> Calculator's version is being frozen at 10.1604.27012.0. This is a regression related to PR #1682.
> ### Description of the changes:
> Add a variable in pipeline config to help decide which manifest should be used to update version.