### PR TITLE
Fix primary display bug by adding leading 0's to binary values

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -137,6 +137,13 @@ StandardCalculatorViewModel::StandardCalculatorViewModel()
 String ^ StandardCalculatorViewModel::LocalizeDisplayValue(_In_ wstring const& displayValue)
 {
     wstring result(displayValue);
+
+    // Adds leading padding 0's to Programmer Mode's Binary Display
+    if (IsProgrammer && CurrentRadixType == NumberBase::BinBase)
+    {
+        result = AddPadding(result);
+    }
+
     LocalizationSettings::GetInstance()->LocalizeDisplayValue(&result);
     return ref new Platform::String(result.c_str());
 }

--- a/src/CalculatorUITestFramework/ProgrammerCalculatorPage.cs
+++ b/src/CalculatorUITestFramework/ProgrammerCalculatorPage.cs
@@ -7,7 +7,7 @@ using OpenQA.Selenium.Appium.Windows;
 namespace CalculatorUITestFramework
 {
     /// <summary>
-    /// This class contains the UI automation objects and helper methods available when the Calculator is in Scientific Mode.
+    /// This class contains the UI automation objects and helper methods available when the Calculator is in Programmer Mode.
     /// </summary>
     public class ProgrammerCalculatorPage
     {

--- a/src/CalculatorUITests/ProgrammerModeFunctionalTests.cs
+++ b/src/CalculatorUITests/ProgrammerModeFunctionalTests.cs
@@ -340,7 +340,7 @@ namespace CalculatorUITests
             page.ProgrammerOperators.LeftShiftButton.Click();
             page.StandardOperators.NumberPad.Input(1);
             page.StandardOperators.EqualButton.Click();
-            Assert.AreEqual("1  0 1 0 0", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("0 0 0 1  0 1 0 0", page.CalculatorResults.GetCalculatorResultText());
         }
 
         [TestMethod]
@@ -352,7 +352,7 @@ namespace CalculatorUITests
             page.ProgrammerOperators.RightShiftButton.Click();
             page.StandardOperators.NumberPad.Input(1);
             page.StandardOperators.EqualButton.Click();
-            Assert.AreEqual("1 0 1", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("0 1 0 1", page.CalculatorResults.GetCalculatorResultText());
         }
 
         [TestMethod]
@@ -429,7 +429,7 @@ namespace CalculatorUITests
             page.ProgrammerOperators.XorButton.Click();
             page.StandardOperators.NumberPad.Input(1100);
             page.StandardOperators.EqualButton.Click();
-            Assert.AreEqual("1 1 0", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("0 1 1 0", page.CalculatorResults.GetCalculatorResultText());
         }
 
         /// <summary>
@@ -623,7 +623,7 @@ namespace CalculatorUITests
             page.ProgrammerOperators.LeftShiftLogicalButton.Click();
             page.StandardOperators.NumberPad.Input(1);
             page.StandardOperators.EqualButton.Click();
-            Assert.AreEqual("1  0 1 0 0", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("0 0 0 1  0 1 0 0", page.CalculatorResults.GetCalculatorResultText());
         }
 
         [TestMethod]
@@ -637,7 +637,7 @@ namespace CalculatorUITests
             page.ProgrammerOperators.RightShiftLogicalButton.Click();
             page.StandardOperators.NumberPad.Input(1);
             page.StandardOperators.EqualButton.Click();
-            Assert.IsTrue(String.Equals(page.CalculatorResults.GetCalculatorResultText(), "1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 0 1 1", StringComparison.OrdinalIgnoreCase));
+            Assert.IsTrue(String.Equals(page.CalculatorResults.GetCalculatorResultText(), "0 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 1 1 1  1 0 1 1", StringComparison.OrdinalIgnoreCase));
         }
 
         /// <summary>
@@ -737,7 +737,7 @@ namespace CalculatorUITests
             page.StandardOperators.NumberPad.Input(1011);
             page.ProgrammerOperators.RoLButton.Click();
             page.StandardOperators.EqualButton.Click();
-            Assert.AreEqual("1  0 1 1 0", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("0 0 0 1  0 1 1 0", page.CalculatorResults.GetCalculatorResultText());
         }
 
         [TestMethod]
@@ -846,7 +846,7 @@ namespace CalculatorUITests
             page.StandardOperators.NumberPad.Input(1010);
             page.ProgrammerOperators.RoLButton.Click();
             page.StandardOperators.EqualButton.Click();
-            Assert.AreEqual("1  0 1 0 0", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("0 0 0 1  0 1 0 0", page.CalculatorResults.GetCalculatorResultText());
         }
 
         [TestMethod]
@@ -858,7 +858,7 @@ namespace CalculatorUITests
             page.StandardOperators.NumberPad.Input(1011);
             page.ProgrammerOperators.RoRCarryButton.Click();
             page.StandardOperators.EqualButton.Click();
-            Assert.AreEqual("1 0 1", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("0 1 0 1", page.CalculatorResults.GetCalculatorResultText());
         }
 
         /// <summary>


### PR DESCRIPTION
## Fixes #1739
Before:
![Calculator5-before](https://user-images.githubusercontent.com/57678673/146152764-5916a37b-333f-4078-9465-b11732214c76.png)
After:
![Calculator5-after](https://user-images.githubusercontent.com/57678673/146152762-bc9c0e15-d2e6-4fb1-9c41-ae260daf3459.png)
### Description of the changes:
- Added leading 0's to binary value of the Primary Display in Programmer Mode to make it consistent with the value after "BIN"
- Note: the location of the change might also affect the NarratorDisplayValue/screen reading, but I am unsure of how to properly test this. If the screen reader reads each digit separately it shouldn't be an issue. 
- Changed some UI Test Cases to reflect the fix by adding some leading 0's to binary values
- Minor fix to the description of a class

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Automated testing - passes all current unit tests and the modified UI tests
- Manually - tested with decimal values of 1, 5, and the example hex value from Issue 1739


Also, please ignore the first and third commits. The one with the SHA that starts with "ede4f48" should contain all the changes