### PR TITLE
Fix History/Memory tab item style in high contrast theme

### DIFF
--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -1170,178 +1170,207 @@
                    Tapped="DockPanelTapped"
                    Template="{StaticResource DockPanelTemplate}">
                 <Pivot.Resources>
-                    <!--
-                        This is a copy/paste of DefaultPivotHeaderItemStyle, but
-                        1. Updated the Foreground in ViewStates.
-                        2. Updated the SelectedPipe
-                    -->
-                    <Style TargetType="PivotHeaderItem">
-                        <Setter Property="FontSize" Value="{ThemeResource PivotHeaderItemFontSize}"/>
-                        <Setter Property="FontFamily" Value="{ThemeResource PivotHeaderItemFontFamily}"/>
-                        <Setter Property="FontWeight" Value="{ThemeResource PivotHeaderItemThemeFontWeight}"/>
-                        <Setter Property="CharacterSpacing" Value="{ThemeResource PivotHeaderItemCharacterSpacing}"/>
-                        <Setter Property="Background" Value="{ThemeResource PivotHeaderItemBackgroundUnselected}"/>
-                        <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}"/>
-                        <Setter Property="Padding" Value="{ThemeResource PivotHeaderItemMargin}"/>
-                        <Setter Property="Height" Value="48"/>
-                        <Setter Property="VerticalContentAlignment" Value="Center"/>
-                        <Setter Property="IsTabStop" Value="False"/>
-                        <Setter Property="UseSystemFocusVisuals" Value="False"/>
-                        <Setter Property="Template">
-                            <Setter.Value>
-                                <ControlTemplate TargetType="PivotHeaderItem">
-                                    <Grid x:Name="Grid"
-                                          Padding="{TemplateBinding Padding}"
-                                          Background="{TemplateBinding Background}"
-                                          CornerRadius="{ThemeResource ControlCornerRadius}">
+                    <ResourceDictionary>
+                        <ResourceDictionary.ThemeDictionaries>
+                            <ResourceDictionary x:Key="Default">
+                                <StaticResource x:Key="PivotHeaderItemForegroundUnselectedCustom" ResourceKey="TextFillColorPrimaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundUnselectedPointerOverCustom" ResourceKey="TextFillColorSecondaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundUnselectedPressedCustom" ResourceKey="TextFillColorTertiaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundSelectedCustom" ResourceKey="TextFillColorPrimaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundSelectedPointerOverCustom" ResourceKey="TextFillColorSecondaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundSelectedPressedCustom" ResourceKey="TextFillColorTertiaryBrush"/>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="HighContrast">
+                                <StaticResource x:Key="PivotHeaderItemForegroundUnselectedCustom" ResourceKey="SystemControlForegroundBaseMediumBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundUnselectedPointerOverCustom" ResourceKey="SystemControlHighlightAltBaseMediumHighBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundUnselectedPressedCustom" ResourceKey="SystemControlHighlightAltBaseMediumHighBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundSelectedCustom" ResourceKey="SystemControlHighlightAltBaseHighBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundSelectedPointerOverCustom" ResourceKey="SystemControlHighlightAltBaseMediumHighBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundSelectedPressedCustom" ResourceKey="SystemControlHighlightAltBaseMediumHighBrush"/>
+                            </ResourceDictionary>
+                            <ResourceDictionary x:Key="Light">
+                                <StaticResource x:Key="PivotHeaderItemForegroundUnselectedCustom" ResourceKey="TextFillColorPrimaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundUnselectedPointerOverCustom" ResourceKey="TextFillColorSecondaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundUnselectedPressedCustom" ResourceKey="TextFillColorTertiaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundSelectedCustom" ResourceKey="TextFillColorPrimaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundSelectedPointerOverCustom" ResourceKey="TextFillColorSecondaryBrush"/>
+                                <StaticResource x:Key="PivotHeaderItemForegroundSelectedPressedCustom" ResourceKey="TextFillColorTertiaryBrush"/>
+                            </ResourceDictionary>
+                        </ResourceDictionary.ThemeDictionaries>
 
