### PR TITLE
eng: migrate pipelines to 1ES PT

### DIFF
--- a/.config/CredScanSuppressions.json
+++ b/.config/CredScanSuppressions.json
@@ -1,0 +1,13 @@
+{
+    "tool": "Credential Scanner",
+    "suppressions": [
+        {
+            "file": "\\src\\Calculator\\WindowsDev_TemporaryKey.pfx",
+            "_justification": "This is an untrusted, self-signed certificate which is used only during development. Its private key is not intended to be secret."
+        },
+        {
+            "file": "\\src\\CalculatorUnitTests\\WindowsDev_TemporaryKey.pfx",
+            "_justification": "This is an untrusted, self-signed certificate which is used only during development. Its private key is not intended to be secret."
+        }
+    ]
+}

--- a/build/pipelines/azure-pipelines.ci-internal.yaml
+++ b/build/pipelines/azure-pipelines.ci-internal.yaml
@@ -12,47 +12,64 @@ pr: none
 
 name: 0.$(Date:yyMM).$(DayOfMonth)$(Rev:rr).0
 
-jobs:
-- template: ./templates/build-single-architecture.yaml
-  parameters:
-    isReleaseBuild: true
-    useReleaseAppxManifest: false
-    platform: x64
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
-- template: ./templates/build-single-architecture.yaml
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
-    isReleaseBuild: true
-    useReleaseAppxManifest: false
-    platform: x86
+    pool:
+      name: EssentialExperiences-windows-2022
+      image: MMSWindows2022-Secure
+      os: windows
 
-- template: ./templates/build-single-architecture.yaml
-  parameters:
-    isReleaseBuild: true
-    useReleaseAppxManifest: false
-    platform: ARM
+    stages:
+    - stage:
+      jobs:
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          isReleaseBuild: true
+          useReleaseAppxManifest: false
+          platform: x64
 
-- template: ./templates/build-single-architecture.yaml
-  parameters:
-    isReleaseBuild: true
-    useReleaseAppxManifest: false
-    platform: ARM64
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          isReleaseBuild: true
+          useReleaseAppxManifest: false
+          platform: x86
 
-- template: ./templates/run-ui-tests.yaml
-  parameters:
-    platform: x64
-    runsettingsFileName: CalculatorUITests.ci-internal.runsettings
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          isReleaseBuild: true
+          useReleaseAppxManifest: false
+          platform: ARM
 
-- template: ./templates/run-ui-tests.yaml
-  parameters:
-    platform: x86
-    runsettingsFileName: CalculatorUITests.ci-internal.runsettings
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          isReleaseBuild: true
+          useReleaseAppxManifest: false
+          platform: ARM64
 
-- template: ./templates/run-unit-tests.yaml
-  parameters:
-    platform: x64
+      - template: /build/pipelines/templates/run-ui-tests.yaml@self
+        parameters:
+          platform: x64
+          runsettingsFileName: CalculatorUITests.ci-internal.runsettings
 
-- template: ./templates/run-unit-tests.yaml
-  parameters:
-    platform: x86
+      - template: /build/pipelines/templates/run-ui-tests.yaml@self
+        parameters:
+          platform: x86
+          runsettingsFileName: CalculatorUITests.ci-internal.runsettings
 
-- template: ./templates/package-msixbundle.yaml
+      - template: /build/pipelines/templates/run-unit-tests.yaml@self
+        parameters:
+          platform: x64
+
+      - template: /build/pipelines/templates/run-unit-tests.yaml@self
+        parameters:
+          platform: x86
+
+      - template: /build/pipelines/templates/package-msixbundle.yaml@self

--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -15,46 +15,63 @@ pr:
 
 name: 0.$(Date:yyMM).$(DayOfMonth)$(Rev:rr).0
 
-jobs:
-- template: ./templates/build-single-architecture.yaml
-  parameters:
-    platform: x64
-    isOSSBuild: true
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
-- template: ./templates/build-single-architecture.yaml
+extends:
+  template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
-    platform: x86
-    isOSSBuild: true
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+    pool:
+      name: EssentialExperiencesOpenSource-windows-2022
+      image: MMSWindows2022-Secure
+      os: windows
 
