### PR TITLE
Fixes a bug: currency converter never shows error message for service failures

### DIFF
--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -188,10 +188,9 @@ void CurrencyDataLoader::ResetLoadStatus()
 #pragma optimize("", off) // Turn off optimizations to work around DevDiv 393321
 void CurrencyDataLoader::LoadData()
 {
-    RegisterForNetworkBehaviorChanges();
-
     if (!LoadFinished())
     {
+        RegisterForNetworkBehaviorChanges();
         create_task([this]() -> task<bool> {
             vector<function<future<bool>()>> loadFunctions = {
                 [this]() { return TryLoadDataFromCacheAsync(); },

--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -673,9 +673,8 @@
                                 </ResourceDictionary>
                             </HyperlinkButton.Resources>
                         </HyperlinkButton>
-                        <TextBlock Margin="3,7,0,0" Style="{ThemeResource CaptionTextBlockStyle}">
+                        <TextBlock Margin="3,6,0,0" Style="{ThemeResource CaptionTextBlockStyle}">
                             <Run x:Name="CurrencySecondaryStatus"
-                                 FontWeight="SemiBold"
                                  Text=""/>
                         </TextBlock>
                     </StackPanel>


### PR DESCRIPTION
## Fixes: currency converter never shows error message for service failures


### Description of the changes:
- Before the fix,  CurrencyDataLoader always discard and register a new *NetworkBehavior* even if it doesn't really take action to load the data. This results in many redundant callback invocation which force the state gets reset so that the VM reset the error message back to normal state immediately.
- After the fix, the *NetworkBehavior* will only be registered when the loader decides to take real actions to load data.

### Screenshots
Before the fix:
![image](https://user-images.githubusercontent.com/60599517/154324327-12d39aa0-eddf-4e02-a9d7-c5fa6314be05.png)

After the fix:
![image](https://user-images.githubusercontent.com/60599517/154325998-704122d2-9b45-484b-b86f-bb7557172c35.png)


### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Tested manually

