### PR TITLE
Update Main to 2209

### DIFF
--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -9,7 +9,7 @@ pr: none
 
 variables:
   versionMajor: 11
-  versionMinor: 2208
+  versionMinor: 2209
   versionBuild: $[counter(format('{0}.{1}.*', variables['versionMajor'], variables['versionMinor']), 0)]
   versionPatch: 0
 


### PR DESCRIPTION
## Fixes #.
N/A

### Description of the changes:
- Updating Main to 2209 version now that the 2208 release branch has been forked.
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

