### PR TITLE
Settings page is redesigned.

### DIFF
--- a/src/Calculator/Resources/en-GB/Resources.resw
+++ b/src/Calculator/Resources/en-GB/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2320,6 +2320,14 @@
   <data name="AboutControlContribute" xml:space="preserve">
     <value>To learn how you can contribute to Windows Calculator, check out the project on %HL%GitHub%HL%.</value>
     <comment>{Locked="%HL%GitHub%HL%"}. GitHub link, Displayed on the About panel</comment>
+  </data>
+  <data name="AboutCalculator.Text" xml:space="preserve">
+    <value>About Calculator</value>
+    <comment>Title of about information expander.</comment>
+  </data>
+  <data name="LearnMoreAboutCalculator.Text" xml:space="preserve">
+    <value>Learn more about Windows Calculator</value>
+    <comment>Label of about information expander.</comment>
   </data>
   <data name="AboutGroupTitle.Text" xml:space="preserve">
     <value>About</value>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -2721,6 +2721,14 @@
     <value>To learn how you can contribute to Windows Calculator, check out the project on %HL%GitHub%HL%.</value>
     <comment>{Locked="%HL%GitHub%HL%"}. GitHub link, Displayed on the About panel</comment>
   </data>
+  <data name="AboutCalculator.Text" xml:space="preserve">
+    <value>About Calculator</value>
+    <comment>Title of about information expander.</comment>
+  </data>
+  <data name="LearnMoreAboutCalculator.Text" xml:space="preserve">
+    <value>Learn more about Windows Calculator</value>
+    <comment>Label of about information expander.</comment>
+  </data>
   <data name="AboutGroupTitle.Text" xml:space="preserve">
     <value>About</value>
     <comment>Subtitle of about message on Settings page</comment>

--- a/src/Calculator/Resources/tr-TR/Resources.resw
+++ b/src/Calculator/Resources/tr-TR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -2320,6 +2320,14 @@
   <data name="AboutControlContribute" xml:space="preserve">
     <value>Windows hesap makinesi 'ne nasıl katkıda bulunabileceğinizi öğrenmek için %HL%GitHub%HL% projeyi kullanıma alın.</value>
     <comment>{Locked="%HL%GitHub%HL%"}. GitHub link, Displayed on the About panel</comment>
+  </data>
+  <data name="AboutCalculator.Text" xml:space="preserve">
+    <value>Hesap Makinesi Hakkında</value>
+    <comment>Title of about information expander.</comment>
+  </data>
+  <data name="LearnMoreAboutCalculator.Text" xml:space="preserve">
+    <value>Windows Hesap Makinesi hakkında daha fazla bilgi edinin</value>
+    <comment>Label of about information expander.</comment>
   </data>
   <data name="AboutGroupTitle.Text" xml:space="preserve">
     <value>Hakkında</value>

--- a/src/Calculator/Views/Settings.xaml
+++ b/src/Calculator/Views/Settings.xaml
@@ -115,12 +115,16 @@
                 <Grid.RowDefinitions>
                     <RowDefinition x:Name="AppearanceTitleRow" Height="Auto"/>
                     <RowDefinition x:Name="AppearanceExpanderRow" Height="Auto"/>
+                    <RowDefinition x:Name="ContentTitleRow" Height="Auto"/>
+                    <RowDefinition x:Name="ContentExpanderRow" Height="Auto"/>
+                    <RowDefinition x:Name="FeedbackRow" Height="Auto"/>
                     <RowDefinition x:Name="AboutTitleContentRow" Height="*"/>
                 </Grid.RowDefinitions>
 
                 <TextBlock x:Uid="SettingsAppearance"
                            Style="{StaticResource BodyStrongTextBlockStyle}"
                            AutomationProperties.HeadingLevel="Level1"/>
+
 
                 <muxc:Expander x:Name="AppThemeExpander"
                                x:Uid="AppThemeExpander"
@@ -172,69 +176,106 @@
                         </muxc:RadioButtons>
                     </muxc:Expander.Content>
                 </muxc:Expander>
+                
+                <TextBlock x:Uid="AboutGroupTitle"
+                           Grid.Row="2"
+                           Style="{StaticResource BodyStrongTextBlockStyle}"
+                           AutomationProperties.HeadingLevel="Level1"/>
 
