### PR TITLE
Replace dead link in ApplicationArchitecture.md

### DIFF
--- a/docs/ApplicationArchitecture.md
+++ b/docs/ApplicationArchitecture.md
@@ -21,11 +21,11 @@ that build into the final Calculator application.
 
 The View layer is contained in the [Calculator project][Calculator folder]. This project contains mostly XAML files
 and various custom controls that support the UI. [App.xaml][App.xaml] contains many of the [static][StaticResource] and
-[theme][ThemeResource] resources that the other XAML files will reference. Its code-behind file, [App.xaml.cpp][App.xaml.cpp],
+[theme][ThemeResource] resources that the other XAML files will reference. Its code-behind file, [App.xaml.cs][App.xaml.cs],
 contains the main entry point to the application. On startup, it navigates to the main page.
 
-```C++
-rootFrame->Navigate(MainPage::typeid, argument)
+```C#
+rootFrame.Navigate(typeof(MainPage), argument)
 ```
 
 In Calculator, there is only one concrete [Page][Page] class: [MainPage.xaml][MainPage.xaml]. `MainPage` is the root
@@ -166,7 +166,7 @@ instead of regular floating point arithmetic). The interface to this layer is de
 
 [Calculator folder]:                  ../src/Calculator
 [App.xaml]:                           ../src/Calculator/App.xaml
-[App.xaml.cpp]:                       ../src/Calculator/App.xaml.cpp
+[App.xaml.cs]:                       ../src/Calculator/App.xaml.cs
 [StaticResource]:                     https://docs.microsoft.com/en-us/windows/uwp/xaml-platform/staticresource-markup-extension
 [ThemeResource]:                      https://docs.microsoft.com/en-us/windows/uwp/xaml-platform/themeresource-markup-extension
 [Page]:                               https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Xaml.Controls.Page


### PR DESCRIPTION
## Fixes

Fixes a dead link to an old C++ code-behind file in `ApplicationArchitecture.md`.

### Description of the changes:

It seems the `ApplicationArchitecture.md` document hasn't been updated with the introduction of C# and still references an old C++ code-behind file, which is a dead link. This change replaces the dead link with a link to the C# counterpart and also replaces the C++ code excerpt with the corresponding C# code.

### How changes were validated:

Local check (markdown-only change).