-- template: ./templates/build-single-architecture.yaml
-  parameters:
-    platform: ARM
-    isOSSBuild: true
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+    sdl:
+      binskim:
+        enabled: false
 
-- template: ./templates/build-single-architecture.yaml
-  parameters:
-    platform: ARM64
-    isOSSBuild: true
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+    stages:
+    - stage: Calculator
+      jobs:
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          platform: x64
 
-- template: ./templates/run-ui-tests.yaml
-  parameters:
-    platform: x64
-    isOSSBuild: true
-    runsettingsFileName: CalculatorUITests.ci.runsettings
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          platform: x86
+          condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
-- template: ./templates/run-unit-tests.yaml
-  parameters:
-    platform: x64
-    isOSSBuild: true
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          platform: ARM
+          isOSSBuild: true
+          condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
-- template: ./templates/run-unit-tests.yaml
-  parameters:
-    platform: x86
-    isOSSBuild: true
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          platform: ARM64
+          isOSSBuild: true
+          condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
-- template: ./templates/package-msixbundle.yaml
-  parameters:
-    isOSSBuild: true
+      - template: /build/pipelines/templates/run-ui-tests.yaml@self
+        parameters:
+          platform: x64
+          isOSSBuild: true
+          runsettingsFileName: CalculatorUITests.ci.runsettings
+
+      - template: /build/pipelines/templates/run-unit-tests.yaml@self
+        parameters:
+          platform: x64
+
+      - template: /build/pipelines/templates/run-unit-tests.yaml@self
+        parameters:
+          platform: x86
+
+      - template: /build/pipelines/templates/package-msixbundle.yaml@self
+        parameters:
+          isOSSBuild: true

--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -49,13 +49,11 @@ extends:
       - template: /build/pipelines/templates/build-single-architecture.yaml@self
         parameters:
           platform: ARM
-          isOSSBuild: true
           condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
       - template: /build/pipelines/templates/build-single-architecture.yaml@self
         parameters:
           platform: ARM64
-          isOSSBuild: true
           condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
       - template: /build/pipelines/templates/run-ui-tests.yaml@self
@@ -73,5 +71,3 @@ extends:
           platform: x86
 
       - template: /build/pipelines/templates/package-msixbundle.yaml@self
-        parameters:
-          isOSSBuild: true

--- a/build/pipelines/azure-pipelines.ci.yaml
+++ b/build/pipelines/azure-pipelines.ci.yaml
@@ -40,21 +40,25 @@ extends:
       - template: /build/pipelines/templates/build-single-architecture.yaml@self
         parameters:
           platform: x64
+          isOSSBuild: true
 
       - template: /build/pipelines/templates/build-single-architecture.yaml@self
         parameters:
           platform: x86
           condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+          isOSSBuild: true
 
       - template: /build/pipelines/templates/build-single-architecture.yaml@self
         parameters:
           platform: ARM
           condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+          isOSSBuild: true
 
       - template: /build/pipelines/templates/build-single-architecture.yaml@self
         parameters:
           platform: ARM64
           condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+          isOSSBuild: true
 
       - template: /build/pipelines/templates/run-ui-tests.yaml@self
         parameters:

--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -8,7 +8,7 @@ trigger: none
 pr: none
 
 variables:
-  versionMajor: 0 # TODO: revert this to 11 before checking in the code
+  versionMajor: 11
   versionMinor: 2310
   versionBuild: $[counter(format('{0}.{1}.*', variables['versionMajor'], variables['versionMinor']), 0)]
   versionPatch: 0

--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -8,63 +8,80 @@ trigger: none
 pr: none
 
 variables:
-  versionMajor: 11
+  versionMajor: 0 # TODO: revert this to 11 before checking in the code
   versionMinor: 2310
   versionBuild: $[counter(format('{0}.{1}.*', variables['versionMajor'], variables['versionMinor']), 0)]
   versionPatch: 0
 
 name: '$(versionMajor).$(versionMinor).$(versionBuild).$(versionPatch)'
 
