### PR TITLE
UnitTest: IsGraphingModeEnabled() should not fail if user-id is not specified

### DIFF
--- a/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
+++ b/src/CalculatorUnitTests/NavCategoryUnitTests.cpp
@@ -370,6 +370,12 @@ namespace CalculatorUnitTests
             }
         }
 
+        TEST_METHOD(GraphingModeIsEnabled_ShouldBeTrue_WhenNullUserAssigned)
+        {
+            NavCategoryStates::SetCurrentUser("null-user"); // make sure User::GetFromId() returns nullptr
+            VERIFY_IS_TRUE(NavCategoryStates::IsViewModeEnabled(ViewMode::Graphing));
+        }
+
     private:
         const static inline std::vector<ViewMode> _orderedModes {
             ViewMode::Standard, ViewMode::Scientific, ViewMode::Graphing, ViewMode::Programmer,  ViewMode::Date,     ViewMode::Currency,


### PR DESCRIPTION
## UnitTest: `IsGraphingModeEnabled()` should not fail if user-id is not specified
It is possible that `IsGraphingModeEnabled()` cannot have a correct user info to check its policy settings.

### Description of the changes:
- Add a test method `GraphingModeIsEnabled_ShouldBeTrue_WhenNullUserAssigned`

### Notes:
We should add some other cases to verify that `IsGraphingModeEnabled()` works correctly, however it is hard to do so for now because there seems no good way to mock the context of `NavCategoryStates`. We can add these cases at the time once we introduced a better unit-test design.