### PR TITLE
Fix localizations on data byte units (#1725)

### DIFF
--- a/src/Calculator/Resources/ko-KR/Resources.resw
+++ b/src/Calculator/Resources/ko-KR/Resources.resw
@@ -1654,7 +1654,7 @@
     <comment>A measurement unit for power: British Thermal Units per minute. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Byte" xml:space="preserve">
-    <value>바이트 수</value>
+    <value>바이트</value>
     <comment>A measurement unit for data. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Calorie" xml:space="preserve">
@@ -1726,7 +1726,7 @@
     <comment>A measurement unit for data. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Gigabyte" xml:space="preserve">
-    <value>GB</value>
+    <value>기가바이트</value>
     <comment>A measurement unit for data. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Hectare" xml:space="preserve">
@@ -1754,7 +1754,7 @@
     <comment>An option in the unit converter to select the temperature system "Kelvin" (eg. 0 degrees Celsius = 273 Kelvin). At least in English, Kelvin does not use "degrees". A measurement is just stated as "273 Kelvin".</comment>
   </data>
   <data name="UnitName_Kilobit" xml:space="preserve">
-    <value>Kbps</value>
+    <value>킬로비트</value>
     <comment>A measurement unit for data. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Kilobyte" xml:space="preserve">
@@ -2346,7 +2346,7 @@
     <comment>The paste operation cannot be performed, if the expression is invalid.</comment>
   </data>
   <data name="UnitName_Gibibits" xml:space="preserve">
-    <value>기비비트(비트)</value>
+    <value>기비비트</value>
     <comment>A measurement unit for data. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Gibibytes" xml:space="preserve">
@@ -2362,7 +2362,7 @@
     <comment>A measurement unit for data. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Mebibits" xml:space="preserve">
-    <value>메비바이트</value>
+    <value>메비비트</value>
     <comment>A measurement unit for data. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Mebibytes" xml:space="preserve">
@@ -2394,7 +2394,7 @@
     <comment>A measurement unit for data. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Exbibits" xml:space="preserve">
-    <value>엑시비비트</value>
+    <value>엑스비비트</value>
     <comment>A measurement unit for data. (Please choose the most appropriate plural form to fit any number between 0 and 999,999,999,999,999)</comment>
   </data>
   <data name="UnitName_Exbibytes" xml:space="preserve">


### PR DESCRIPTION
## Fixes #1725

### Description of the changes:


| English | Korean (before) | Fixed | description |
| - | - | - | - |
| Bytes | 바이트 수 | 바이트 | `수` is useless (it means unit/number in korean) |
| Kilobits | Kbps | 킬로비트 | wrong translation, `Kbps` means bitrate for 'Kilobits Per Second' |
| Mebibits | 메비바이트 | 메비비트 | wrong translation, it's '비트' for bits, not '바이트' |
| Gibibits | 기비비트(비트) | 기비비트 | `(비트)` is useless |
| Gigabytes | GB | 기가바이트 | missing translation |
| Exbibits | 엑시비비트 | 엑스비비트 | typo |


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- forked it and fixed localizations
- then, build an application to test as shown as following screenshot:

![image](https://user-images.githubusercontent.com/9527681/137921552-ad2608a1-1aa2-4975-b6c6-cebc90cddd92.png)

