### PR TITLE
Add a script to check nuget config for pull requests

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -37,6 +37,12 @@ jobs:
   - checkout: self
     fetchDepth: 1
 
+  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+    - powershell: |
+        $(Build.SourcesDirectory)\build\scripts\VerifyNugetConfig.ps1 -FilePath "$(Build.SourcesDirectory)\nuget.config"
+      displayName: Verify nuget config
+      failOnStderr: true
+
   - ${{ if eq(parameters.isReleaseBuild, true) }}:
     - task: UniversalPackages@0
       displayName: Download internals package

--- a/build/scripts/VerifyNugetConfig.ps1
+++ b/build/scripts/VerifyNugetConfig.ps1
@@ -1,0 +1,28 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+<#
+.SYNOPSIS
+  Verify the specified nuget.config. Throw to fail the pipeline if the config is ill-formed.
+.PARAMETER FilePath
+  The path pointing to the nuget.config file to be verified by this script.
+.EXAMPLE
+  VerifyNugetConfig -FilePath .\nuget.config
+#>
+
+param([Parameter(Mandatory)][string]$FilePath)
+
+$doc = [XML](Get-Content $FilePath)
+$sources = (Select-Xml $doc -XPath "//configuration/packageSources").Node
+$count = 0
+foreach($src in $sources.ChildNodes){
+  if ($src.Name -eq "add"){
+    ++$count
+  }
+  elseif ($src.Name -eq "clear"){
+    $count = 0
+  }
+}
+if ($count -gt 1){
+  throw "Adding multiple package sources is not allowed in nuget.config."
+}


### PR DESCRIPTION
### Why
Adding multiple package sources is not allowed in nuget.config, because it causes failures to our release pipeline.
With this check, we can block those changes at the PR stage.

### Description of the changes:
- Introduce a new script: VerifyNugetConfig
- Run the script in pipeline if the build reason is *Pull Request*

### How changes were validated:
Expectation: No feature changed, no regressions.
Manually tested.

