### PR TITLE
Add a NatVis file for ratpak

### DIFF
--- a/src/CalcManager/CalcManager.vcxproj
+++ b/src/CalcManager/CalcManager.vcxproj
@@ -344,6 +344,9 @@
     <ClCompile Include="NumberFormattingUtils.cpp" />
     <ClCompile Include="UnitConverter.cpp" />
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="ratpak.natvis" />
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/src/CalcManager/CalcManager.vcxproj.filters
+++ b/src/CalcManager/CalcManager.vcxproj.filters
@@ -162,4 +162,9 @@
     </ClInclude>
     <ClInclude Include="NumberFormattingUtils.h" />
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="ratpak.natvis">
+      <Filter>RatPack</Filter>
+    </Natvis>
+  </ItemGroup>
 </Project>

--- a/src/CalcManager/ratpak.natvis
+++ b/src/CalcManager/ratpak.natvis
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="_number">
+    <Expand>
+        <Item Name="sign">sign</Item>
+        <Item Name="exp">exp</Item>
+        <ArrayItems>
+          <Size>cdigit</Size>
+          <ValuePointer>mant</ValuePointer>
+        </ArrayItems>
+    </Expand>
+  </Type>
+  <Type Name="_rat">
+    <DisplayString>{*pp}/{*pq}</DisplayString>
+  </Type>
+</AutoVisualizer>


### PR DESCRIPTION
Adds a .natvis file which makes it a little bit easier to see the contents of PRAT and PNUMBER structures in the Visual Studio debugger.