### PR TITLE
Remove NuGetCommand workaround in YAML

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -48,9 +48,7 @@ jobs:
     inputs:
       versionSpec: 5.x
 
-  # In most accounts, you can just use 'NuGetCommand' instead of this GUID.
-  # In the microsoft.visualstudio.com account, NuGetCommand is ambiguous so the GUID is needed.
-  - task: 333b11bd-d341-40d9-afcf-b32d5ce6f23b@2
+  - task: NuGetCommand@2
     displayName: NuGet restore src/Calculator.sln
     inputs:
       command: custom


### PR DESCRIPTION
An internal Azure DevOps organization at Microsoft used to have two tasks named "NuGetCommand". That problem has been resolved, and only the official NuGetCommand remains. This change removes the workaround and out-of-date comment, so our pipeline can be a better example for others.