### PR TITLE
Workaround for Simplified Chinese localization issue of currency API

### DIFF
--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -109,14 +109,12 @@ CurrencyDataLoader::CurrencyDataLoader(_In_ unique_ptr<ICurrencyHttpClient> clie
             m_responseLanguage = GlobalizationPreferences::Languages->GetAt(0);
 
             // Workaround for Simplified Chinese localization issue of currency API.
-            std::wstring responseLanguage(m_responseLanguage->Data());
-            wregex pattern = wregex(L"zh-hans-[a-zA-Z]+", std::regex_constants::icase);
-            std::wsmatch match;
-            if (regex_match(responseLanguage, match, pattern))
+            std::wstring_view responseLanguage(m_responseLanguage->Data(), m_responseLanguage->Length());
+            std::match_results<std::wstring_view::const_iterator> match;
+            if (std::regex_match(responseLanguage.cbegin(), responseLanguage.cend(), match, std::wregex(L"zh-hans-[a-z]+", std::regex_constants::icase)))
             {
-                responseLanguage = L"zh-CN";
+                m_responseLanguage = L"zh-CN";
             }
-            m_responseLanguage = ref new Platform::String(responseLanguage.c_str());
         }
         else
         {

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -107,6 +107,16 @@ CurrencyDataLoader::CurrencyDataLoader(_In_ unique_ptr<ICurrencyHttpClient> clie
         if (GlobalizationPreferences::Languages->Size > 0)
         {
             m_responseLanguage = GlobalizationPreferences::Languages->GetAt(0);
+
+            // Workaround for Simplified Chinese localization issue of currency API.
+            std::wstring responseLanguage(m_responseLanguage->Data());
+            wregex pattern = wregex(L"zh-hans-[a-zA-Z]+", std::regex_constants::icase);
+            std::wsmatch match;
+            if (regex_match(responseLanguage, match, pattern))
+            {
+                responseLanguage = L"zh-CN";
+            }
+            m_responseLanguage = ref new Platform::String(responseLanguage.c_str());
         }
         else
         {


### PR DESCRIPTION
## Fixes #.
Strings on the Currency Converter of the Calculator app is not localized into Simplified Chinese while in Simplified Chinese language.

### Description of the changes:
When in Simplified Chinese language, the language we get through `GlobalizationPreferences::Languages` will in the format starting with 'zh-Hans-', e.g., 'zh-Hans-CN' for Chinese (Simplified, China). But the currency APIs fail to recognize such locale and we will get the data in default locale which is in Traditional Chinese. The workaround will transform the locale to 'zh-CN' for Simplified Chinese.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manually tested with currency APIs.

