### PR TITLE
Update Main to 2207 version

### DIFF
--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -9,7 +9,7 @@ pr: none
 
 variables:
   versionMajor: 11
-  versionMinor: 2206
+  versionMinor: 2207
   versionBuild: $[counter(format('{0}.{1}.*', variables['versionMajor'], variables['versionMinor']), 0)]
   versionPatch: 0
 


### PR DESCRIPTION
Now that the 2206 release branch fork has been created, updating main to the 2207 version.

