### PR TITLE
Update to WinUI 2.8

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -108,10 +108,12 @@ jobs:
         # Below are ignored files
         #   - clrcompression.dll
         #   - WebView2Loader.dll
+        #   - Microsoft.Web.WebView2.Core.dll
         Contents: |
           **\*
           !**\clrcompression.dll
           !**\WebView2Loader.dll
+          !**\Microsoft.Web.WebView2.Core.dll
         TargetFolder: '$(Agent.BuildDirectory)\binskim'
         CleanTargetFolder: true
         OverWrite: true

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -107,9 +107,11 @@ jobs:
         # If we put more things than we produce pdbs for and can index (such as nuget packages that ship without pdbs), binskim will fail.
         # Below are ignored files
         #   - clrcompression.dll
+        #   - WebView2Loader.dll
         Contents: |
           **\*
           !**\clrcompression.dll
+          !**\WebView2Loader.dll
         TargetFolder: '$(Agent.BuildDirectory)\binskim'
         CleanTargetFolder: true
         OverWrite: true

--- a/src/Calculator/Calculator.csproj
+++ b/src/Calculator/Calculator.csproj
@@ -794,7 +794,7 @@
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.2.10</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.UI.Xaml" Version="2.7.0" />
+    <PackageReference Include="Microsoft.UI.Xaml" Version="2.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CalcViewModel\CalcViewModel.vcxproj">


### PR DESCRIPTION
### Description of the changes:
- Update WinUI from 2.7 to 2.8.
- Bypass WebView2Loader.dll and Microsoft.Web.WebView2.Core.dll at BinSkim phase since they are introduced in WinUI 2.8 but they don't have pdb for BinSkim to analyze.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manually tested.