-                                        <Grid.RenderTransform>
-                                            <TranslateTransform x:Name="ContentPresenterTranslateTransform"/>
-                                        </Grid.RenderTransform>
+                        <!--
+                            This is a copy/paste of DefaultPivotHeaderItemStyle, but
+                            1. Updated the Foreground in ViewStates.
+                            2. Updated the SelectedPipe
+                        -->
+                        <Style TargetType="PivotHeaderItem">
+                            <Setter Property="FontSize" Value="{ThemeResource PivotHeaderItemFontSize}"/>
+                            <Setter Property="FontFamily" Value="{ThemeResource PivotHeaderItemFontFamily}"/>
+                            <Setter Property="FontWeight" Value="{ThemeResource PivotHeaderItemThemeFontWeight}"/>
+                            <Setter Property="CharacterSpacing" Value="{ThemeResource PivotHeaderItemCharacterSpacing}"/>
+                            <Setter Property="Background" Value="{ThemeResource PivotHeaderItemBackgroundUnselected}"/>
+                            <Setter Property="Foreground" Value="{ThemeResource PivotHeaderItemForegroundUnselectedCustom}"/>
+                            <Setter Property="Padding" Value="{ThemeResource PivotHeaderItemMargin}"/>
+                            <Setter Property="Height" Value="48"/>
+                            <Setter Property="VerticalContentAlignment" Value="Center"/>
+                            <Setter Property="IsTabStop" Value="False"/>
+                            <Setter Property="UseSystemFocusVisuals" Value="False"/>
+                            <Setter Property="Template">
+                                <Setter.Value>
+                                    <ControlTemplate TargetType="PivotHeaderItem">
+                                        <Grid x:Name="Grid"
+                                              Padding="{TemplateBinding Padding}"
+                                              Background="{TemplateBinding Background}"
+                                              CornerRadius="{ThemeResource ControlCornerRadius}">
 
-                                        <VisualStateManager.VisualStateGroups>
-                                            <VisualStateGroup x:Name="SelectionStates">
+                                            <Grid.RenderTransform>
+                                                <TranslateTransform x:Name="ContentPresenterTranslateTransform"/>
+                                            </Grid.RenderTransform>
 
-                                                <VisualStateGroup.Transitions>
-                                                    <VisualTransition From="Unselected"
-                                                                      GeneratedDuration="0:0:0.33"
-                                                                      To="UnselectedLocked"/>
-                                                    <VisualTransition From="UnselectedLocked"
-                                                                      GeneratedDuration="0:0:0.33"
-                                                                      To="Unselected"/>
-                                                </VisualStateGroup.Transitions>
+                                            <VisualStateManager.VisualStateGroups>
+                                                <VisualStateGroup x:Name="SelectionStates">
 
-                                                <VisualState x:Name="Disabled">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
-                                                    </VisualState.Setters>
+                                                    <VisualStateGroup.Transitions>
+                                                        <VisualTransition From="Unselected"
+                                                                          GeneratedDuration="0:0:0.33"
+                                                                          To="UnselectedLocked"/>
+                                                        <VisualTransition From="UnselectedLocked"
+                                                                          GeneratedDuration="0:0:0.33"
+                                                                          To="Unselected"/>
+                                                    </VisualStateGroup.Transitions>
 
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorDisabledBrush}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundDisabled}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="Unselected">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
-                                                    </VisualState.Setters>
-                                                </VisualState>
-                                                <VisualState x:Name="UnselectedLocked">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
-                                                    </VisualState.Setters>
+                                                    <VisualState x:Name="Disabled">
+                                                        <VisualState.Setters>
+                                                            <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
+                                                        </VisualState.Setters>
 
