### PR TITLE
Fix blurry buttons

### DIFF
--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -982,8 +982,7 @@
                                                   FontFamily="{ThemeResource CalculatorFontFamily}"
                                                   FontSize="12"
                                                   Glyph="&#xE970;"
-                                                  MirroredWhenRightToLeft="True"
-                                                  UseLayoutRounding="False"/>
+                                                  MirroredWhenRightToLeft="True"/>
                                     </Border>
                                 </ControlTemplate>
 
@@ -1030,8 +1029,7 @@
                                                   FontFamily="{ThemeResource CalculatorFontFamily}"
                                                   FontSize="12"
                                                   Glyph="&#xE96F;"
-                                                  MirroredWhenRightToLeft="True"
-                                                  UseLayoutRounding="False"/>
+                                                  MirroredWhenRightToLeft="True"/>
                                     </Border>
                                 </ControlTemplate>
                             </Grid.Resources>

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -918,7 +918,6 @@
                                                       Margin="2"
                                                       Style="{StaticResource ScrollViewerStyle}"
                                                       IsFocusEngagementEnabled="True"
-                                                      UseLayoutRounding="False"
                                                       Visibility="Collapsed">
                                             <ScrollViewer.RenderTransform>
                                                 <ScaleTransform x:Name="YearViewTransform"
@@ -931,7 +930,6 @@
                                                       Margin="2"
                                                       Style="{StaticResource ScrollViewerStyle}"
                                                       IsFocusEngagementEnabled="True"
-                                                      UseLayoutRounding="False"
                                                       Visibility="Collapsed">
                                             <ScrollViewer.RenderTransform>
                                                 <ScaleTransform x:Name="DecadeViewTransform"

--- a/src/Calculator/Views/GraphingCalculator/EquationStylePanelControl.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationStylePanelControl.xaml
@@ -65,9 +65,8 @@
                                              VerticalAlignment="Stretch"
                                              Fill="Transparent"
                                              Stroke="Transparent"
-                                             StrokeThickness="2"
-                                             UseLayoutRounding="false"/>
-                                    <ContentPresenter x:Name="ItemContent" UseLayoutRounding="false"/>
+                                             StrokeThickness="2"/>
+                                    <ContentPresenter x:Name="ItemContent" />
                                 </Grid>
                             </ControlTemplate>
                         </Setter.Value>
@@ -87,8 +86,7 @@
                              Fill="{x:Bind}"
                              StrokeThickness="0"
                              AutomationProperties.Name="{x:Bind local:EquationStylePanelControl.GetColorAutomationName((Brush))}"
-                             ToolTipService.ToolTip="{x:Bind local:EquationStylePanelControl.GetColorAutomationName((Brush))}"
-                             UseLayoutRounding="false"/>
+                             ToolTipService.ToolTip="{x:Bind local:EquationStylePanelControl.GetColorAutomationName((Brush))}"/>
                 </DataTemplate>
             </GridView.ItemTemplate>
             <GridView.ItemsPanel>

--- a/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
+++ b/src/Calculator/Views/GraphingCalculator/GraphingNumPad.xaml
@@ -335,7 +335,7 @@
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
-        <Grid x:Name="GraphingOperators" UseLayoutRounding="False">
+        <Grid x:Name="GraphingOperators">
             <Grid.RowDefinitions>
                 <RowDefinition x:Name="OperatorPanelRow" Height="Auto"/>
                 <RowDefinition Height="1*"/>

--- a/src/Calculator/Views/OperatorsPanel.xaml
+++ b/src/Calculator/Views/OperatorsPanel.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="CalculatorApp.OperatorsPanel"
+<UserControl x:Class="CalculatorApp.OperatorsPanel"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -6,7 +6,6 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              d:DesignHeight="315"
              d:DesignWidth="235"
-             UseLayoutRounding="False"
              mc:Ignorable="d">
     <Grid>
         <local:CalculatorStandardOperators x:Name="StandardOperators"


### PR DESCRIPTION
Fixes #1713.

UseLayoutRounding was disabled in a lot of places, which made a lot of buttons blurry.