### PR TITLE
Fix UI Tests

### DIFF
--- a/src/CalculatorUITests/CalculatorUITests.csproj
+++ b/src/CalculatorUITests/CalculatorUITests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
## Fix UI Tests
Recently, our CI pipeline failed all the time due to an error of unmatched dotnet version.
Root cause: pipeline agent upgrades to dotnet 8 while the UI test framework asks for dotnet 6.

## Fix
Upgrade the UI test target to dotnet 8.