### PR TITLE
Improve the German translation, update Resources.resw, typing error.

### DIFF
--- a/src/Calculator/Resources/de-DE/Resources.resw
+++ b/src/Calculator/Resources/de-DE/Resources.resw
@@ -2334,7 +2334,7 @@
     <comment>{Locked="%1"}. Copyright statement, displayed on the About panel. %1 = the current year (4 digits)</comment>
   </data>
   <data name="AboutControlContribute" xml:space="preserve">
-    <value>Um zu erfahren, wie Sie dem Windows-Rechner mitwirken können, checken Sie das Projekt auf %HL%GitHub%HL% aus.</value>
+    <value>Um zu erfahren, wie Sie am Windows-Rechner mitwirken können, checken Sie das Projekt auf %HL%GitHub%HL% aus.</value>
     <comment>{Locked="%HL%GitHub%HL%"}. GitHub link, Displayed on the About panel</comment>
   </data>
   <data name="AboutGroupTitle.Text" xml:space="preserve">


### PR DESCRIPTION
Text is: "Um zu erfahren, wie Sie dem Windows-Rechner mitwirken können, ..."
Using only “dem” is wrong. Either “an dem” or “am”. "am" sounds better IMHO. "am" is short for “an dem”.

## Fixes #.

Accept the PR to fix the error and use "am".

### Description of the changes:

Changed the word "dem" into the word "am".

### How changes were validated:

Not tested.