-jobs:
-- template: ./templates/build-single-architecture.yaml
-  parameters:
-    platform: x64
-    isReleaseBuild: true
-    useReleaseAppxmanifest: true
+resources:
+  repositories:
+  - repository: 1esPipelines
+    type: git
+    name: 1ESPipelineTemplates/1ESPipelineTemplates
+    ref: refs/tags/release
 
-- template: ./templates/build-single-architecture.yaml
+extends:
+  template: v1/1ES.Official.PipelineTemplate.yml@1esPipelines
   parameters:
-    platform: x86
-    isReleaseBuild: true
-    useReleaseAppxmanifest: true
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+    pool:
+      name: EssentialExperiences-windows-2022
+      image: MMSWindows2022-Secure
+      os: windows
 
-- template: ./templates/build-single-architecture.yaml
-  parameters:
-    platform: ARM
-    isReleaseBuild: true
-    useReleaseAppxmanifest: true
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+    stages:
+    - stage: Calculator
+      jobs:
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          platform: x64
+          isReleaseBuild: true
+          useReleaseAppxmanifest: true
 
-- template: ./templates/build-single-architecture.yaml
-  parameters:
-    platform: ARM64
-    isReleaseBuild: true
-    useReleaseAppxmanifest: true
-    condition: not(eq(variables['Build.Reason'], 'PullRequest'))
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          platform: x86
+          isReleaseBuild: true
+          useReleaseAppxmanifest: true
+          condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
-- template: ./templates/run-ui-tests.yaml
-  parameters:
-    platform: x64
-    runsettingsFileName: CalculatorUITests.release.runsettings
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          platform: ARM
+          isReleaseBuild: true
+          useReleaseAppxmanifest: true
+          condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
-- template: ./templates/run-ui-tests.yaml
-  parameters:
-    platform: x86
-    runsettingsFileName: CalculatorUITests.release.runsettings
+      - template: /build/pipelines/templates/build-single-architecture.yaml@self
+        parameters:
+          platform: ARM64
+          isReleaseBuild: true
+          useReleaseAppxmanifest: true
+          condition: not(eq(variables['Build.Reason'], 'PullRequest'))
 
-- template: ./templates/run-unit-tests.yaml
-  parameters:
-    platform: x64
+      - template: /build/pipelines/templates/run-ui-tests.yaml@self
+        parameters:
+          platform: x64
+          runsettingsFileName: CalculatorUITests.release.runsettings
 
-- template: ./templates/run-unit-tests.yaml
-  parameters:
-    platform: x86
+      - template: /build/pipelines/templates/run-ui-tests.yaml@self
+        parameters:
+          platform: x86
+          runsettingsFileName: CalculatorUITests.release.runsettings
 
-- template: ./templates/package-msixbundle.yaml
-  parameters:
-    signBundle: true
-    createStoreBrokerPackages: true
+      - template: /build/pipelines/templates/run-unit-tests.yaml@self
+        parameters:
+          platform: x64
 
-- template: ./templates/release-store.yaml
-- template: ./templates/release-vpack.yaml
+      - template: /build/pipelines/templates/run-unit-tests.yaml@self
+        parameters:
+          platform: x86
+
+      - template: /build/pipelines/templates/package-msixbundle.yaml@self
+        parameters:
+          signBundle: true
+          createStoreBrokerPackages: true
+
+      - template: /build/pipelines/templates/release-store.yaml@self
+      - template: /build/pipelines/templates/release-vpack.yaml@self

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -2,6 +2,7 @@
 
 parameters:
   isReleaseBuild: false
+  isOSSBuild: false
   useReleaseAppxManifest: false
   platform: ''
   condition: ''
@@ -41,6 +42,10 @@ jobs:
   steps:
   - checkout: self
     fetchDepth: 1
+
+  - ${{ if eq(parameters.isOSSBuild, true) }}:
+    - task: nuget-security-analysis@0
+      displayName: Secure Supply Chain Analysis
 
   - ${{ if eq(parameters.isReleaseBuild, true) }}:
     - task: UniversalPackages@0

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -30,7 +30,7 @@ jobs:
   templateContext:
     sdl:
       binskim:
