### PR TITLE
Update internals package to 0.0.78

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -41,7 +41,7 @@ jobs:
         downloadDirectory: $(Build.SourcesDirectory)
         vstsFeed: WindowsInboxApps
         vstsFeedPackage: calculator-internals
-        vstsPackageVersion: 0.0.67
+        vstsPackageVersion: 0.0.78
 
   - task: NuGetToolInstaller@1
     displayName: Use NuGet 5.x

--- a/build/pipelines/templates/package-msixbundle.yaml
+++ b/build/pipelines/templates/package-msixbundle.yaml
@@ -43,7 +43,7 @@ jobs:
         downloadDirectory: $(Build.SourcesDirectory)
         vstsFeed: WindowsInboxApps
         vstsFeedPackage: calculator-internals
-        vstsPackageVersion: 0.0.67
+        vstsPackageVersion: 0.0.78
 
   - task: PowerShell@2
     displayName: Generate MsixBundle mapping


### PR DESCRIPTION
Since #1793 was merged, we also need to update our internals package to build properly with Visual Studio 2022.