### PR TITLE
Fix background of controls with focus in Date calculation in high contrast theme

### DIFF
--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -223,7 +223,7 @@
                                         <VisualState x:Name="Focused">
                                             <Storyboard>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="Background" Storyboard.TargetProperty="Background">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource CalendarDatePickerBackgroundFocused}"/>
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource SubtleFillColorTransparentBrush}"/>
                                                 </ObjectAnimationUsingKeyFrames>
                                             </Storyboard>
                                         </VisualState>

--- a/src/Calculator/Views/DateCalculator.xaml
+++ b/src/Calculator/Views/DateCalculator.xaml
@@ -1023,7 +1023,12 @@
                             <StaticResource x:Key="ComboBoxBackgroundUnfocused" ResourceKey="SubtleFillColorTransparentBrush"/>
                             <StaticResource x:Key="ComboBoxBackgroundFocused" ResourceKey="SubtleFillColorTransparentBrush"/>
                         </ResourceDictionary>
-                        <ResourceDictionary x:Key="HighContrast"/>
+                        <ResourceDictionary x:Key="HighContrast">
+                            <StaticResource x:Key="ComboBoxBackgroundPointerOver" ResourceKey="SubtleFillColorSecondaryBrush"/>
+                            <StaticResource x:Key="ComboBoxBackgroundPressed" ResourceKey="SubtleFillColorTertiaryBrush"/>
+                            <StaticResource x:Key="ComboBoxBackgroundUnfocused" ResourceKey="SubtleFillColorTransparentBrush"/>
+                            <StaticResource x:Key="ComboBoxBackgroundFocused" ResourceKey="SubtleFillColorTransparentBrush"/>
+                        </ResourceDictionary>
                     </ResourceDictionary.ThemeDictionaries>
                 </ResourceDictionary>
             </ComboBox.Resources>


### PR DESCRIPTION
### Description of the changes:
When the option ComboBox and CalendarDatePicker controls are in focus in high contrast theme, the contrast ratio is not large enough for the text and background.

Updated the HighContrast theme resources for ComboBox and the background theme resource of focused VisualState for CalendarDatePicker to fix the issue.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Before the fix with option ComboBox in focus,
![image](https://github.com/microsoft/calculator/assets/78525595/d56f03d0-7655-45cf-86b8-7a61caa2062f)
Before the fix with CalendarDatePicker in focus while a date is selected,
![image](https://github.com/microsoft/calculator/assets/78525595/1f766db8-9e5d-4642-8012-a8ff005d1b59)
After the fix with option ComboBox in focus,
![image](https://github.com/microsoft/calculator/assets/78525595/50c86978-e600-4318-81ec-6ae7620541e4)
After the fix with CalendarDatePicker in focus while a date is selected,
![image](https://github.com/microsoft/calculator/assets/78525595/6ec14e82-0dcf-4a25-a53b-d75cd0824bee)