### PR TITLE
Disable buttons when units are not loaded

### DIFF
--- a/src/Calculator/Views/UnitConverter.xaml
+++ b/src/Calculator/Views/UnitConverter.xaml
@@ -499,6 +499,9 @@
                         <Setter Target="Value1Container.Visibility" Value="Collapsed"/>
                         <Setter Target="Units2.Visibility" Value="Collapsed"/>
                         <Setter Target="Value2Container.Visibility" Value="Collapsed"/>
+                        <Setter Target="NumberPad.IsEnabled" Value="False"/>
+                        <Setter Target="ClearEntryButtonPos0.IsEnabled" Value="False"/>
+                        <Setter Target="BackSpaceButtonSmall.IsEnabled" Value="False"/>
                     </VisualState.Setters>
                 </VisualState>
                 <VisualState x:Name="UnitLoadedState"/>


### PR DESCRIPTION
### Description of the changes:
When units are not loaded, units related controls are hidden. Thus, disable number pad, clear entry and back space buttons in such case.
![image](https://user-images.githubusercontent.com/78525595/156711689-6d16cf8e-4944-46c4-8fdc-dd88f8ba5740.png)

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manually tested.

