### PR TITLE
Update references to main branch name

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 <!--
-See https://github.com/Microsoft/calculator/blob/master/docs/NewFeatureProcess.md for suggestions on how to write a good feature pitch. Just want to submit an idea quickly? Try Feedback Hub instead: https://insider.windows.com/en-us/fb/?contextid=130
+See https://github.com/Microsoft/calculator/blob/main/docs/NewFeatureProcess.md for suggestions on how to write a good feature pitch. Just want to submit an idea quickly? Try Feedback Hub instead: https://insider.windows.com/en-us/fb/?contextid=130
 -->
 
 **Problem Statement**

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,7 +7,7 @@
 -
 
 ### How changes were validated:
-<!--Review https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md and ensure all contributing requirements are met.
+<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.
 
 Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
 -

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ should be used where automated testing is not feasible.
 
 ### Git workflow
 Calculator uses the [GitHub flow](https://guides.github.com/introduction/flow/) where most
-development happens directly on the `master` branch. The `master` branch should always be in a
+development happens directly on the `main` branch. The `main` branch should always be in a
 healthy state which is ready for release.
 
 If your change is complex, please clean up the branch history before submitting a pull request.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The app provides standard, scientific, and programmer calculator functionality, 
 
 Calculator ships regularly with new features and bug fixes. You can get the latest version of Calculator in the [Microsoft Store](https://www.microsoft.com/store/apps/9WZDNCRFHVN5).
 
-[![Build Status](https://dev.azure.com/ms/calculator/_apis/build/status/Calculator-CI?branchName=master)](https://dev.azure.com/ms/calculator/_build/latest?definitionId=57&branchName=master)
+[![Build Status](https://dev.azure.com/ms/calculator/_apis/build/status/Calculator-CI?branchName=main)](https://dev.azure.com/ms/calculator/_build/latest?definitionId=57&branchName=main)
 
   ![Calculator Screenshot](docs/Images/CalculatorScreenshot.png)
 

--- a/build/pipelines/azure-pipelines.ci-internal.yaml
+++ b/build/pipelines/azure-pipelines.ci-internal.yaml
@@ -5,7 +5,7 @@
 #
 
 trigger:
-- master
+- main
 - release/*
 - feature/*
 pr: none

--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -5,11 +5,11 @@
 #
 
 trigger:
-- master
+- main
 - release/*
 - feature/*
 pr:
-- master
+- main
 - release/*
 - feature/*
 

--- a/build/pipelines/azure-pipelines.loc.yaml
+++ b/build/pipelines/azure-pipelines.loc.yaml
@@ -12,7 +12,7 @@ schedules:
   displayName: Daily sync
   branches:
     include:
-    - master
+    - main
   always: true
 
 trigger: none

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -10,9 +10,9 @@ In 2021, the Windows Calculator team is focused on:
   * Migrating the codebase to C# ([#893](https://github.com/microsoft/calculator/issues/893))
   * Releasing infinite-precision engine as standalone package ([#1545](https://github.com/microsoft/calculator/issues/1545)) and adding support for arbitrary expression parsing ([#526](https://github.com/microsoft/calculator/issues/526))
   * Adding a settings page ([#596](https://github.com/microsoft/calculator/issues/596))
-* [Your feature idea here] - please review our [new feature development process](https://github.com/Microsoft/calculator/blob/master/docs/NewFeatureProcess.md) to get started!
+* [Your feature idea here] - please review our [new feature development process](https://github.com/Microsoft/calculator/blob/main/docs/NewFeatureProcess.md) to get started!
 
-We welcome contributions of all kinds from the community, but especially those that support the efforts above. Please see our [contributing guidelines](https://github.com/Microsoft/calculator/blob/master/CONTRIBUTING.md) for more information on how to get involved.
+We welcome contributions of all kinds from the community, but especially those that support the efforts above. Please see our [contributing guidelines](https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md) for more information on how to get involved.
 
 ## Releases
 


### PR DESCRIPTION
The main branch of this repo has been renamed to `main`. This PR updates build pipelines and documentation to point at the name `main`.