### PR TITLE
Update UnitConverterDataLoader.cpp

### DIFF
--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -927,7 +927,7 @@ void UnitConverterDataLoader::GetConversionData(_In_ unordered_map<ViewMode, uno
                                                    { ViewMode::Speed, UnitConverterUnits::Speed_Knot, 51.44 },
                                                    { ViewMode::Speed, UnitConverterUnits::Speed_Mach, 34030 },
                                                    { ViewMode::Speed, UnitConverterUnits::Speed_MetersPerSecond, 100 },
-                                                   { ViewMode::Speed, UnitConverterUnits::Speed_MilesPerHour, 44.7 },
+                                                   { ViewMode::Speed, UnitConverterUnits::Speed_MilesPerHour, 44.704 },
                                                    { ViewMode::Speed, UnitConverterUnits::Speed_Turtle, 8.94 },
                                                    { ViewMode::Speed, UnitConverterUnits::Speed_Horse, 2011.5 },
                                                    { ViewMode::Speed, UnitConverterUnits::Speed_Jet, 24585 },


### PR DESCRIPTION
Issue #2026 

## Fixes #.
Due to incorrect value of 44.7, result varied as given in the issue.
```
ViewMode::Speed, UnitConverterUnits::Speed_MilesPerHour, 44.7
``` 

The originally calculated value was different from actual (which should be) 
```
ViewMode::Speed, UnitConverterUnits::Speed_MilesPerHour, 44.704
```

### Description of the changes:
- changed values of `Speed_MilesPerHour`

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

