### PR TITLE
Include cstdint in CalcErr.h for uint32_t et al

### DIFF
--- a/src/CalcManager/Ratpack/CalcErr.h
+++ b/src/CalcManager/Ratpack/CalcErr.h
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 // CalcErr.h
 //
 // Defines the error codes thrown by ratpak and caught by Calculator


### PR DESCRIPTION
## Fixes

Fixes part of GCC build

### Description of the changes:
- include header for types in use

### How changes were validated:
- compiled with GCC