-        analyzeTargetGlob: +:f|$(Agent.BuildDirectory)\binskim\**\*.dll;+:f|$(Agent.BuildDirectory)\binskim\**\*.exe
+        analyzeTargetGlob: +:f|$(Agent.BuildDirectory)\binskim\**\*
 
     outputs:
     - output: pipelineArtifact
@@ -91,7 +91,8 @@ jobs:
         #   - WebView2Loader.dll
         #   - Microsoft.Web.WebView2.Core.dll
         Contents: |
-          **\*
+          **\*.dll
+          **\*.exe
           !**\clrcompression.dll
           !**\WebView2Loader.dll
           !**\Microsoft.Web.WebView2.Core.dll

--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -2,7 +2,6 @@
 
 parameters:
   isReleaseBuild: false
-  isOSSBuild: false
   useReleaseAppxManifest: false
   platform: ''
   condition: ''
@@ -11,11 +10,6 @@ jobs:
 - job: Build${{ parameters.platform }}
   displayName: Build ${{ parameters.platform }}
   condition: ${{ parameters.condition }}
-  pool:
-    ${{ if eq(parameters.isOSSBuild, true) }}:
-      name: EssentialExperiencesOpenSource-windows-2022
-    ${{ if eq(parameters.isOSSBuild, false) }}:
-      name: EssentialExperiences-windows-2022
   variables:
     BuildConfiguration: Release
     BuildPlatform: ${{ parameters.platform }}
@@ -33,13 +27,20 @@ jobs:
       ManifestFileName: 'Package.appxmanifest'
     ${{ if eq(parameters.useReleaseAppxManifest, true) }}:
       ManifestFileName: 'Package.Release.appxmanifest'
+  templateContext:
+    sdl:
+      binskim:
+        analyzeTargetGlob: +:f|$(Agent.BuildDirectory)\binskim\**\*.dll;+:f|$(Agent.BuildDirectory)\binskim\**\*.exe
+
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish drop artifact
+      targetPath: $(Build.BinariesDirectory)\$(BuildConfiguration)\${{ parameters.platform }}
+      artifactName: drop-${{ parameters.platform }}
+
   steps:
   - checkout: self
     fetchDepth: 1
-
-  - ${{ if eq(parameters.isOSSBuild, true) }}:
-    - task: nuget-security-analysis@0
-      displayName: Secure Supply Chain Analysis
 
   - ${{ if eq(parameters.isReleaseBuild, true) }}:
     - task: UniversalPackages@0
@@ -79,29 +80,6 @@ jobs:
       maximumCpuCount: true
 
   - ${{ if eq(parameters.isReleaseBuild, true) }}:          
-    - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
-      displayName: 'Generate Software Bill of Material(SBoM)'
-      inputs:
-          BuildDropPath: $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)\Calculator
-          PackageName: 'Microsoft.WindowsCalculator'
-          PackageVersion: $(Build.BuildNumber)
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish drop artifact
-    inputs:
-      artifactName: drop
-      pathToPublish: $(Build.BinariesDirectory)
-      parallel: true
-
-  - ${{ if eq(parameters.isReleaseBuild, true) }}:          
-    - task: PublishSymbols@2
-      displayName: Publish symbols
-      inputs:
-        symbolsFolder: $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)
-        searchPattern: '**/*.pdb'
-        symbolServerType: teamServices
-        treatNotIndexedAsWarning: true
-
     - task: CopyFiles@2
       displayName: Copy Files for BinSkim analysis
       inputs:
@@ -123,24 +101,15 @@ jobs:
         flattenFolders: false
         analyzeTarget: '$(Agent.BuildDirectory)\binskim\*'
 
-    - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
-      displayName: Run BinSkim
+    - task: PublishSymbols@2
+      displayName: Publish symbols
       inputs:
