### PR TITLE
Use NuGet 6.x

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -48,9 +48,9 @@ jobs:
         vstsPackageVersion: 0.0.103
 
   - task: NuGetToolInstaller@1
-    displayName: Use NuGet 5.x
+    displayName: Use NuGet 6.x
     inputs:
-      versionSpec: 5.x
+      versionSpec: 6.x
 
   - task: NuGetCommand@2
     displayName: NuGet restore src/Calculator.sln


### PR DESCRIPTION
Update the build pipeline to use the latest available version of NuGet.