### PR TITLE
Temporary workaround for Secure Supply Chain Analysis in release build

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="Toolkit Labs" value="https://pkgs.dev.azure.com/dotnet/CommunityToolkit/_packaging/CommunityToolkit-Labs/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
### Description of the changes:
The internal pipelines are blocked, which is caused by the extra nuget feed in nuget.config file of the GitHub repo for the CommunityToolkit-Labs package introduced for the new settings control. The calculator internal pipelines will fail as the automatically injected build task of Secure Supply Chain Analysis for the pipelines that are marked a internal to Microsoft requires one feed per nuget.config file.

Remove the extra nuget feed in the release branch to run the release pipeline.

### How changes were validated:
Release pipeline was passed.
