### PR TITLE
Add hint about MathRichEditBox's context menu for narrator

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4750,4 +4750,8 @@
     <value>Settings page</value>
     <comment>Announcement used when Settings page is opened</comment>
   </data>
+  <data name="MathRichEditBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
+    <value>Press Shift + F10 to open the context menu</value>
+    <comment>Screen reader prompt for the equation and accelerator to context menu</comment>
+  </data>
 </root>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4751,7 +4751,7 @@
     <comment>Announcement used when Settings page is opened</comment>
   </data>
   <data name="MathRichEditBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Press Shift + F10 to open the context menu</value>
+    <value>Open the context menu for more functionalities</value>
     <comment>Screen reader prompt for the equation and accelerator to context menu</comment>
   </data>
 </root>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4751,7 +4751,7 @@
     <comment>Announcement used when Settings page is opened</comment>
   </data>
   <data name="MathRichEditBox.[using:Windows.UI.Xaml.Automation]AutomationProperties.Name" xml:space="preserve">
-    <value>Open the context menu for more functionalities</value>
-    <comment>Screen reader prompt for the equation and accelerator to context menu</comment>
+    <value>Open the context menu for available actions</value>
+    <comment>Screen reader prompt for the context menu of the expression box</comment>
   </data>
 </root>

--- a/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
+++ b/src/Calculator/Views/GraphingCalculator/EquationInputArea.xaml
@@ -661,6 +661,7 @@
                                                                   FontSize="{TemplateBinding FontSize}"
                                                                   FontWeight="{TemplateBinding FontWeight}"
                                                                   AcceptsReturn="false"
+                                                                  AutomationProperties.Name="{utils:ResourceString Name=MathRichEditBox/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name}"
                                                                   InputScope="Text"
                                                                   MathText="{Binding MathEquation, RelativeSource={RelativeSource TemplatedParent}, Mode=TwoWay}"
                                                                   MaxLength="2048"


### PR DESCRIPTION
### Description of the changes:
Narrator will inform users about the context menu when the MathRichEditBox is focused.

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manually tested.