-        inputType: Basic
-        analyzeTarget: '$(Agent.BuildDirectory)\binskim\*'
-        analyzeVerbose: true
-        analyzeHashes: true
-      continueOnError: true
+        symbolsFolder: $(Build.BinariesDirectory)\$(BuildConfiguration)\$(BuildPlatform)
+        searchPattern: '**/*.pdb'
+        symbolServerType: teamServices
+        treatNotIndexedAsWarning: true
 
     - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
       displayName: Run PoliCheck
       inputs:
         targetType: F
-
-    - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
-      displayName: Publish security analysis logs
-
-    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-      displayName: Detect open source components
-      inputs:
-        sourceScanPath: $(Agent.BuildDirectory)

--- a/build/pipelines/templates/package-msixbundle.yaml
+++ b/build/pipelines/templates/package-msixbundle.yaml
@@ -3,7 +3,6 @@
 # this job also signs the bundle and creates StoreBroker packages.
 
 parameters:
-  isOSSBuild: false
   signBundle: false
   createStoreBrokerPackages: false
 
@@ -22,24 +21,67 @@ jobs:
       in(dependencies.BuildARM.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
       in(dependencies.BuildARM64.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     ) 
-  pool:
-    ${{ if eq(parameters.isOSSBuild, true) }}:
-      name: EssentialExperiencesOpenSource-windows-2022
-    ${{ if eq(parameters.isOSSBuild, false) }}:
-      name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
     StoreBrokerMediaRootPath: $(TEMP)\SBMedia
     StoreBrokerPackagePath: $(Build.ArtifactStagingDirectory)\storeBrokerPayload
+    PackageX86: $[in(dependencies.Buildx86.result, 'Succeeded', 'SucceededWithIssues')]
+    PackageX64: $[in(dependencies.Buildx64.result, 'Succeeded', 'SucceededWithIssues')]
+    PackageARM: $[in(dependencies.BuildARM.result, 'Succeeded', 'SucceededWithIssues')]
+    PackageARM64: $[in(dependencies.BuildARM64.result, 'Succeeded', 'SucceededWithIssues')]
+  templateContext:
+    outputs:
+    - ${{ if eq(parameters.signBundle, false) }}:
+      - output: pipelineArtifact
+        displayName: Publish MsixBundle artifact
+        targetPath: $(Build.ArtifactStagingDirectory)\msixBundle
+        artifactName: msixBundle
+    - ${{ else }}:
+      - output: pipelineArtifact
+        displayName: Publish MsixBundleSigned artifact
+        targetPath: $(Build.ArtifactStagingDirectory)\msixBundle
+        artifactName: msixBundleSigned
+      - ${{ if eq(parameters.createStoreBrokerPackages, true) }}:      
+        - output: pipelineArtifact
+          displayName: Publish StoreBroker Payload artifact
+          targetPath: $(StoreBrokerPackagePath)
+          artifactName: storeBrokerPayload
+
   steps:
   - checkout: self
     fetchDepth: 1
 
-  - task: DownloadBuildArtifacts@0
-    displayName: Download all .msix artifacts
+  - task: DownloadPipelineArtifact@2
+    displayName: Download all .msix artifacts (x86)
+    condition: and(succeeded(), eq(variables.PackageX86, 'true'))
     inputs:
-      artifactName: drop
+      artifactName: drop-x86
       itemPattern: '**/*.msix'
+      targetPath: $(Build.ArtifactStagingDirectory)\drop\x86
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download all .msix artifacts (x64)
+    condition: and(succeeded(), eq(variables.PackageX64, 'true'))
+    inputs:
+      artifactName: drop-x64
+      itemPattern: '**/*.msix'
+      targetPath: $(Build.ArtifactStagingDirectory)\drop\x64
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download all .msix artifacts (ARM)
+    condition: and(succeeded(), eq(variables.PackageARM, 'true'))
+    inputs:
+      artifactName: drop-ARM
+      itemPattern: '**/*.msix'
+      targetPath: $(Build.ArtifactStagingDirectory)\drop\ARM
+
+  - task: DownloadPipelineArtifact@2
+    displayName: Download all .msix artifacts (ARM64)
+    condition: and(succeeded(), eq(variables.PackageARM64, 'true'))
+    inputs:
+      artifactName: drop-ARM64
+      itemPattern: '**/*.msix'
+      targetPath: $(Build.ArtifactStagingDirectory)\drop\ARM64
 
   - ${{ if eq(parameters.createStoreBrokerPackages, true) }}:
     - task: UniversalPackages@0
@@ -55,7 +97,7 @@ jobs:
     displayName: Generate MsixBundle mapping
     inputs:
       filePath: $(Build.SourcesDirectory)\build\scripts\CreateMsixBundleMapping.ps1
-      arguments: '-InputPath $(Build.ArtifactStagingDirectory)\drop\Release -ProjectName Calculator -OutputFile $(Build.BinariesDirectory)\MsixBundleMapping.txt'
+      arguments: '-InputPath $(Build.ArtifactStagingDirectory)\drop -ProjectName Calculator -OutputFile $(Build.BinariesDirectory)\MsixBundleMapping.txt'
 
   - powershell: |
       $buildVersion = [version]$Env:BUILDVERSION
@@ -73,12 +115,6 @@ jobs:
       sourceFolder: $(Build.BinariesDirectory)
       contents: Microsoft.WindowsCalculator_8wekyb3d8bbwe.msixbundle
       targetFolder: $(Build.ArtifactStagingDirectory)\msixBundle
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish MsixBundle artifact
-    inputs:
-      artifactName: msixBundle
-      pathToPublish: $(Build.ArtifactStagingDirectory)\msixBundle
 
   - ${{ if eq(parameters.signBundle, true) }}:
     - task: EsrpCodeSigning@2
@@ -114,11 +150,6 @@ jobs:
               "ToolVersion": "1.0"
             }
           ]
