### PR TITLE
Updating ESRP code signing task to v2

### DIFF
--- a/build/pipelines/templates/package-msixbundle.yaml
+++ b/build/pipelines/templates/package-msixbundle.yaml
@@ -81,7 +81,7 @@ jobs:
       pathToPublish: $(Build.ArtifactStagingDirectory)\msixBundle
 
   - ${{ if eq(parameters.signBundle, true) }}:
-    - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+    - task: EsrpCodeSigning@2
       displayName: Send msixbundle to code signing service
       inputs:
         ConnectedServiceName: Essential Experiences Codesign


### PR DESCRIPTION
## Fixes #.
Updating ESRP code signing task to v2.

### Description of the changes:
The ESRP code signing task v1 relies on .NET Core 2.1, which is out of support and no longer installed on the build agents. Code signing is failing in the build.

### How changes were validated:
tested with another app which signed successfully.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

