### PR TITLE
Fix crash: GetPolicyFromPathForUser() throws InvalidArgumentException

### DIFF
--- a/src/CalcViewModel/Common/NavCategory.cpp
+++ b/src/CalcViewModel/Common/NavCategory.cpp
@@ -49,7 +49,7 @@ static constexpr int GRAPHING_ID = 17;
 
 namespace // put the utils within this TU
 {
-    Platform::Agile<Windows::System::User^> CurrentUser;
+    Platform::String^ CurrentUserId;
     std::mutex GraphingModeCheckMutex;
 
     bool IsGraphingModeEnabled()
@@ -64,8 +64,14 @@ namespace // put the utils within this TU
         }
         else
         {
+            auto user = User::GetFromId(CurrentUserId);
+            if (user == nullptr)
+            {
+                return true;
+            }
+
             auto namedPolicyData = NamedPolicy::GetPolicyFromPathForUser(
-                CurrentUser.Get(),
+                user,
                 L"Education",
                 L"AllowGraphingCalculator");
             isEnabled = namedPolicyData->GetBoolean();
@@ -310,10 +316,10 @@ NavCategoryGroup::NavCategoryGroup(const NavCategoryGroupInitializer& groupIniti
     }
 }
 
-void NavCategoryStates::SetCurrentUser(Windows::System::User^ user)
+void NavCategoryStates::SetCurrentUser(Platform::String^ userId)
 {
     std::scoped_lock<std::mutex> lock(GraphingModeCheckMutex);
-    CurrentUser = user;
+    CurrentUserId = userId;
 }
 
 IObservableVector<NavCategoryGroup ^> ^ NavCategoryStates::CreateMenuOptions()

--- a/src/CalcViewModel/Common/NavCategory.h
+++ b/src/CalcViewModel/Common/NavCategory.h
@@ -152,7 +152,7 @@ namespace CalculatorApp::ViewModel
         public ref class NavCategoryStates sealed
         {
         public:
-            static void SetCurrentUser(Windows::System::User^ user);
+            static void SetCurrentUser(Platform::String^ user);
             static Windows::Foundation::Collections::IObservableVector<NavCategoryGroup ^> ^ CreateMenuOptions();
             static NavCategoryGroup ^ CreateCalculatorCategoryGroup();
             static NavCategoryGroup ^ CreateConverterCategoryGroup();

--- a/src/Calculator/App.xaml.cs
+++ b/src/Calculator/App.xaml.cs
@@ -85,7 +85,8 @@ namespace CalculatorApp
                 // If the app got pre-launch activated, then save that state in a flag
                 m_preLaunched = true;
             }
-            NavCategoryStates.SetCurrentUser(args.User);
+
+            NavCategoryStates.SetCurrentUser(args.User.NonRoamableId);
 
             // It takes time to check GraphingMode at the 1st time. So, do it in a background thread
             Task.Run(() => NavCategoryStates.IsViewModeEnabled(ViewMode.Graphing));


### PR DESCRIPTION
## Fixes GetPolicyFromPathForUser() throws InvalidArgumentException


### Description of the changes:
- Cache user-id instead of an object of `Windows::System::User^`
- `IsGraphingModeEnabled` returns `true` if current user is unknown. (Same logic before 11.2204)



