### PR TITLE
Modify package identity on CI pipelines for easier testing

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -56,6 +56,13 @@ jobs:
       command: custom
       arguments: restore src/Calculator.sln -Verbosity Detailed
 
+  - ${{ if eq(parameters.isReleaseBuild, false) }}:
+    - task: PowerShell@2
+      displayName: Set package identity to Calculator.Dev.$(Build.BuildId)
+      inputs:
+        filePath: $(Build.SourcesDirectory)\build\scripts\UpdateAppxManifestIdentity.ps1
+        arguments: '-AppxManifest $(Build.SourcesDirectory)\src\Calculator\$(ManifestFileName) -Identity Calculator.Dev.$(Build.BuildId)'
+
   - task: PowerShell@2
     displayName: Set version number in AppxManifest
     inputs:

--- a/build/scripts/UpdateAppxManifestIdentity.ps1
+++ b/build/scripts/UpdateAppxManifestIdentity.ps1
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+    Updates the package identity in an AppxManifest file.
+
+.PARAMETER AppxManifest
+    The path to the AppxManifest file.
+
+.PARAMETER Identity
+    The package identity to write into the file.
+
+.EXAMPLE
+    Update-AppxManifestIdentity -AppxManifest "C:\App\Package.appxmanifest" -Identity "Microsoft.AppName"
+#>
+param(
+    [ValidateScript({Test-Path -Path $_ -PathType 'Leaf'})]
+    [Parameter(Mandatory)]
+    [string] $AppxManifest,
+
+    [Parameter(Mandatory)]
+    [string] $Identity
+)
+
+$xmlDoc = [XML](Get-Content $AppxManifest -Encoding UTF8)
+$xmlDoc.Package.Identity.setAttribute("Name", $Identity)
+$xmlDoc.Save($AppxManifest)


### PR DESCRIPTION
## Fixes #.
Modify package identity on CI pipelines for easier testing.

### Description of the changes:
- Add a script to modify the package identity
- Add a stage for CI builds to call the script

### How changes were validated:
- Validated with internal ADO pipelines