### PR TITLE
Fix foreground resource of operator panel button in high contrast theme

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -909,6 +909,22 @@
                                     <contract7Present:BrushTransition Duration="0:0:0.083"/>
                                 </contract7Present:ContentPresenter.BackgroundTransition>
 
+                                <ContentPresenter.Resources>
+                                    <ResourceDictionary>
+                                        <ResourceDictionary.ThemeDictionaries>
+                                            <ResourceDictionary x:Key="Default">
+                                                <StaticResource x:Key="ToggleButtonForegroundCheckedCustom" ResourceKey="AppControlForegroundSecondaryBrush"/>
+                                            </ResourceDictionary>
+                                            <ResourceDictionary x:Key="HighContrast">
+                                                <StaticResource x:Key="ToggleButtonForegroundCheckedCustom" ResourceKey="TextFillColorSecondaryBrush"/>
+                                            </ResourceDictionary>
+                                            <ResourceDictionary x:Key="Light">
+                                                <StaticResource x:Key="ToggleButtonForegroundCheckedCustom" ResourceKey="AppControlForegroundSecondaryBrush"/>
+                                            </ResourceDictionary>
+                                        </ResourceDictionary.ThemeDictionaries>
+                                    </ResourceDictionary>
+                                </ContentPresenter.Resources>
+
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
                                         <VisualState x:Name="Normal"/>
@@ -958,7 +974,7 @@
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AppControlBackgroundTertiaryBrush}"/>
                                                 </ObjectAnimationUsingKeyFrames>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AppControlForegroundSecondaryBrush}"/>
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedCustom}"/>
                                                 </ObjectAnimationUsingKeyFrames>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBorderBrush}"/>

--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -909,22 +909,6 @@
                                     <contract7Present:BrushTransition Duration="0:0:0.083"/>
                                 </contract7Present:ContentPresenter.BackgroundTransition>
 
-                                <ContentPresenter.Resources>
-                                    <ResourceDictionary>
-                                        <ResourceDictionary.ThemeDictionaries>
-                                            <ResourceDictionary x:Key="Default">
-                                                <StaticResource x:Key="ToggleButtonForegroundCheckedCustom" ResourceKey="AppControlForegroundSecondaryBrush"/>
-                                            </ResourceDictionary>
-                                            <ResourceDictionary x:Key="HighContrast">
-                                                <StaticResource x:Key="ToggleButtonForegroundCheckedCustom" ResourceKey="TextFillColorSecondaryBrush"/>
-                                            </ResourceDictionary>
-                                            <ResourceDictionary x:Key="Light">
-                                                <StaticResource x:Key="ToggleButtonForegroundCheckedCustom" ResourceKey="AppControlForegroundSecondaryBrush"/>
-                                            </ResourceDictionary>
-                                        </ResourceDictionary.ThemeDictionaries>
-                                    </ResourceDictionary>
-                                </ContentPresenter.Resources>
-
                                 <VisualStateManager.VisualStateGroups>
                                     <VisualStateGroup x:Name="CommonStates">
                                         <VisualState x:Name="Normal"/>
@@ -974,7 +958,7 @@
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource AppControlBackgroundTertiaryBrush}"/>
                                                 </ObjectAnimationUsingKeyFrames>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
-                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonForegroundCheckedCustom}"/>
+                                                    <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource TextFillColorSecondaryBrush}"/>
                                                 </ObjectAnimationUsingKeyFrames>
                                                 <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="BorderBrush">
                                                     <DiscreteObjectKeyFrame KeyTime="0" Value="{ThemeResource ToggleButtonBorderBrush}"/>


### PR DESCRIPTION
### Description of the changes:
Text present for the operator panel buttons in Scientific, Graphing and Programmer mode don't have enough contrast ratio with the background.

`AppControlForegroundSecondaryBrush` is paired with `TextFillColorSecondaryBrush` in default and light themes. Use the same `TextFillColorSecondaryBrush` for high contrast theme in the Checked VisualState to fix this issue.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Before the fix with Trigonometry panel opened,
![image](https://github.com/microsoft/calculator/assets/78525595/d92d4d17-46ee-4d98-8566-9fafd2890537)
After the fix with Trigonometry panel opened,
![image](https://github.com/microsoft/calculator/assets/78525595/0ea6c0a4-2227-47b7-8122-84a081bf46a9)
