### PR TITLE
fixed decimal usability in converter section

### DIFF
--- a/src/CalcViewModel/UnitConverterViewModel.cpp
+++ b/src/CalcViewModel/UnitConverterViewModel.cpp
@@ -177,6 +177,8 @@ void UnitConverterViewModel::ResetCategory()
     IsCurrencyLoadingVisible = m_IsCurrencyCurrentCategory && !m_isCurrencyDataLoaded;
     IsDropDownEnabled = m_Units->GetAt(0) != EMPTY_UNIT;
 
+    IsDecimalEnabled = true;
+
     UnitChanged->Execute(nullptr);
 }
 


### PR DESCRIPTION
## Fixes #1832.

After selecting a currency that does not handle fractional units, the decimal is turned off. This is the correct functionality. However, when a user goes to change the category of conversion, say to length, then the decimal is still turned off despite needing to be on. The only way the decimal can be reenabled is to go back to the currency category and change the units to a currency that allows for fractional units. 

### Description of the changes:
- I inserted the line "IsDecimalEnabled = true" inside the ResetCategory() method of the unit converter.
In my thinking, the decimal should be reenabled upon category switching and will be disabled when a unit with non-fractional units is being used.  All code styles were followed, and no major code changes occurred.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

I searched for occurrences of the same problems in other parts of the code base and none were found.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Rigorous manual testing. Swapping between categories and units to ensure the decimal is enabled when it needs to be.
