### PR TITLE
Simplify ChangeConstants

### DIFF
--- a/src/CalcManager/Ratpack/support.cpp
+++ b/src/CalcManager/Ratpack/support.cpp
@@ -25,7 +25,7 @@
 
 using namespace std;
 
-void _readconstants(void);
+void _readconstants();
 
 #if defined(GEN_CONST)
 static int cbitsofprecision = 0;
@@ -136,13 +136,14 @@ void ChangeConstants(uint32_t radix, int32_t precision)
     // in the internal BASEX radix, this is important for length calculations
     // in translating from radix to BASEX and back.
 
-    uint64_t limit = static_cast<uint64_t>(BASEX) / static_cast<uint64_t>(radix);
+    const uint32_t limit = BASEX / radix;
     g_ratio = 0;
     for (uint32_t digit = 1; digit < limit; digit *= radix)
     {
         g_ratio++;
     }
-    g_ratio += !g_ratio;
+    if (g_ratio == 0)
+        g_ratio = 1; // g_ratio is always at least 1
 
     destroyrat(rat_nRadix);
     rat_nRadix = i32torat(radix);

--- a/src/CalcManager/Ratpack/support.cpp
+++ b/src/CalcManager/Ratpack/support.cpp
@@ -136,14 +136,7 @@ void ChangeConstants(uint32_t radix, int32_t precision)
     // in the internal BASEX radix, this is important for length calculations
     // in translating from radix to BASEX and back.
 
-    const uint32_t limit = BASEX / radix;
-    g_ratio = 0;
-    for (uint32_t digit = 1; digit < limit; digit *= radix)
-    {
-        g_ratio++;
-    }
-    if (g_ratio == 0)
-        g_ratio = 1; // g_ratio is always at least 1
+    g_ratio = static_cast<int32_t>(ceil(log2(BASEX) / log2(radix))) - 1;
 
     destroyrat(rat_nRadix);
     rat_nRadix = i32torat(radix);


### PR DESCRIPTION
Since BASEX is a constant and radix is a uint32_t radix, there is nothing to be gained from having the limit be 64 bit.

In addition, the g_ratio += !g_ratio only applies if g_ratio is 0, so I simplified that too.