-    - task: PublishBuildArtifacts@1
-      displayName: Publish MsixBundleSigned artifact
-      inputs:
-        pathtoPublish: $(Build.ArtifactStagingDirectory)\msixBundle
-        artifactName: msixBundleSigned
 
     - ${{ if eq(parameters.createStoreBrokerPackages, true) }}:      
       - powershell: |
@@ -152,9 +183,3 @@ jobs:
           pdpMediaPath: $(StoreBrokerMediaRootPath)
           outSBPackagePath: $(StoreBrokerPackagePath)
           outSBName: SBCalculator
-
-      - task: PublishBuildArtifacts@1
-        displayName: Publish StoreBroker Payload artifact
-        inputs:
-          pathtoPublish: $(StoreBrokerPackagePath)
-          artifactName: storeBrokerPayload

--- a/build/pipelines/templates/release-store.yaml
+++ b/build/pipelines/templates/release-store.yaml
@@ -3,11 +3,9 @@
 jobs:
 - job: ReleaseStore
   dependsOn: Package
-  pool:
-    name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
-    StoreBrokerPackagePath: $(Build.ArtifactStagingDirectory)\storeBrokerPayload
+    StoreBrokerPackagePath: $(Pipeline.Workspace)\storeBrokerPayload
     StoreBrokerLogPath: $(StoreBrokerPackagePath)\StoreBroker.log
     FlightId: 161f0975-cb5f-475b-8ef6-26383c37621f
     AppId: 9WZDNCRFHVN5
@@ -15,10 +13,9 @@ jobs:
   steps:
   - checkout: none
 
-  - task: DownloadBuildArtifacts@0
+  - download: current
     displayName: Download storeBrokerPayload artifact
-    inputs:
-      artifactName: storeBrokerPayload
+    artifact: storeBrokerPayload
 
   - task: MS-RDX-MRO.windows-store-publish-dev.flight-task.store-flight@2
     displayName: Flight StoreBroker Payload to team ring

--- a/build/pipelines/templates/release-vpack.yaml
+++ b/build/pipelines/templates/release-vpack.yaml
@@ -4,39 +4,38 @@
 jobs:
 - job: ReleaseVPack
   dependsOn: Package
-  pool:
-    name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
+  templateContext:
+    outputs:
+    - output: pipelineArtifact
+      displayName: Publish vpack\app artifact with vpack manifest
+      targetPath: $(XES_VPACKMANIFESTDIRECTORY)\$(XES_VPACKMANIFESTNAME)
+      artifactName: vpackManifest
+      sbomEnabled: false
+
   steps:
   - checkout: none
 
