### PR TITLE
Adding support for Tsubo, a Japanese unit of floorspace for Japan and Taiwan

### DIFF
--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -175,9 +175,9 @@ void UnitConverterDataLoader::GetUnits(_In_ unordered_map<ViewMode, vector<Order
 
     bool useWattInsteadOfKilowatt = m_currentRegionCode == "GB";
 
-    // Use Pyeong, a Korean floorspace unit.
-    // https://en.wikipedia.org/wiki/Korean_units_of_measurement#Area
-    bool usePyeong = m_currentRegionCode == L"KP" || m_currentRegionCode == L"KR";
+    // Use 坪(Tsubo), or Pyeong in Korean, a Japanese unit of floorspace.
+    // https://en.wikipedia.org/wiki/Japanese_units_of_measurement#Area
+    bool usePyeong = m_currentRegionCode == L"JP" || m_currentRegionCode == L"TW" || m_currentRegionCode == L"KP" || m_currentRegionCode == L"KR";
 
     vector<OrderedUnit> areaUnits;
     areaUnits.push_back(


### PR DESCRIPTION
## Fixes #2100.


### Description of the changes:
- Added JP & TW to the existing Tsubo-equivalent unit conversion Pyeong.

### How changes were validated:
- User can convert between Tsubo and other units of area (such as square meters, square feet, etc.) within the Calculator app.
  ![image](https://github.com/microsoft/calculator/assets/9109405/9e059c1b-69cc-456d-b351-63de134ce8e3)

