### PR TITLE
Fixed Graph layout direction in Right To Left languages

### DIFF
--- a/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingCalculator.xaml
@@ -592,6 +592,7 @@
                                   LosingFocus="GraphingControl_LosingFocus"
                                   LostFocus="GraphingControl_LostFocus"
                                   UseSystemFocusVisuals="True"
+                                  FlowDirection="LeftToRight"
                                   VariablesUpdated="GraphingControl_VariablesUpdated">
                 <graphControl:Grapher.ContextFlyout>
                     <MenuFlyout Placement="Bottom">


### PR DESCRIPTION
## Fixes #1352.

This change is created because the graph renders backwards when the app FlowDirection is RightToLeft.

This change should override the FlowDirection for grapher, fixing that bug

### Description of the changes:
- Added FlowDirection override to the grapher control.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- I could not properly test the result because the grapher control is closed source

