### PR TITLE
Set versionBuild automatically

### DIFF
--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -10,7 +10,7 @@ pr: none
 variables:
   versionMajor: 11
   versionMinor: 2202
-  versionBuild: $[counter('11.2202.*', 0)]
+  versionBuild: $[counter(format('{0}.{1}.*', variables['versionMajor'], variables['versionMinor']), 0)]
   versionPatch: 0
 
 name: '$(versionMajor).$(versionMinor).$(versionBuild).$(versionPatch)'


### PR DESCRIPTION
We update the minor version of our apps manually every month by updating `versionMinor` in azure-pipelines.release.yaml. Whenever we update the minor version, we also need to create a new counter for the build version that starts at 0 and increases every build. We create a new counter by changing the first parameter of the `counter` function to a new string.

This PR sets the `counter` string automatically based on the major and minor version variables, eliminating the need for manual updates.