### PR TITLE
Fixed incorrect Russian graphing translations

### DIFF
--- a/src/Calculator/Resources/ru-RU/Resources.resw
+++ b/src/Calculator/Resources/ru-RU/Resources.resw
@@ -2318,7 +2318,7 @@
     <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutControlContribute" xml:space="preserve">
-    <value>Чтобы узнать, как вы можете участвовать в Windows калькулятора, изучите проект на %HL%GitHub%HL%.</value>
+    <value>Чтобы узнать, как вы можете участвовать в разработке Windows калькулятора, изучите проект на %HL%GitHub%HL%.</value>
     <comment>{Locked="%HL%GitHub%HL%"}. GitHub link, Displayed on the About panel</comment>
   </data>
   <data name="AboutGroupTitle.Text" xml:space="preserve">
@@ -3368,7 +3368,7 @@
     <comment>String describing constant monotonicity of a function</comment>
   </data>
   <data name="KGFMonotonicityDecreasing" xml:space="preserve">
-    <value>Уменьшающаяся</value>
+    <value>убывающая</value>
     <comment>String describing decreasing monotonicity of a function</comment>
   </data>
   <data name="KGFMonotonicityError" xml:space="preserve">
@@ -3376,7 +3376,7 @@
     <comment>Error displayed when monotonicity cannot be determined</comment>
   </data>
   <data name="KGFMonotonicityIncreasing" xml:space="preserve">
-    <value>Увеличивающаяся</value>
+    <value>возрастающая</value>
     <comment>String describing increasing monotonicity of a function</comment>
   </data>
   <data name="KGFMonotonicityUnknown" xml:space="preserve">
@@ -3436,7 +3436,7 @@
     <comment>Message displayed when the graph does not have any y-intercepts</comment>
   </data>
   <data name="Domain" xml:space="preserve">
-    <value>Домен</value>
+    <value>Область определения</value>
     <comment>Title for KeyGraphFeatures Domain Property</comment>
   </data>
   <data name="HorizontalAsymptotes" xml:space="preserve">
@@ -3476,7 +3476,7 @@
     <comment>Title for KeyGraphFeatures Parity Property</comment>
   </data>
   <data name="Periodicity" xml:space="preserve">
-    <value>Цикл</value>
+    <value>Период</value>
     <comment>Title for KeyGraphFeatures Periodicity Property. The period of a mathematical function is the smallest interval in its input values such that its output values repeat every such interval.</comment>
   </data>
   <data name="Range" xml:space="preserve">
@@ -3499,7 +3499,7 @@
     <value>Не удалось выполнить анализ функции.</value>
   </data>
   <data name="KGFDomainNone" xml:space="preserve">
-    <value>Не удалось вычислить домен для этой функции.</value>
+    <value>Не удалось вычислить область определения для этой функции.</value>
     <comment>Error displayed when Domain is not returned from the analyzer.</comment>
   </data>
   <data name="KGFRangeNone" xml:space="preserve">
@@ -3531,7 +3531,7 @@
     <comment>Error that occurs during graphing when a factorial has a large n</comment>
   </data>
   <data name="ModuloCannotPerformOnFloat" xml:space="preserve">
-    <value>По модулю можно использовать только целые числа</value>
+    <value>По модулю можно брать только целые числа</value>
     <comment>Error that occurs during graphing when modulo is used with a float.</comment>
   </data>
   <data name="EquationHasNoSolution" xml:space="preserve">
@@ -3567,7 +3567,7 @@
     <comment>Error that occurs during graphing when a number has too many decimals. Ex: 1.2.3</comment>
   </data>
   <data name="DecimalPointWithoutDigits" xml:space="preserve">
-    <value>В десятичной запятой отсутствуют цифры</value>
+    <value>Нет цифр рядом с десятичной запятой</value>
     <comment>Error that occurs during graphing with a decimal point without digits</comment>
   </data>
   <data name="UnexpectedEndOfExpression" xml:space="preserve">
@@ -3599,7 +3599,7 @@
     <comment>Error that occurs during graphing when the expression is empty</comment>
   </data>
   <data name="EqualWithoutEquation" xml:space="preserve">
-    <value>Равный был использован без уравнения</value>
+    <value>Знак равенства использован без уравнения</value>
     <comment>Error that occurs during graphing when equal is used without an equation. Ex: sin(x=y)</comment>
   </data>
   <data name="ExpectParenthesisAfterFunctionName" xml:space="preserve">
@@ -3607,7 +3607,7 @@
     <comment>Error that occurs during graphing when parenthesis are missing after a function.</comment>
   </data>
   <data name="IncorrectNumParameter" xml:space="preserve">
-    <value>Математическая операция имеет неверное количество параметров</value>
+    <value>Неверное количество параметров функции</value>
     <comment>Error that occurs during graphing when a function has the wrong number of parameters</comment>
   </data>
   <data name="InvalidVariableNameFormat" xml:space="preserve">
@@ -3627,11 +3627,11 @@
     <comment>Error that occurs during graphing when i or I is used.</comment>
   </data>
   <data name="GeneralError" xml:space="preserve">
-    <value>Уравнение не может быть построено</value>
+    <value>График уравнения не может быть построен</value>
     <comment>General error that occurs during graphing.</comment>
   </data>
   <data name="InvalidNumberDigit" xml:space="preserve">
-    <value>Цифра не может быть разрешена для данной базы</value>
+    <value>Цифра не может использоваться с этим основанием</value>
     <comment>Error that occurs during graphing when trying to use bases incorrect. Ex: base(2,1020).</comment>
   </data>
   <data name="InvalidNumberBase" xml:space="preserve">
@@ -3639,7 +3639,7 @@
     <comment>Error that occurs during graphing when the base is out of range.</comment>
   </data>
   <data name="InvalidVariableSpecification" xml:space="preserve">
-    <value>Математическая операция требует, чтобы один из ее параметров был переменной</value>
+    <value>Один из параметров функции должен быть переменной</value>
     <comment>Error that occurs during graphing when a function requires a variable in a particular position. Ex: 2nd argument of deriv.</comment>
   </data>
   <data name="ExpectingLogicalOperands" xml:space="preserve">
@@ -3655,11 +3655,11 @@
     <comment>Error that occurs during graphing when x or y is used in the limit point.</comment>
   </data>
   <data name="CannotUseComplexInfinityInReal" xml:space="preserve">
-    <value>Не может использовать сложную бесконечность</value>
+    <value>Нельзя использовать комплексную бесконечность</value>
     <comment>Error that occurs during graphing when complex infinity is used</comment>
   </data>
   <data name="CannotUseIInInequalitySolving" xml:space="preserve">
-    <value>Не может использовать комплексные числа в неравенствах</value>
+    <value>Нельзя использовать комплексные числа в неравенствах</value>
     <comment>Error that occurs during graphing when complex numbers are used in inequalities.</comment>
   </data>
   <data name="equationAnalysisBack.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">
@@ -3755,7 +3755,7 @@
     <comment>Used in Graphing Calculator to switch the view to the equation mode</comment>
   </data>
   <data name="GraphSwitchToGraphMode" xml:space="preserve">
-    <value>Перейти в режим графа</value>
+    <value>Перейти в режим графика</value>
     <comment>Used in Graphing Calculator to switch the view to the graph mode</comment>
   </data>
   <data name="SwitchModeToggleButton.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">


### PR DESCRIPTION
## Fixes #.

https://github.com/microsoft/calculator/issues/2052
https://github.com/microsoft/calculator/issues/2053

### Description of the changes:
- Fixed Russian translations in graphing calculator
- Corrected contribute text in settings
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- manual
-
-