-  - task: DownloadBuildArtifacts@0
+  - download: current
     displayName: Download msixBundleSigned artifact
-    inputs:
-      artifactName: msixBundleSigned
+    artifact: msixBundleSigned
 
   - task: CopyFiles@2
     displayName: Copy signed MsixBundle to vpack staging folder
     inputs:
-      sourceFolder: $(Build.ArtifactStagingDirectory)\msixBundleSigned
+      sourceFolder: $(Pipeline.Workspace)\msixBundleSigned
       contents: Microsoft.WindowsCalculator_8wekyb3d8bbwe.msixbundle
-      targetFolder: $(Build.ArtifactStagingDirectory)\vpack\msixBundle
+      targetFolder: $(Pipeline.Workspace)\vpack\msixBundle
 
   - task: PkgESVPack@12
     displayName: Create and push vpack for app
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)
     inputs:
-      sourceDirectory: $(Build.ArtifactStagingDirectory)\vpack\msixBundle
+      sourceDirectory: $(Pipeline.Workspace)\vpack\msixBundle
       description: VPack for the Calculator Application
       pushPkgName: calculator.app
       version: $(versionMajor).$(versionMinor).$(versionBuild)
       owner: paxeeapps
       provData: true
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish vpack\app artifact with vpack manifest
-    inputs:
-      pathtoPublish: $(XES_VPACKMANIFESTDIRECTORY)\$(XES_VPACKMANIFESTNAME)
-      artifactName: vpackManifest

--- a/build/pipelines/templates/run-ui-tests.yaml
+++ b/build/pipelines/templates/run-ui-tests.yaml
@@ -17,6 +17,8 @@ jobs:
       name: EssentialExperiences-Win11
   variables:
     skipComponentGovernanceDetection: true
+    DropName: drop-${{ parameters.platform }}
+
   steps:
   - checkout: self
     fetchDepth: 1
@@ -33,30 +35,29 @@ jobs:
       width: 1920
       height: 1080
 
-  - task: DownloadBuildArtifacts@0
+  - download: current
     displayName: Download MsixBundle and CalculatorUITests