-                <Grid x:Name="AboutContentGrid" Grid.Row="2">
-                    <Grid.RowDefinitions>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                        <RowDefinition Height="Auto"/>
-                    </Grid.RowDefinitions>
+                <muxc:Expander x:Name="AboutContentExpander"
+                               x:Uid="AboutContentExpander"
+                               Grid.Row="3"
+                               Margin="0,8,0,0"
+                               HorizontalAlignment="Stretch"
+                               VerticalAlignment="Top"
+                               HorizontalContentAlignment="Left"
+                               ExpandDirection="Down"
+                               IsExpanded="False">
+                    <muxc:Expander.Header>
+                        <Grid HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            
+                            <BitmapIcon  Margin="0,0,12,0"
+                                         VerticalAlignment="Center"
+                                         AutomationProperties.AccessibilityView="Raw"
+                                         Height="16"
+                                         Width="16"
+                                         UriSource="ms-appx:///Assets/CalculatorAppList.png"/>
+                            
+                            <StackPanel Grid.Column="1"
+                                        Margin="0,12"
+                                        Orientation="Vertical">
 
-                    <TextBlock x:Name="AboutGroupTitle"
-                               x:Uid="AboutGroupTitle"
-                               Margin="0,20,0,0"
-                               Style="{ThemeResource BodyStrongTextBlockStyle}"
-                               AutomationProperties.HeadingLevel="Level1"/>
-                    <StackPanel Grid.Row="1"
+                                <TextBlock x:Uid="AboutCalculator" Style="{StaticResource BodyTextBlockStyle}"/>
+
+                                <TextBlock x:Uid="LearnMoreAboutCalculator" 
+                                           Style="{StaticResource CaptionTextBlockStyle}"
+                                           Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                           TextWrapping="WrapWholeWords"/>
+                            </StackPanel>
+                        </Grid>
+                    </muxc:Expander.Header>
+                    <muxc:Expander.Content>
+                        <StackPanel Grid.Row="1"
                                 Margin="0,8,0,0"
                                 Orientation="Vertical">
-                        <RichTextBlock x:Name="AboutContentBody" Style="{StaticResource SettingsRichTextBlockStyle}">
-                            <Paragraph>
-                                <Run x:Name="AboutBuildVersion"/>
-                                <LineBreak/>
-                                <Run x:Name="AboutControlCopyrightRun"/>
-                            </Paragraph>
-                        </RichTextBlock>
-
-                        <HyperlinkButton x:Name="AboutEULA"
+                            <TextBlock x:Name="AboutBuildVersion" 
+                                       TextWrapping="WrapWholeWords"/>
+                            <TextBlock x:Name="AboutControlCopyrightRun"
+                                       Style="{StaticResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       TextWrapping="WrapWholeWords"/>
+                            <HyperlinkButton x:Name="AboutEULA"
                                          Margin="0,16,0,0"
                                          Padding="0"
                                          NavigateUri="https://go.microsoft.com/fwlink/?LinkID=529064"
                                          ToolTipService.ToolTip="https://go.microsoft.com/fwlink/?LinkID=529064">
-                            <TextBlock x:Uid="AboutEULA"
+                                <TextBlock x:Uid="AboutEULA"
                                        FontSize="{ThemeResource BodyFontSize}"
                                        TextWrapping="Wrap"/>
-                        </HyperlinkButton>
+                            </HyperlinkButton>
 
-                        <HyperlinkButton x:Name="AboutControlServicesAgreement"
+                            <HyperlinkButton x:Name="AboutControlServicesAgreement"
                                          Margin="0,16,0,0"
                                          Padding="0"
                                          NavigateUri="https://go.microsoft.com/fwlink/?LinkID=822631"
                                          ToolTipService.ToolTip="https://go.microsoft.com/fwlink/?LinkID=822631">
-                            <TextBlock x:Uid="AboutControlServicesAgreement"
+                                <TextBlock x:Uid="AboutControlServicesAgreement"
                                        FontSize="{ThemeResource BodyFontSize}"
                                        TextWrapping="Wrap"/>
-                        </HyperlinkButton>
+                            </HyperlinkButton>
 
-                        <HyperlinkButton x:Name="AboutControlPrivacyStatement"
+                            <HyperlinkButton x:Name="AboutControlPrivacyStatement"
                                          Margin="0,16,0,0"
                                          Padding="0"
                                          NavigateUri="https://go.microsoft.com/fwlink/?LinkID=521839"
                                          ToolTipService.ToolTip="https://go.microsoft.com/fwlink/?LinkID=521839">
-                            <TextBlock x:Uid="AboutControlPrivacyStatement"
+                                <TextBlock x:Uid="AboutControlPrivacyStatement"
                                        FontSize="{ThemeResource BodyFontSize}"
                                        TextWrapping="Wrap"/>
