### PR TITLE
Switch internal localization pipeline to new pool

### DIFF
--- a/build/pipelines/azure-pipelines.loc.yaml
+++ b/build/pipelines/azure-pipelines.loc.yaml
@@ -23,7 +23,7 @@ name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 jobs:
 - job: Localize
   pool:
-    vmImage: windows-2022
+    name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
   steps:


### PR DESCRIPTION
Switch the internal localization pipeline from the Azure Pipelines pool to the "EssentialExperiences-windows-2022" pool.