### PR TITLE
Update Main to 2210 version

### DIFF
--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -9,7 +9,7 @@ pr: none
 
 variables:
   versionMajor: 11
-  versionMinor: 2209
+  versionMinor: 2210
   versionBuild: $[counter(format('{0}.{1}.*', variables['versionMajor'], variables['versionMinor']), 0)]
   versionPatch: 0
 


### PR DESCRIPTION
Updating Main to the 2210 version now that the 2209 release branch fork has been created.

