### PR TITLE
Remove unnecessary metadata to reduce binary size

### DIFF
--- a/src/Calculator/Calculator.csproj
+++ b/src/Calculator/Calculator.csproj
@@ -35,6 +35,7 @@
     <GenerateTestArtifacts>True</GenerateTestArtifacts>
     <AppxBundlePlatforms>$(Platform)</AppxBundlePlatforms>
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
+    <IlcParameters>/disableStackTraceMetadata /disableExceptionMessages</IlcParameters>
   </PropertyGroup>
   <!-- This has to be exactly in this place for this to work -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x86'">

--- a/src/Calculator/Properties/Default.rd.xml
+++ b/src/Calculator/Properties/Default.rd.xml
@@ -17,15 +17,6 @@
 
 <Directives xmlns="http://schemas.microsoft.com/netfx/2013/01/metadata">
   <Application>
-    <!--
-      An Assembly element with Name="*Application*" applies to all assemblies in
-      the application package. The asterisks are not wildcards.
-    -->
-    <Assembly Name="*Application*" Dynamic="Required All" />
-    
-    
     <!-- Add your application specific runtime directives here. -->
-
-
   </Application>
 </Directives>


### PR DESCRIPTION
Fixes #1688

As described in the issue above, the rd.xml in this project comes from the default Visual Studio project template which is optimized for compatibility. Removing `*Application*` avoids adding reflection data into the binary for things which the app doesn't actually need.

This PR also applies two other size optimizations:
`/disableStackTraceMetadata`: The compiler generates data structures that help generating stack traces (for things like Exception.ToString() on thrown exceptions). Our debugging tools (e.g. crash dumps with postmortem debugging) don't rely on this, so we don't need to include this data in the binary.
`/disableExceptionMessages`: This option disables generation of exception messages for framework-thrown exceptions (so instead of e.g. the "Object reference not set to an instance of an object." message, we'll get "Arg_NullReferenceException" in the exception's Message field).

The net effect of these optimizations is a substantial size decrease in CalculatorApp.dll. On x64, before: 8.79MB after: 7.25 MB