### PR TITLE
Resolve TODO - MSFT 12735088

### DIFF
--- a/src/CalcViewModel/pch.h
+++ b/src/CalcViewModel/pch.h
@@ -42,14 +42,3 @@
 #include "winrt/Windows.UI.Xaml.h"
 #include "winrt/Windows.Foundation.Metadata.h"
 #include "winrt/Windows.Management.Policies.h"
-
-// The following namespaces exist as a convenience to resolve
-// ambiguity for Windows types in the Windows::UI::Xaml::Automation::Peers
-// namespace that only exist on RS3.
-// Once the app switches to min version RS3, the namespaces can be removed.
-// TODO - MSFT 12735088
-namespace StandardPeers = Windows::UI::Xaml::Automation::Peers;
-namespace CalculatorApp::ViewModel::Common::Automation
-{
-}
-namespace CustomPeers = CalculatorApp::ViewModel::Common::Automation;


### PR DESCRIPTION
Since we use minimum version 17763, we can safely remove these namespaces

## Fixes #.
MSFT 12735088