-                        </HyperlinkButton>
+                            </HyperlinkButton>
+                        </StackPanel>
+                    </muxc:Expander.Content>
+                </muxc:Expander>
 
-                        <Button x:Name="FeedbackButton"
+
+                <Button x:Name="FeedbackButton"
                                 x:Uid="FeedbackButton"
+                                Grid.Row="4"
                                 MinWidth="120"
                                 Margin="0,24,0,0"
                                 HorizontalAlignment="Left"
                                 VerticalAlignment="Top"
                                 FontSize="{StaticResource BodyFontSize}"
                                 Click="FeedbackButton_Click"/>
-                    </StackPanel>
+
+                <Grid x:Name="AboutContributeGrid" Grid.Row="5">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto"/>
+                    </Grid.RowDefinitions>
                     <RichTextBlock x:Name="AboutContribute"
                                    Grid.Row="2"
                                    Margin="0,16,0,0"
@@ -244,13 +285,15 @@
                                 Note: don't put Hyperlink element start to the next line
                                 otherwise unexpected whitespace will be add.
                             -->
-                            <Run x:Name="ContributeRunBeforeLink"/><Hyperlink Foreground="{x:Bind AboutEULA.Foreground, Mode=OneWay}"
+                            <Run x:Name="ContributeRunBeforeLink"/>
+                            <Hyperlink Foreground="{x:Bind AboutEULA.Foreground, Mode=OneWay}"
                                        NavigateUri="https://go.microsoft.com/fwlink/?linkid=2099939"
                                        TextDecorations="None"
                                        ToolTipService.ToolTip="https://go.microsoft.com/fwlink/?linkid=2099939"
                                        UnderlineStyle="None">
                                 <Run x:Name="ContributeRunLink"/>
-                            </Hyperlink><Run x:Name="ContributeRunAfterLink"/>
+                            </Hyperlink>
+                            <Run x:Name="ContributeRunAfterLink"/>
                         </Paragraph>
                     </RichTextBlock>
                 </Grid>

--- a/src/Calculator/Views/Settings.xaml.cs
+++ b/src/Calculator/Views/Settings.xaml.cs
@@ -46,7 +46,7 @@ namespace CalculatorApp
             var copyrightText =
                 LocalizationStringUtil.GetLocalizedString(resourceLoader.GetResourceString("AboutControlCopyright"), BUILD_YEAR);
             AboutControlCopyrightRun.Text = copyrightText;
-
+           
             InitializeContributeTextBlock();
         }
 
@@ -109,6 +109,7 @@ namespace CalculatorApp
         {
             PackageVersion version = Package.Current.Id.Version;
             string appName = AppResourceProvider.GetInstance().GetResourceString("AppName");
+
             AboutBuildVersion.Text = appName + " " + version.Major + "." + version.Minor + "." + version.Build + "." + version.Revision;
         }
 

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -286,7 +286,11 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <None Include="..\calculator\views\titlebar.xaml.cs" />
     <None Include="WindowsDev_TemporaryKey.pfx" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="..\calculator\views\titlebar.xaml" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj.filters
@@ -81,5 +81,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="WindowsDev_TemporaryKey.pfx" />
+    <None Include="..\calculator\views\titlebar.xaml.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Page Include="..\calculator\views\titlebar.xaml" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Its a kind of diss to Pull Request #1964 :smile:

## Fixes #1963
And also problems that I see in #1964

### Description of the changes:
- As mentioned before, the content of the About section in the Settings tab was just sitting there. However, some changes were made in the aforementioned PR that I thought unnecessary. As a matter of fact, I think that the title and label values entered in Expander are incompatible with Windows style. (See the about output of the Photos Application 
![image](https://user-images.githubusercontent.com/22801690/222927832-8bdb4e29-e42a-4324-a541-56702113a991.png)
.)
- For this reason, I made a change in accordance with the spirit of the Windows application as much as possible.
- While doing this, unfortunately I had to add 2 new Resources. Although I entered these translations for en-us en-gb and tr-tr, I did not touch other translations. They also need to be translated.
- 

### How changes were validated:

https://user-images.githubusercontent.com/22801690/222927746-75d20154-9ddd-47a8-869b-e8423611862b.mp4

<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

I tested it manually on English and Turkish. But needs to look up Resources.resw files for each language and run unit tests.
-
-
-

# Notes:

By the way, please don't be offended by the diss issue I joked about. After all, the source is open, everyone can interpret a view differently.