### PR TITLE
[Localization] Fix invalid "microseconds" on ko-KR localization

### DIFF
--- a/src/Calculator/Resources/ko-KR/Resources.resw
+++ b/src/Calculator/Resources/ko-KR/Resources.resw
@@ -1810,7 +1810,7 @@
     <comment>A measurement unit for length. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Microsecond" xml:space="preserve">
-    <value>밀리초</value>
+    <value>마이크로초</value>
     <comment>A measurement unit for time. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Mile" xml:space="preserve">


### PR DESCRIPTION
**I know this repository doesn't accept the localization PR, but I created this PR to show that it still exists on the master branch on the discussion in #1719  .**

## Fixes #1719 .

### Description of the changes:
- Fix both "Milliseconds(밀리초)" and "Microseconds(마이크로초)" are
  translated to "Milliseconds("밀리초") on ko-KR localization