### PR TITLE
Drop non-negative tests on unsigned values

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -600,7 +600,7 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         // Set the "(=xx" indicator.
         if (nullptr != m_pCalcDisplay)
         {
-            m_pCalcDisplay->SetParenthesisNumber(m_openParenCount >= 0 ? static_cast<unsigned int>(m_openParenCount) : 0);
+            m_pCalcDisplay->SetParenthesisNumber(static_cast<unsigned int>(m_openParenCount));
         }
 
         if (!m_bError)

--- a/src/CalcManager/CalculatorHistory.cpp
+++ b/src/CalcManager/CalculatorHistory.cpp
@@ -79,7 +79,7 @@ vector<shared_ptr<HISTORYITEM>> const& CalculatorHistory::GetHistory()
 
 shared_ptr<HISTORYITEM> const& CalculatorHistory::GetHistoryItem(unsigned int uIdx)
 {
-    assert(uIdx >= 0 && uIdx < m_historyItems.size());
+    assert(uIdx < m_historyItems.size());
     return m_historyItems.at(uIdx);
 }
 


### PR DESCRIPTION
As some of the variables are of unsigned types, it makes no sense to
test them for non-negativeness, as this is enforced by type already.