-                                                    <Storyboard>
-                                                        <DoubleAnimation Duration="0"
-                                                                         Storyboard.TargetName="ContentPresenterTranslateTransform"
-                                                                         Storyboard.TargetProperty="X"
-                                                                         To="{ThemeResource PivotHeaderItemLockedTranslation}"/>
-                                                        <DoubleAnimation Duration="0"
-                                                                         Storyboard.TargetName="ContentPresenter"
-                                                                         Storyboard.TargetProperty="(UIElement.Opacity)"
-                                                                         To="0"/>
-                                                    </Storyboard>
-                                                </VisualState>
+                                                        <Storyboard>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorDisabledBrush}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundDisabled}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                        </Storyboard>
+                                                    </VisualState>
+                                                    <VisualState x:Name="Unselected">
+                                                        <VisualState.Setters>
+                                                            <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
+                                                        </VisualState.Setters>
+                                                    </VisualState>
+                                                    <VisualState x:Name="UnselectedLocked">
+                                                        <VisualState.Setters>
+                                                            <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
+                                                        </VisualState.Setters>
 
-                                                <VisualState x:Name="Selected">
+                                                        <Storyboard>
+                                                            <DoubleAnimation Duration="0"
+                                                                             Storyboard.TargetName="ContentPresenterTranslateTransform"
+                                                                             Storyboard.TargetProperty="X"
+                                                                             To="{ThemeResource PivotHeaderItemLockedTranslation}"/>
+                                                            <DoubleAnimation Duration="0"
+                                                                             Storyboard.TargetName="ContentPresenter"
+                                                                             Storyboard.TargetProperty="(UIElement.Opacity)"
+                                                                             To="0"/>
+                                                        </Storyboard>
+                                                    </VisualState>
 
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorPrimaryBrush}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundSelected}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="UnselectedPointerOver">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
-                                                    </VisualState.Setters>
+                                                    <VisualState x:Name="Selected">
 
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorSecondaryBrush}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundUnselectedPointerOver}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="SelectedPointerOver">
+                                                        <Storyboard>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemForegroundSelectedCustom}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundSelected}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                        </Storyboard>
+                                                    </VisualState>
+                                                    <VisualState x:Name="UnselectedPointerOver">
+                                                        <VisualState.Setters>
+                                                            <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
+                                                        </VisualState.Setters>
 
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorSecondaryBrush}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundSelectedPointerOver}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SelectedPipe" Storyboard.TargetProperty="Fill">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AccentFillColorSecondaryBrush}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="UnselectedPressed">
-                                                    <VisualState.Setters>
-                                                        <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
-                                                    </VisualState.Setters>
+                                                        <Storyboard>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemForegroundUnselectedPointerOverCustom}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundUnselectedPointerOver}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                        </Storyboard>
+                                                    </VisualState>
+                                                    <VisualState x:Name="SelectedPointerOver">
 
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorTertiaryBrush}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundUnselectedPressed}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                                <VisualState x:Name="SelectedPressed">
+                                                        <Storyboard>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemForegroundSelectedPointerOverCustom}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundSelectedPointerOver}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SelectedPipe" Storyboard.TargetProperty="Fill">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AccentFillColorSecondaryBrush}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                        </Storyboard>
+                                                    </VisualState>
+                                                    <VisualState x:Name="UnselectedPressed">
+                                                        <VisualState.Setters>
+                                                            <Setter Target="SelectedPipe.Visibility" Value="Collapsed"/>
+                                                        </VisualState.Setters>
 
-                                                    <Storyboard>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorTertiaryBrush}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundSelectedPressed}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SelectedPipe" Storyboard.TargetProperty="Fill">
-                                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AccentFillColorTertiaryBrush}"/>
-                                                        </ObjectAnimationUsingKeyFrames>
-                                                    </Storyboard>
-                                                </VisualState>
-                                            </VisualStateGroup>
+                                                        <Storyboard>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemForegroundUnselectedPressedCustom}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundUnselectedPressed}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                        </Storyboard>
+                                                    </VisualState>
+                                                    <VisualState x:Name="SelectedPressed">
 
