### PR TITLE
Fix: Narrator doesn't announce "There's no history yet"

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -2778,11 +2778,11 @@
     <comment>{Locked}The Octal button</comment>
   </data>
   <data name="HistoryEmpty.Text" xml:space="preserve">
-    <value>There’s no history yet</value>
+    <value>There’s no history yet.</value>
     <comment>The text that shows as the header for the history list</comment>
   </data>
   <data name="MemoryPaneEmpty.Text" xml:space="preserve">
-    <value>There’s nothing saved in memory</value>
+    <value>There’s nothing saved in memory.</value>
     <comment>The text that shows as the header for the memory list</comment>
   </data>
   <data name="MemoryFlyout.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">

--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -1374,6 +1374,7 @@
                 </Pivot.Resources>
                 <PivotItem x:Name="HistoryPivotItem"
                            Margin="0,10,0,0"
+                           AutomationProperties.AutomationId="HistoryLabel"
                            AutomationProperties.Name="{x:Bind HistoryPivotItemUiaName, Mode=OneWay}">
                     <PivotItem.Header>
                         <TextBlock AccessKey="{utils:ResourceString Name=HistoryLabel/AccessKey}"
@@ -1384,6 +1385,7 @@
                 </PivotItem>
                 <PivotItem x:Name="MemoryPivotItem"
                            Margin="0,10,0,0"
+                           AutomationProperties.AutomationId="MemoryLabel"
                            AutomationProperties.Name="{x:Bind MemoryPivotItemUiaName, Mode=OneWay}">
                     <PivotItem.Header>
                         <TextBlock AccessKey="{utils:ResourceString Name=MemoryLabel/AccessKey}"

--- a/src/Calculator/Views/Calculator.xaml
+++ b/src/Calculator/Views/Calculator.xaml
@@ -1374,8 +1374,7 @@
                 </Pivot.Resources>
                 <PivotItem x:Name="HistoryPivotItem"
                            Margin="0,10,0,0"
-                           AutomationProperties.AutomationId="HistoryLabel"
-                           AutomationProperties.Name="{utils:ResourceString Name=HistoryPivotItem/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name}">
+                           AutomationProperties.Name="{x:Bind HistoryPivotItemUiaName, Mode=OneWay}">
                     <PivotItem.Header>
                         <TextBlock AccessKey="{utils:ResourceString Name=HistoryLabel/AccessKey}"
                                    AccessKeyInvoked="OnHistoryAccessKeyInvoked"
@@ -1385,8 +1384,7 @@
                 </PivotItem>
                 <PivotItem x:Name="MemoryPivotItem"
                            Margin="0,10,0,0"
-                           AutomationProperties.AutomationId="MemoryLabel"
-                           AutomationProperties.Name="{utils:ResourceString Name=MemoryPivotItem/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name}">
+                           AutomationProperties.Name="{x:Bind MemoryPivotItemUiaName, Mode=OneWay}">
                     <PivotItem.Header>
                         <TextBlock AccessKey="{utils:ResourceString Name=MemoryLabel/AccessKey}"
                                    AccessKeyInvoked="OnMemoryAccessKeyInvoked"

--- a/src/Calculator/Views/Calculator.xaml.cs
+++ b/src/Calculator/Views/Calculator.xaml.cs
@@ -6,7 +6,7 @@ using CalculatorApp.ViewModel;
 using CalculatorApp.ViewModel.Common;
 
 using System;
-
+using Windows.ApplicationModel.Resources;
 using Windows.Foundation;
 using Windows.Globalization.NumberFormatting;
 using Windows.UI.Core;
@@ -120,6 +120,26 @@ namespace CalculatorApp
                 self.OnIsAlwaysOnTopPropertyChanged((bool)args.OldValue, (bool)args.NewValue);
             }));
 
