### PR TITLE
Check for exactly 1 before using the singular noun, rather than greater than 1

### DIFF
--- a/src/CalcViewModel/DateCalculatorViewModel.cpp
+++ b/src/CalcViewModel/DateCalculatorViewModel.cpp
@@ -157,10 +157,13 @@ void DateCalculatorViewModel::OnInputsChanged()
             // Subtract number of Days, Months and Years from a Date
             dateTimeResult = m_dateCalcEngine->SubtractDuration(StartDate, dateDiff);
         }
-        IsOutOfBound = dateTimeResult == nullptr;
-
-        if (!m_isOutOfBound)
+        if (dateTimeResult == nullptr)
         {
+            IsOutOfBound = true;
+        }
+        else
+        {
+            IsOutOfBound = false;
             DateResult = dateTimeResult->Value;
         }
     }
@@ -254,13 +257,13 @@ String ^ DateCalculatorViewModel::GetDateDiffString() const
         result += GetLocalizedNumberString(yearCount)->Data();
         result += L' ';
 
-        if (yearCount > 1)
+        if (yearCount == 1)
         {
-            result += resourceLoader->GetResourceString(L"Date_Years")->Data();
+            result += resourceLoader->GetResourceString(L"Date_Year")->Data();
         }
         else
         {
-            result += resourceLoader->GetResourceString(L"Date_Year")->Data();
+            result += resourceLoader->GetResourceString(L"Date_Years")->Data();
         }
 
         // set the flags to add a delimiter whenever the next unit is added
@@ -282,13 +285,13 @@ String ^ DateCalculatorViewModel::GetDateDiffString() const
         result += GetLocalizedNumberString(monthCount)->Data();
         result += L' ';
 
-        if (monthCount > 1)
+        if (monthCount == 1)
         {
-            result += resourceLoader->GetResourceString(L"Date_Months")->Data();
+            result += resourceLoader->GetResourceString(L"Date_Month")->Data();
         }
         else
         {
-            result += resourceLoader->GetResourceString(L"Date_Month")->Data();
+            result += resourceLoader->GetResourceString(L"Date_Months")->Data();
         }
     }
 
@@ -307,13 +310,13 @@ String ^ DateCalculatorViewModel::GetDateDiffString() const
         result += GetLocalizedNumberString(weekCount)->Data();
         result += L' ';
 
-        if (weekCount > 1)
+        if (weekCount == 1)
         {
-            result += resourceLoader->GetResourceString(L"Date_Weeks")->Data();
+            result += resourceLoader->GetResourceString(L"Date_Week")->Data();
         }
         else
         {
-            result += resourceLoader->GetResourceString(L"Date_Week")->Data();
+            result += resourceLoader->GetResourceString(L"Date_Weeks")->Data();
         }
     }
 
@@ -332,13 +335,13 @@ String ^ DateCalculatorViewModel::GetDateDiffString() const
         result += GetLocalizedNumberString(dayCount)->Data();
         result += L' ';
 
-        if (dayCount > 1)
+        if (dayCount == 1)
         {
-            result += resourceLoader->GetResourceString(L"Date_Days")->Data();
+            result += resourceLoader->GetResourceString(L"Date_Day")->Data();
         }
         else
         {
-            result += resourceLoader->GetResourceString(L"Date_Day")->Data();
+            result += resourceLoader->GetResourceString(L"Date_Days")->Data();
         }
     }
 
@@ -351,13 +354,13 @@ String ^ DateCalculatorViewModel::GetDateDiffStringInDays() const
     result += L' ';
 
     // Display the result as '1 day' or 'N days'
-    if (m_dateDiffResultInDays.day > 1)
+    if (m_dateDiffResultInDays.day == 1)
     {
-        result += AppResourceProvider::GetInstance()->GetResourceString(L"Date_Days")->Data();
+        result += AppResourceProvider::GetInstance()->GetResourceString(L"Date_Day")->Data();
     }
     else
     {
-        result += AppResourceProvider::GetInstance()->GetResourceString(L"Date_Day")->Data();
+        result += AppResourceProvider::GetInstance()->GetResourceString(L"Date_Days")->Data();
     }
 
     return ref new String(result.data());
@@ -393,15 +396,14 @@ DateTime DateCalculatorViewModel::ClipTime(DateTime dateTime, bool adjustUsingLo
     if (adjustUsingLocalTime)
     {
         FILETIME fileTime;
-        fileTime.dwLowDateTime = (DWORD)(dateTime.UniversalTime & 0xffffffff);
-        fileTime.dwHighDateTime = (DWORD)(dateTime.UniversalTime >> 32);
+        fileTime.dwLowDateTime = static_cast<DWORD>(dateTime.UniversalTime & 0xffffffff);
+        fileTime.dwHighDateTime = static_cast<DWORD>(dateTime.UniversalTime >> 32);
 
         FILETIME localFileTime;
         FileTimeToLocalFileTime(&fileTime, &localFileTime);
 
-        referenceDateTime.UniversalTime = (DWORD)localFileTime.dwHighDateTime;
-        referenceDateTime.UniversalTime <<= 32;
-        referenceDateTime.UniversalTime |= (DWORD)localFileTime.dwLowDateTime;
+        referenceDateTime.UniversalTime = (static_cast<INT64>(localFileTime.dwHighDateTime) << 32) | localFileTime.dwLowDateTime;
+
     }
     else
     {

--- a/src/CalculatorUnitTests/DateUtils.h
+++ b/src/CalculatorUnitTests/DateUtils.h
@@ -16,9 +16,7 @@ namespace DateCalculationUnitTests
             SystemTimeToFileTime(&systemTime, lpFileTime);
 
             Windows::Foundation::DateTime dateTime;
-            dateTime.UniversalTime = (DWORD)lpFileTime->dwHighDateTime;
-            dateTime.UniversalTime <<= 32;
-            dateTime.UniversalTime |= (DWORD)lpFileTime->dwLowDateTime;
+            dateTime.UniversalTime = (static_cast<INT64>(lpFileTime->dwHighDateTime) << 32) | (lpFileTime->dwLowDateTime);
 
             return dateTime;
         }
@@ -28,8 +26,8 @@ namespace DateCalculationUnitTests
         static SYSTEMTIME DateTimeToSystemTime(Windows::Foundation::DateTime dateTime)
         {
             FILETIME fileTime;
-            fileTime.dwLowDateTime = (DWORD)(dateTime.UniversalTime & 0xffffffff);
-            fileTime.dwHighDateTime = (DWORD)(dateTime.UniversalTime >> 32);
+            fileTime.dwLowDateTime = static_cast<DWORD>(dateTime.UniversalTime & 0xffffffff);
+            fileTime.dwHighDateTime = static_cast<DWORD>(dateTime.UniversalTime >> 32);
 
             SYSTEMTIME systemTime;
             FileTimeToSystemTime(&fileTime, &systemTime);


### PR DESCRIPTION
Should this code ever be refactored in such a way that the check to 0 is changed, this will ensure the end result does not change. In addition, it is naturally immediately apparent to the developers what is going on, potentially enhancing maintainability.

Additionally, make bitwise operations more obvious in their intentions.

### Description of the changes:
- Change the logic so that the count has to be exactly 1 to print the singular noun version of the strings.
- Additionally, make bitwise operations more obvious in their intentions.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual, ad-hoc + automated testing.