-                                        </VisualStateManager.VisualStateGroups>
+                                                        <Storyboard>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemForegroundSelectedPressedCustom}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Grid" Storyboard.TargetProperty="Background">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource PivotHeaderItemBackgroundSelectedPressed}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                            <ObjectAnimationUsingKeyFrames Storyboard.TargetName="SelectedPipe" Storyboard.TargetProperty="Fill">
+                                                                <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AccentFillColorTertiaryBrush}"/>
+                                                            </ObjectAnimationUsingKeyFrames>
+                                                        </Storyboard>
+                                                    </VisualState>
+                                                </VisualStateGroup>
 
-                                        <ContentPresenter x:Name="ContentPresenter"
-                                                          HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                          VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
-                                                          FontFamily="{TemplateBinding FontFamily}"
-                                                          FontSize="{TemplateBinding FontSize}"
-                                                          FontWeight="{TemplateBinding FontWeight}"
-                                                          Content="{TemplateBinding Content}"
-                                                          ContentTemplate="{TemplateBinding ContentTemplate}"
-                                                          OpticalMarginAlignment="TrimSideBearings"/>
-                                        <Rectangle x:Name="SelectedPipe"
-                                                   Width="16"
-                                                   Height="3"
-                                                   Margin="0,0,0,2"
-                                                   HorizontalAlignment="Center"
-                                                   VerticalAlignment="Bottom"
-                                                   Fill="{ThemeResource AccentFillColorDefaultBrush}"
-                                                   RadiusX="1.5"
-                                                   RadiusY="1.5"/>
+                                            </VisualStateManager.VisualStateGroups>
 
-                                    </Grid>
-                                </ControlTemplate>
-                            </Setter.Value>
-                        </Setter>
-                    </Style>
+                                            <ContentPresenter x:Name="ContentPresenter"
+                                                              HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                              VerticalAlignment="{TemplateBinding VerticalContentAlignment}"
+                                                              FontFamily="{TemplateBinding FontFamily}"
+                                                              FontSize="{TemplateBinding FontSize}"
+                                                              FontWeight="{TemplateBinding FontWeight}"
+                                                              Content="{TemplateBinding Content}"
+                                                              ContentTemplate="{TemplateBinding ContentTemplate}"
+                                                              OpticalMarginAlignment="TrimSideBearings"/>
+                                            <Rectangle x:Name="SelectedPipe"
+                                                       Width="16"
+                                                       Height="3"
+                                                       Margin="0,0,0,2"
+                                                       HorizontalAlignment="Center"
+                                                       VerticalAlignment="Bottom"
+                                                       Fill="{ThemeResource AccentFillColorDefaultBrush}"
+                                                       RadiusX="1.5"
+                                                       RadiusY="1.5"/>
+
+                                        </Grid>
+                                    </ControlTemplate>
+                                </Setter.Value>
+                            </Setter>
+                        </Style>
+                    </ResourceDictionary>
                 </Pivot.Resources>
                 <PivotItem x:Name="HistoryPivotItem"
                            Margin="0,10,0,0"


### PR DESCRIPTION
### Description of the changes:
Text present for "History/Memory" tab is not adapting properly in high contrast theme.

To fix this issue, created a series of custom theme resources to handle the text display in different ViewStates.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Before the fix with "History" selected,
![image](https://github.com/microsoft/calculator/assets/78525595/febe5f76-01d1-4c24-ad52-9f9da59aa13e)
Before the fix with "History" selected and "Memory" hovered,
![image](https://github.com/microsoft/calculator/assets/78525595/95f4d64a-84f8-461d-8737-22a78fdb6f7a)
After the fix with "History" selected,
![image](https://github.com/microsoft/calculator/assets/78525595/eaf664de-c75b-4260-9579-22954a66c12e)
After the fix with "History" selected and "Memory" hovered,
![image](https://github.com/microsoft/calculator/assets/78525595/211fb129-3e8d-4f73-9cf6-03400e37c735)


