### PR TITLE
README: require Windows 11 to build and run

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Calculator ships regularly with new features and bug fixes. You can get the late
 
 ## Getting started
 Prerequisites:
-- Your computer must be running Windows 10, version 1809 or newer. Windows 11 is recommended.
+- Your computer must be running Windows 11, build 22000 or newer.
 - Install the latest version of [Visual Studio](https://developer.microsoft.com/en-us/windows/downloads) (the free community edition is sufficient).
   - Install the "Universal Windows Platform Development" workload.
   - Install the optional "C++ Universal Windows Platform tools" component.


### PR DESCRIPTION
Update the README to say that Windows 11 is required to build and run the project.

Building on older versions of Windows 10 _might_ work, but the app won't run because Calculator's minimum OS version is currently 22000. Even if we lower the minimum OS version to support some versions of Windows 10 (see #1880), we'd prefer to guide people towards using Windows 11 for development since that's what we use and are able to support.