### PR TITLE
Run builds in proper VM pools

### DIFF
--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -19,33 +19,42 @@ jobs:
 - template: ./templates/build-single-architecture.yaml
   parameters:
     platform: x64
+    isOSSBuild: true
 
 - template: ./templates/build-single-architecture.yaml
   parameters:
     platform: x86
+    isOSSBuild: true
     condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
 - template: ./templates/build-single-architecture.yaml
   parameters:
     platform: ARM
+    isOSSBuild: true
     condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
 - template: ./templates/build-single-architecture.yaml
   parameters:
     platform: ARM64
+    isOSSBuild: true
     condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
 - template: ./templates/run-ui-tests.yaml
   parameters:
     platform: x64
+    isOSSBuild: true
     runsettingsFileName: CalculatorUITests.ci.runsettings
 
 - template: ./templates/run-unit-tests.yaml
   parameters:
     platform: x64
+    isOSSBuild: true
 
 - template: ./templates/run-unit-tests.yaml
   parameters:
     platform: x86
+    isOSSBuild: true
 
 - template: ./templates/package-msixbundle.yaml
+  parameters:
+    isOSSBuild: true

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -2,6 +2,7 @@
 
 parameters:
   isReleaseBuild: false
+  isOSSBuild: false
   useReleaseAppxManifest: false
   platform: ''
   condition: ''
@@ -11,7 +12,10 @@ jobs:
   displayName: Build ${{ parameters.platform }}
   condition: ${{ parameters.condition }}
   pool:
-    vmImage: windows-2022
+    ${{ if eq(parameters.isOSSBuild, true) }}:
+      name: EssentialExperiencesOpenSource-windows-2022
+    ${{ if eq(parameters.isOSSBuild, false) }}:
+      name: EssentialExperiences-windows-2022
   variables:
     BuildConfiguration: Release
     BuildPlatform: ${{ parameters.platform }}

--- a/build/pipelines/templates/package-msixbundle.yaml
+++ b/build/pipelines/templates/package-msixbundle.yaml
@@ -3,6 +3,7 @@
 # this job also signs the bundle and creates StoreBroker packages.
 
 parameters:
+  isOSSBuild: false
   signBundle: false
   createStoreBrokerPackages: false
 
@@ -20,7 +21,10 @@ jobs:
       in(dependencies.BuildARM.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     ) 
   pool:
-    vmImage: windows-2022
+    ${{ if eq(parameters.isOSSBuild, true) }}:
+      name: EssentialExperiencesOpenSource-windows-2022
+    ${{ if eq(parameters.isOSSBuild, false) }}:
+      name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
     StoreBrokerMediaRootPath: $(TEMP)\SBMedia

--- a/build/pipelines/templates/release-store.yaml
+++ b/build/pipelines/templates/release-store.yaml
@@ -4,7 +4,7 @@ jobs:
 - job: ReleaseStore
   dependsOn: Package
   pool:
-    vmImage: windows-2022
+    name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
     StoreBrokerPackagePath: $(Build.ArtifactStagingDirectory)\storeBrokerPayload

--- a/build/pipelines/templates/release-vpack.yaml
+++ b/build/pipelines/templates/release-vpack.yaml
@@ -5,7 +5,7 @@ jobs:
 - job: ReleaseVPack
   dependsOn: Package
   pool:
-    vmImage: windows-2022
+    name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
   steps:

--- a/build/pipelines/templates/run-ui-tests.yaml
+++ b/build/pipelines/templates/run-ui-tests.yaml
@@ -1,6 +1,7 @@
 # This template contains jobs to run UI tests using WinAppDriver.
 
 parameters:
+  isOSSBuild: false
   platform: ''
   runsettingsFileName: ''
 
@@ -10,7 +11,10 @@ jobs:
   dependsOn: Build${{ parameters.platform }}
   condition: succeeded()
   pool:
-    vmImage: windows-2022
+    ${{ if eq(parameters.isOSSBuild, true) }}:
+      name: EssentialExperiencesOpenSource-windows-2022
+    ${{ if eq(parameters.isOSSBuild, false) }}:
+      name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
   steps:

--- a/build/pipelines/templates/run-unit-tests.yaml
+++ b/build/pipelines/templates/run-unit-tests.yaml
@@ -1,6 +1,7 @@
 # This template contains jobs to run unit tests.
 
 parameters:
+  isOSSBuild: false
   platform: ''
   runsettingsFileName: ''
 
@@ -10,7 +11,10 @@ jobs:
   dependsOn: Build${{ parameters.platform }}
   condition: succeeded()
   pool:
-    vmImage: windows-2022
+    ${{ if eq(parameters.isOSSBuild, true) }}:
+      name: EssentialExperiencesOpenSource-windows-2022
+    ${{ if eq(parameters.isOSSBuild, false) }}:
+      name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
   steps:


### PR DESCRIPTION
## Run builds in proper VM pools


### Description of the changes:
- GitHub PR/CI pipelines run in `EssentialExperiencesOpenSource-windows-2022`
- Others run in `EssentialExperiences-windows-2022`