+        public string HistoryPivotItemUiaName
+        {
+            get => (string)GetValue(HistoryPivotItemUiaNameProperty);
+            set => SetValue(HistoryPivotItemUiaNameProperty, value);
+        }
+
+        // Using a DependencyProperty as the backing store for HistoryPivotItemUiaName.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty HistoryPivotItemUiaNameProperty =
+            DependencyProperty.Register(nameof(HistoryPivotItemUiaName), typeof(string), typeof(Calculator), new PropertyMetadata(string.Empty));
+
+        public string MemoryPivotItemUiaName
+        {
+            get => (string)GetValue(MemoryPivotItemUiaNameProperty);
+            set => SetValue(MemoryPivotItemUiaNameProperty, value);
+        }
+
+        // Using a DependencyProperty as the backing store for MemoryPivotItemUiaName.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty MemoryPivotItemUiaNameProperty =
+            DependencyProperty.Register(nameof(MemoryPivotItemUiaName), typeof(string), typeof(Calculator), new PropertyMetadata(string.Empty));
+
         public System.Windows.Input.ICommand HistoryButtonPressed
         {
             get
@@ -159,6 +179,7 @@ namespace CalculatorApp
         {
             if (m_historyList == null)
             {
+                historyVM.PropertyChanged += (s, e) => UpdateHistoryState();
                 m_historyList = new HistoryList
                 {
                     DataContext = historyVM
@@ -167,6 +188,7 @@ namespace CalculatorApp
                 historyVM.HistoryItemClicked += OnHistoryItemClicked;
             }
         }
+
 
         public void UpdatePanelViewState()
         {
@@ -296,6 +318,7 @@ namespace CalculatorApp
                     MemRecall.IsEnabled = false;
                     ClearMemoryButton.IsEnabled = false;
                 }
+                MemoryPivotItemUiaName = GetMemoryPivotItemUiaString(Model.IsMemoryEmpty);
 
                 if (DockPanel.Visibility == Visibility.Visible)
                 {
@@ -328,6 +351,7 @@ namespace CalculatorApp
                 {
                     DockPivot.SelectedIndex = 0;
                 }
+                HistoryPivotItemUiaName = GetHistoryPivotItemUiaString(Model.HistoryVM.ItemsCount == 0);
             }
             else
             {
@@ -842,6 +866,20 @@ namespace CalculatorApp
 
             var mode = IsStandard ? ViewMode.Standard : IsScientific ? ViewMode.Scientific : ViewMode.Programmer;
             TraceLogger.GetInstance().LogVisualStateChanged(mode, e.NewState.Name, IsAlwaysOnTop);
+        }
+
+        private string GetMemoryPivotItemUiaString(bool isEmpty)
+        {
+            var loader = ResourceLoader.GetForCurrentView();
+            var label = loader.GetString("MemoryLabel/Text");
+            return isEmpty ? $"{loader.GetString("MemoryPaneEmpty/Text")} {label}" : label;
+        }
+
+        private string GetHistoryPivotItemUiaString(bool isEmpty)
+        {
+            var loader = ResourceLoader.GetForCurrentView();
+            var label = loader.GetString("HistoryLabel/Text");
+            return isEmpty ? $"{loader.GetString("HistoryEmpty/Text")} {label}" : label;
         }
     }
 }


### PR DESCRIPTION
## Fix: Narrator doesn't announce "There's no history yet"
Repro steps:
1. Launch Calculator app.
1. Navigate Open navigation button and activate it.
1. Navigate to Scientific calculator list item and activate it.
1. Turn on Narrator by 'Ctrl+Win+Enter' keys.
1. Navigate to the "History" tab item and activate it.
1. Observe the issue.

Actual Result:
When no history is present there, narrator does not announce “There’s no history yet”. It announces as 'History tab item 1 of 2, selected'.

Expected Result:
When no history is present there, narrator should announce the information also as 'There’s no history yet'. It should announce as 'History tab item 1 of 2, selected, there's no history yet'.

## How
Due to the technical limitation from XAML UIA infra, there is no canonical way to append Narrator announcement right after the announcement generated for items-container, i.e. after the string _1 of 2, selected_.
To fix this problem, I have to use a work around in the announcement for Pivot Item Headers, which is, instead of saying _History tab item 1 of 2, selected, there's no history yet_, we can make it by saying _There's no history yet. History tab item 1 of 2, selected_.