### PR TITLE
Fix the broken decimal key

### DIFF
--- a/src/Calculator/Views/NumberPad.xaml
+++ b/src/Calculator/Views/NumberPad.xaml
@@ -110,10 +110,12 @@
                                    AutomationProperties.AutomationId="num9Button"
                                    AutomationProperties.Name="{utils:ResourceString Name=num9Button/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name}"
                                    ButtonId="Nine"/>
+        <!-- DO NOT REMOVE the common:KeyboardShortcutManager.Character from this element, it's value will be overwritten by the KeyboardShortcutManager -->
         <controls:CalculatorButton x:Name="DecimalSeparatorButton"
                                    Grid.Row="3"
                                    Grid.Column="2"
                                    Style="{Binding ElementName=ControlRoot, Path=ButtonStyle}"
+                                   common:KeyboardShortcutManager.Character="."
                                    common:KeyboardShortcutManager.VirtualKey="{utils:ResourceVirtualKey Name=decimalSeparatorButton/[using:CalculatorApp.Common]KeyboardShortcutManager/VirtualKey}"
                                    AutomationProperties.AutomationId="decimalSeparatorButton"
                                    AutomationProperties.Name="{utils:ResourceString Name=decimalSeparatorButton/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name}"

--- a/src/CalculatorUITests/StandardModeFunctionalTests.cs
+++ b/src/CalculatorUITests/StandardModeFunctionalTests.cs
@@ -316,11 +316,8 @@ namespace CalculatorUITests
             Assert.AreEqual("square (9)", page.CalculatorResults.GetCalculatorExpressionText()); //verifies squared hotkey
         }
 
-        // Ignore this test and add a new test KeyboardInput_PercentSquareRootBackspaceNegateOneZero below
-        // to avoid the issue of decimal keyboard input
         [TestMethod]
         [Priority(1)]
-        [Ignore]
         public void KeyboardInput_PercentSquareRootBackspaceDecimalNegateOneZero()
         {
             //Verifies the %, square root, backspace, decimal, negate, 1, and 0 button
@@ -343,34 +340,6 @@ namespace CalculatorUITests
             Assert.AreEqual("0 point", page.CalculatorResults.GetCalculatorResultText()); //verifies using decimal key
             CalculatorApp.Window.SendKeys(Keys.F9);
             CalculatorApp.Window.SendKeys("1");
-            Assert.AreEqual("-0.1", page.CalculatorResults.GetCalculatorResultText()); //verifies negate hotkey
-            page.StandardOperators.EqualButton.Click();
-            Assert.AreEqual("9.9", page.CalculatorResults.GetCalculatorResultText()); //verifies calculation with decimal point and negative number
-        }
-
-        [TestMethod]
-        [Priority(1)]
-        public void KeyboardInput_PercentSquareRootBackspaceNegateOneZero()
-        {
-            //Verifies the %, square root, backspace, negate, 1, and 0 button
-            CalculatorApp.EnsureCalculatorHasFocus();
-            CalculatorApp.Window.SendKeys("100");
-            CalculatorApp.Window.SendKeys(Keys.Backspace);
-            Assert.AreEqual("10", page.CalculatorResults.GetCalculatorResultText()); // verifies using the 1 key, the 0 key, and the backspace key
-            CalculatorApp.Window.SendKeys(Keys.Add);
-            CalculatorApp.EnsureCalculatorHasFocus();
-            CalculatorApp.Window.SendKeys(Keys.Shift + "5" + Keys.Shift);
-            Assert.AreEqual("1", page.CalculatorResults.GetCalculatorResultText()); //verifies percent calculation
-            Assert.AreEqual("10 + 1", page.CalculatorResults.GetCalculatorExpressionText()); //verifies percent hotkey
-            CalculatorApp.Window.SendKeys(Keys.Shift);
-            CalculatorApp.Window.SendKeys(Keys.Shift + "5" + Keys.Shift);
-            CalculatorApp.Window.SendKeys(Keys.Shift);
-            CalculatorApp.Window.SendKeys(Keys.Shift + "2" + Keys.Shift);
-            Assert.AreEqual("0.3162277660168379", page.CalculatorResults.GetCalculatorResultText()); //verifies square root calculation
-            Assert.AreEqual("10 + √(0.1)", page.CalculatorResults.GetCalculatorExpressionText()); //verifies 2√x hotkey
-            CalculatorApp.Window.SendKeys("1");
-            CalculatorApp.Window.SendKeys(Keys.Shift + "5" + Keys.Shift);
-            CalculatorApp.Window.SendKeys(Keys.F9);
             Assert.AreEqual("-0.1", page.CalculatorResults.GetCalculatorResultText()); //verifies negate hotkey
             page.StandardOperators.EqualButton.Click();
             Assert.AreEqual("9.9", page.CalculatorResults.GetCalculatorResultText()); //verifies calculation with decimal point and negative number


### PR DESCRIPTION
## Fixes #.
The decimal key is not working due to recent change.

### Description of the changes:
Add the `common:KeyboardShortcutManager.Character` back to the decimal separator button element, and update the corresponding UI test.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manually tested and passed the UI test.

