### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ components, prefer the patterns described in the
 [C++ core guidelines](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines)
 and the [modern C++/WinRT language projections](https://docs.microsoft.com/en-us/windows/uwp/cpp-and-winrt-apis/).
 
+For C# coding standards you can follow the coding styles and guidelines in [C# coding conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
+
 ### Testing
 Your change should include tests to verify new functionality wherever possible. Code should be
 structured so that it can be unit tested independently of the UI. [Manual test cases](docs/ManualTests.md)


### PR DESCRIPTION
I was thinking to add a link to a C# coding convention so those who plan to convert C++ code to C# code can follow.

## Fixes #.
I added a description and a link to the C# coding guidelines for new contributers that want to take on the conversion of C++ to C# project. 

### Description of the changes:
-Added this link (https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-No testing required since this is a documentation update. 
-
-