-    inputs:
-      artifactName: drop
-      itemPattern: |
-        drop/Release/${{ parameters.platform }}/Calculator/AppPackages/**
-        drop/Release/${{ parameters.platform }}/publish/**
+    artifact: $(DropName)
+    patterns: |
+      Calculator/AppPackages/**
+      publish/**
 
   - task: PowerShell@2
     displayName: Install certificate
     inputs:
-      filePath: $(Build.ArtifactStagingDirectory)/drop/Release/${{ parameters.platform }}/Calculator/AppPackages/Calculator_$(Build.BuildNumber)_Test/Add-AppDevPackage.ps1
-      arguments: -CertificatePath $(Build.ArtifactStagingDirectory)/drop/Release/${{ parameters.platform }}/Calculator/AppPackages/Calculator_$(Build.BuildNumber)_Test/Calculator_$(Build.BuildNumber)_${{ parameters.platform }}.cer -Force
+      filePath: $(Pipeline.Workspace)/$(DropName)/Calculator/AppPackages/Calculator_$(Build.BuildNumber)_Test/Add-AppDevPackage.ps1
+      arguments: -CertificatePath $(Pipeline.Workspace)/$(DropName)/Calculator/AppPackages/Calculator_$(Build.BuildNumber)_Test/Calculator_$(Build.BuildNumber)_${{ parameters.platform }}.cer -Force
 
   - task: PowerShell@2
     displayName: Install app
     inputs:
-      filePath: $(Build.ArtifactStagingDirectory)/drop/Release/${{ parameters.platform }}/Calculator/AppPackages/Calculator_$(Build.BuildNumber)_Test/Add-AppDevPackage.ps1
+      filePath: $(Pipeline.Workspace)/$(DropName)/Calculator/AppPackages/Calculator_$(Build.BuildNumber)_Test/Add-AppDevPackage.ps1
       arguments: -Force
 
   - task: VSTest@2
     displayName: Run CalculatorUITests
     inputs:
-      testAssemblyVer2: $(Build.ArtifactStagingDirectory)/drop/Release/${{ parameters.platform }}/publish/CalculatorUITests.dll
-      runSettingsFile: $(Build.ArtifactStagingDirectory)/drop/Release/${{ parameters.platform }}/publish/${{ parameters.runsettingsFileName }}
+      testAssemblyVer2: $(Pipeline.Workspace)/$(DropName)/publish/CalculatorUITests.dll
+      runSettingsFile: $(Pipeline.Workspace)/$(DropName)/publish/${{ parameters.runsettingsFileName }}
       platform: ${{ parameters.platform }}
       configuration: Release

--- a/build/pipelines/templates/run-unit-tests.yaml
+++ b/build/pipelines/templates/run-unit-tests.yaml
@@ -1,7 +1,6 @@
 # This template contains jobs to run unit tests.
 
 parameters:
-  isOSSBuild: false
   platform: ''
   runsettingsFileName: ''
 
@@ -10,30 +9,25 @@ jobs:
   displayName: UnitTests ${{ parameters.platform }}
   dependsOn: Build${{ parameters.platform }}
   condition: succeeded()
-  pool:
-    ${{ if eq(parameters.isOSSBuild, true) }}:
-      name: EssentialExperiencesOpenSource-windows-2022
-    ${{ if eq(parameters.isOSSBuild, false) }}:
-      name: EssentialExperiences-windows-2022
   variables:
     skipComponentGovernanceDetection: true
+    UnitTestsDir: $(Pipeline.Workspace)\drop-${{ parameters.platform }}\CalculatorUnitTests\AppPackages\CalculatorUnitTests_Test
   steps:
   - checkout: none
   
-  - task: DownloadBuildArtifacts@0
+  - download: current
     displayName: Download CalculatorUnitTests
-    inputs:
-      artifactName: drop
-      itemPattern: drop/Release/${{ parameters.platform }}/CalculatorUnitTests/AppPackages/CalculatorUnitTests_Test/**
+    artifact: drop-${{ parameters.platform }}
+    patterns: '**/CalculatorUnitTests_Test/**'
 
   - task: PowerShell@2
     displayName: Install Certificate
     inputs:
-      filePath: $(Build.ArtifactStagingDirectory)\drop\Release\${{ parameters.platform }}\CalculatorUnitTests\AppPackages\CalculatorUnitTests_Test\Add-AppDevPackage.ps1
-      arguments: -CertificatePath $(Build.ArtifactStagingDirectory)\drop\Release\${{ parameters.platform }}\CalculatorUnitTests\AppPackages\CalculatorUnitTests_Test\CalculatorUnitTests.cer -Force
+      filePath: $(UnitTestsDir)\Add-AppDevPackage.ps1
+      arguments: -CertificatePath $(UnitTestsDir)\CalculatorUnitTests.cer -Force
 
   - task: VSTest@2
     displayName: Run CalculatorUnitTests
     inputs:
-      testAssemblyVer2: $(Build.ArtifactStagingDirectory)\drop\Release\${{ parameters.platform }}\CalculatorUnitTests\AppPackages\CalculatorUnitTests_Test\CalculatorUnitTests.msix
+      testAssemblyVer2: $(UnitTestsDir)\CalculatorUnitTests.msix
       otherConsoleOptions: /Platform:${{ parameters.platform }}

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -145,6 +145,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -163,6 +164,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -181,6 +183,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -199,6 +202,7 @@
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/src/GraphingImpl/GraphingImpl.vcxproj
+++ b/src/GraphingImpl/GraphingImpl.vcxproj
@@ -148,6 +148,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -176,6 +177,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -204,6 +206,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -232,6 +235,7 @@
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
## What
Per the request from 1ES, we are required to onboard 1ES Pipeline Template by Oct 31, 2023.

## Changes
- Update the CI and the Release pipeline with 1ES PT
- Replace the disallowed tasks with substitutions that 1ES PT provides.
- Remove SDL tasks that 1ES PT will manage. Such as SBOM, BinSkim, etc.


