### PR TITLE
Delete packages.config

### DIFF
--- a/src/Calculator/packages.config
+++ b/src/Calculator/packages.config
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.UI.Xaml" version="2.4.3" targetFramework="native" />
-</packages>


### PR DESCRIPTION
Now that the Calculator project is C#, it [uses PackageReference](https://github.com/microsoft/calculator/blob/1ded536d80315e637ee62692648c549f287b1475/src/Calculator/Calculator.csproj#L793) to list the NuGet packages it depends on.

This makes src/Calculator/packages.config obsolete and out-of-date. It can be deleted.