### PR TITLE
Update bundle version to 2021

### DIFF
--- a/build/pipelines/templates/package-appxbundle.yaml
+++ b/build/pipelines/templates/package-appxbundle.yaml
@@ -53,7 +53,7 @@ jobs:
 
   - powershell: |
       $buildVersion = [version]$Env:BUILDVERSION
-      $bundleVersion = "2020.$($buildVersion.Minor).$($buildVersion.Build).$($buildVersion.Revision)"
+      $bundleVersion = "2021.$($buildVersion.Minor).$($buildVersion.Build).$($buildVersion.Revision)"
       & "C:\Program Files (x86)\Windows Kits\10\bin\10.0.18362.0\x86\MakeAppx.exe" bundle /v /bv $bundleVersion /f $Env:MAPPINGFILEPATH /p $Env:OUTPUTPATH
     displayName: Make AppxBundle
     env:


### PR DESCRIPTION
In #1698, the app major version was bumped from 10->11.

We also need to update the _bundle_ major version when we update the app major version, so that 10.* bundles do not have the same bundle version numbers as 11.* bundles.