### PR TITLE
Remove always-false UITest check

### DIFF
--- a/src/CalculatorUITestFramework/WindowsDriverServiceBuilder.cs
+++ b/src/CalculatorUITestFramework/WindowsDriverServiceBuilder.cs
@@ -45,10 +45,6 @@ namespace CalculatorUITestFramework
 
         public WindowsDriverServiceBuilder WithStartUpTimeOut(TimeSpan startUpTimeout)
         {
-            if (startUpTimeout == null)
-            {
-                throw new ArgumentNullException("A startup timeout should not be NULL");
-            }
             this.StartUpTimeout = startUpTimeout;
             return this;
         }


### PR DESCRIPTION
startUpTimeout can never be null. It is impossible. Fixes build warning