### PR TITLE
Update build year in settings page to 2022

### DIFF
--- a/src/Calculator/Views/Settings.xaml.cs
+++ b/src/Calculator/Views/Settings.xaml.cs
@@ -23,9 +23,7 @@ namespace CalculatorApp
 {
     public sealed partial class Settings : UserControl
     {
-        // CSHARP_MIGRATION: TODO:
-        // BUILD_YEAR was a C++/CX macro and may update the value from the pipeline
-        private const string BUILD_YEAR = "2021";
+        private const string BUILD_YEAR = "2022";
 
         public event Windows.UI.Xaml.RoutedEventHandler BackButtonClick;
 


### PR DESCRIPTION
Updates the build year in the settings page to 2022.

Also removes a comment which is unclear--the build year is not updated from the pipeline. Maybe that's something we could do in the future, but I don't think we need to mention it in the code since it's not really a regression from the C++ version of the code.