### PR TITLE
Run loc pipeline on windows-2022 image

### DIFF
--- a/build/pipelines/azure-pipelines.loc.yaml
+++ b/build/pipelines/azure-pipelines.loc.yaml
@@ -23,7 +23,7 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: Localize
   pool:
-    vmImage: windows-2019
+    vmImage: windows-2022
   variables:
     skipComponentGovernanceDetection: true
   steps:


### PR DESCRIPTION
Run the localization pipeline on the windows-2022 image. We will be switching to windows-2022 and Visual Studio 2022 for the main app builds sometime soon. It doesn't really matter which image the loc pipeline runs on, but switching it to windows-2022 will help keep all pipelines consistent.
