### PR TITLE
Fix: heap corruption in the Graphing mode

### DIFF
--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -543,7 +543,7 @@ namespace GraphControl
         if (m_graph != nullptr && m_renderMain != nullptr)
         {
             m_graph->SetArgValue(variableName->Data(), newValue);
-            m_renderMain->RunRenderPass();
+            [](RenderMain ^ renderMain) -> winrt::fire_and_forget { co_await renderMain->RunRenderPassAsync(); }(m_renderMain);
         }
     }
 

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -11,7 +11,6 @@ using namespace GraphControl;
 using namespace GraphControl::DX;
 using namespace Platform;
 using namespace Platform::Collections;
-using namespace std;
 using namespace Concurrency;
 using namespace Windows::Devices::Input;
 using namespace Windows::Foundation;
@@ -54,9 +53,9 @@ namespace
     // posX/posY are the pointer position elements and width,height are the dimensions of the graph surface.
     // The graphing engine interprets x,y position between the range [-1, 1].
     // Translate the pointer position to the [-1, 1] bounds.
-    __inline pair<double, double> PointerPositionToGraphPosition(double posX, double posY, double width, double height)
+    __inline std::pair<double, double> PointerPositionToGraphPosition(double posX, double posY, double width, double height)
     {
-        return make_pair((2 * posX / width - 1), (1 - 2 * posY / height));
+        return std::make_pair((2 * posX / width - 1), (1 - 2 * posY / height));
     }
 }
 
@@ -71,7 +70,7 @@ namespace GraphControl
 
         m_solver->ParsingOptions().SetFormatType(s_defaultFormatType);
         m_solver->FormatOptions().SetFormatType(s_defaultFormatType);
-        m_solver->FormatOptions().SetMathMLPrefix(wstring(L"mml"));
+        m_solver->FormatOptions().SetMathMLPrefix(L"mml");
 
         DefaultStyleKey = StringReference(s_defaultStyleKey);
 
@@ -95,21 +94,10 @@ namespace GraphControl
     {
         if (m_graph != nullptr && m_renderMain != nullptr)
         {
-            if (auto renderer = m_graph->GetRenderer())
+            if (auto renderer = m_graph->GetRenderer(); static_cast<bool>(renderer) && SUCCEEDED(renderer->ScaleRange(centerX, centerY, scale)))
             {
-                m_renderMain->GetCriticalSection().lock();
-
-                if (SUCCEEDED(renderer->ScaleRange(centerX, centerY, scale)))
-                {
-                    m_renderMain->GetCriticalSection().unlock();
-
-                    m_renderMain->RunRenderPass();
-                    GraphViewChangedEvent(this, GraphViewChangedReason::Manipulation);
-                }
-                else
-                {
-                    m_renderMain->GetCriticalSection().unlock();
-                }
+                m_renderMain->RunRenderPass();
+                GraphViewChangedEvent(this, GraphViewChangedReason::Manipulation);
             }
         }
     }
@@ -251,7 +239,7 @@ namespace GraphControl
 
             if (auto analyzer = graph->GetAnalyzer())
             {
-                vector<Equation ^> equationVector;
+                std::vector<Equation ^> equationVector;
                 equationVector.push_back(equation);
                 UpdateGraphOptions(graph->GetOptions(), equationVector);
                 bool variableIsNotX;
@@ -325,15 +313,15 @@ namespace GraphControl
 
     task<bool> Grapher::TryUpdateGraph(bool keepCurrentView)
     {
-        optional<vector<shared_ptr<IEquation>>> initResult = nullopt;
+        std::optional<std::vector<std::shared_ptr<IEquation>>> initResult;
         bool successful = false;
         m_errorCode = 0;
         m_errorType = 0;
 
         if (m_renderMain && m_graph != nullptr)
         {
-            unique_ptr<IExpression> graphExpression;
-            wstring request;
+            std::unique_ptr<IExpression> graphExpression;
+            std::wstring request;
 
             auto validEqs = GetGraphableEquations();
 
@@ -371,13 +359,12 @@ namespace GraphControl
                         co_return false;
                     }
 
-                    unique_ptr<IExpression> expr;
-                    wstring parsableEquation = s_getGraphOpeningTags;
+                    std::wstring parsableEquation = s_getGraphOpeningTags;
                     parsableEquation += equationRequest;
                     parsableEquation += s_getGraphClosingTags;
 
                     // Wire up the corresponding error to an error message in the UI at some point
-                    if (!(expr = m_solver->ParseInput(parsableEquation, m_errorCode, m_errorType)))
+                    if (auto expr = m_solver->ParseInput(parsableEquation, m_errorCode, m_errorType); !static_cast<bool>(expr))
                     {
                         co_return false;
                     }
@@ -392,11 +379,11 @@ namespace GraphControl
             {
                 initResult = TryInitializeGraph(keepCurrentView, graphExpression.get());
 
-                if (initResult != nullopt)
+                if (initResult.has_value())
                 {
-                    auto graphedEquations = initResult.value();
+                    auto graphedEquations = *initResult;
 
-                    for (int i = 0; i < validEqs.size(); i++)
+                    for (size_t i = 0; i < validEqs.size(); ++i)
                     {
                         validEqs[i]->GraphedEquation = graphedEquations[i];
                     }
@@ -407,8 +394,8 @@ namespace GraphControl
                     m_renderMain->Graph = m_graph;
 
                     // It is possible that the render fails, in that case fall through to explicit empty initialization
-                    co_await m_renderMain->RunRenderPassAsync(false);
-                    if (m_renderMain->IsRenderPassSuccesful())
+                    auto succ = co_await m_renderMain->RunRenderPassAsync(false);
+                    if (succ)
                     {
                         UpdateVariables();
                         successful = true;
@@ -417,7 +404,7 @@ namespace GraphControl
                     {
                         // If we failed to render then we have already lost the previous graph
                         shouldKeepPreviousGraph = false;
-                        initResult = nullopt;
+                        initResult.reset();
                         m_solver->HRErrorToErrorInfo(m_renderMain->GetRenderError(), m_errorCode, m_errorType);
                     }
                 }
@@ -427,15 +414,15 @@ namespace GraphControl
                 }
             }
 
-            if (initResult == nullopt)
+            if (!initResult.has_value())
             {
                 // Do not re-initialize the graph to empty if there are still valid equations graphed
                 if (!shouldKeepPreviousGraph)
                 {
                     initResult = TryInitializeGraph(false, nullptr);
-                    if (initResult != nullopt)
+                    if (initResult.has_value())
                     {
-                        UpdateGraphOptions(m_graph->GetOptions(), vector<Equation ^>());
+                        UpdateGraphOptions(m_graph->GetOptions(), {});
                         SetGraphArgs(m_graph);
 
                         m_renderMain->Graph = m_graph;
@@ -475,12 +462,10 @@ namespace GraphControl
         }
     }
 
-    void Grapher::SetGraphArgs(shared_ptr<IGraph> graph)
+    void Grapher::SetGraphArgs(std::shared_ptr<IGraph> graph)
     {
         if (graph != nullptr && m_renderMain != nullptr)
         {
-            critical_section::scoped_lock lock(m_renderMain->GetCriticalSection());
-
             for (auto variablePair : Variables)
             {
                 graph->SetArgValue(variablePair->Key->Data(), variablePair->Value->Value);
@@ -488,17 +473,17 @@ namespace GraphControl
         }
     }
 
-    shared_ptr<IGraph> Grapher::GetGraph(Equation ^ equation)
+    std::shared_ptr<IGraph> Grapher::GetGraph(Equation ^ equation)
     {
-        shared_ptr<Graphing::IGraph> graph = m_solver->CreateGrapher();
+        std::shared_ptr<Graphing::IGraph> graph = m_solver->CreateGrapher();
 
-        wstring request = s_getGraphOpeningTags;
+        std::wstring request = s_getGraphOpeningTags;
         request += equation->GetRequest()->Data();
         request += s_getGraphClosingTags;
 
-        if (unique_ptr<IExpression> graphExpression = m_solver->ParseInput(request, m_errorCode, m_errorType))
+        if (auto expr = m_solver->ParseInput(request, m_errorCode, m_errorType); static_cast<bool>(expr))
         {
-            if (graph->TryInitialize(graphExpression.get()))
+            if (graph->TryInitialize(expr.get()))
             {
                 return graph;
             }
@@ -557,19 +542,12 @@ namespace GraphControl
 
         if (m_graph != nullptr && m_renderMain != nullptr)
         {
-            auto workItemHandler = ref new WorkItemHandler([this, variableName, newValue](IAsyncAction ^ action) {
-                m_renderMain->GetCriticalSection().lock();
-                m_graph->SetArgValue(variableName->Data(), newValue);
-                m_renderMain->GetCriticalSection().unlock();
-
-                m_renderMain->RunRenderPass();
-            });
-
-            ThreadPool::RunAsync(workItemHandler, WorkItemPriority::High, WorkItemOptions::None);
+            m_graph->SetArgValue(variableName->Data(), newValue);
+            m_renderMain->RunRenderPass();
         }
     }
 
-    void Grapher::UpdateGraphOptions(IGraphingOptions& options, const vector<Equation ^>& validEqs)
+    void Grapher::UpdateGraphOptions(IGraphingOptions& options, const std::vector<Equation ^>& validEqs)
     {
         options.SetForceProportional(ForceProportionalAxes);
 
@@ -580,7 +558,7 @@ namespace GraphControl
 
         if (!validEqs.empty())
         {
-            vector<Graphing::Color> graphColors;
+            std::vector<Graphing::Color> graphColors;
             graphColors.reserve(validEqs.size());
             for (Equation ^ eq : validEqs)
             {
@@ -603,9 +581,9 @@ namespace GraphControl
         }
     }
 
-    vector<Equation ^> Grapher::GetGraphableEquations()
+    std::vector<Equation ^> Grapher::GetGraphableEquations()
     {
-        vector<Equation ^> validEqs;
+        std::vector<Equation ^> validEqs;
 
         for (Equation ^ eq : Equations)
         {
@@ -783,15 +761,10 @@ namespace GraphControl
                     translationX /= -width;
                     translationY /= height;
 
-                    m_renderMain->GetCriticalSection().lock();
-
                     if (FAILED(renderer->MoveRangeByRatio(translationX, translationY)))
                     {
-                        m_renderMain->GetCriticalSection().unlock();
                         return;
                     }
-
-                    m_renderMain->GetCriticalSection().unlock();
                     needsRenderPass = true;
                 }
 
@@ -805,15 +778,10 @@ namespace GraphControl
                     const auto& pos = e->Position;
                     const auto [centerX, centerY] = PointerPositionToGraphPosition(pos.X, pos.Y, width, height);
 
-                    m_renderMain->GetCriticalSection().lock();
-
                     if (FAILED(renderer->ScaleRange(centerX, centerY, scale)))
                     {
-                        m_renderMain->GetCriticalSection().unlock();
                         return;
                     }
-
-                    m_renderMain->GetCriticalSection().unlock();
                     needsRenderPass = true;
                 }
 
@@ -834,14 +802,14 @@ namespace GraphControl
         {
             if (auto renderer = m_graph->GetRenderer())
             {
-                shared_ptr<Graphing::IBitmap> BitmapOut;
+                std::shared_ptr<Graphing::IBitmap> BitmapOut;
                 bool hasSomeMissingDataOut = false;
                 HRESULT hr = E_FAIL;
                 hr = renderer->GetBitmap(BitmapOut, hasSomeMissingDataOut);
                 if (SUCCEEDED(hr))
                 {
                     // Get the raw data
-                    vector<BYTE> byteVector = BitmapOut->GetData();
+                    std::vector<BYTE> byteVector = BitmapOut->GetData();
                     auto arr = ArrayReference<BYTE>(byteVector.data(), (unsigned int)byteVector.size());
 
                     // create a memory stream wrapper
@@ -1085,13 +1053,13 @@ void Grapher::OnGraphBackgroundPropertyChanged(Windows::UI::Color /*oldValue*/, 
     }
 }
 
-void Grapher::OnGridLinesColorPropertyChanged(Windows::UI::Color /*oldValue*/, Windows::UI::Color newValue)
+winrt::fire_and_forget Grapher::OnGridLinesColorPropertyChanged(Windows::UI::Color /*oldValue*/, Windows::UI::Color newValue)
 {
     if (m_renderMain != nullptr && m_graph != nullptr)
     {
         auto gridLinesColor = Graphing::Color(newValue.R, newValue.G, newValue.B, newValue.A);
         m_graph->GetOptions().SetGridColor(gridLinesColor);
-        m_renderMain->RunRenderPassAsync();
+        co_await m_renderMain->RunRenderPassAsync();
     }
 }
 
@@ -1110,16 +1078,15 @@ void Grapher::OnLineWidthPropertyChanged(double oldValue, double newValue)
     }
 }
 
-optional<vector<shared_ptr<Graphing::IEquation>>> Grapher::TryInitializeGraph(bool keepCurrentView, const IExpression* graphingExp)
+std::optional<std::vector<std::shared_ptr<Graphing::IEquation>>> Grapher::TryInitializeGraph(bool keepCurrentView, const IExpression* graphingExp)
 {
-    critical_section::scoped_lock lock(m_renderMain->GetCriticalSection());
     if (keepCurrentView || IsKeepCurrentView)
     {
         auto renderer = m_graph->GetRenderer();
         double xMin, xMax, yMin, yMax;
         renderer->GetDisplayRanges(xMin, xMax, yMin, yMax);
         auto initResult = m_graph->TryInitialize(graphingExp);
-        if (initResult != nullopt)
+        if (initResult.has_value())
         {
             if (IsKeepCurrentView)
             {

--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -55,7 +55,7 @@ namespace
     // Translate the pointer position to the [-1, 1] bounds.
     __inline std::pair<double, double> PointerPositionToGraphPosition(double posX, double posY, double width, double height)
     {
-        return std::make_pair((2 * posX / width - 1), (1 - 2 * posY / height));
+        return { (2 * posX / width - 1), (1 - 2 * posY / height) };
     }
 }
 
@@ -381,7 +381,7 @@ namespace GraphControl
 
                 if (initResult.has_value())
                 {
-                    auto graphedEquations = *initResult;
+                    auto& graphedEquations = *initResult;
 
                     for (size_t i = 0; i < validEqs.size(); ++i)
                     {
@@ -573,8 +573,8 @@ namespace GraphControl
                     }
 
                     eq->GraphedEquation->GetGraphEquationOptions()->SetLineStyle(static_cast<::Graphing::Renderer::LineStyle>(eq->EquationStyle));
-                    eq->GraphedEquation->GetGraphEquationOptions()->SetLineWidth(LineWidth);
-                    eq->GraphedEquation->GetGraphEquationOptions()->SetSelectedEquationLineWidth(LineWidth + ((LineWidth <= 2) ? 1 : 2));
+                    eq->GraphedEquation->GetGraphEquationOptions()->SetLineWidth(static_cast<float>(LineWidth));
+                    eq->GraphedEquation->GetGraphEquationOptions()->SetSelectedEquationLineWidth(static_cast<float>(LineWidth + ((LineWidth <= 2) ? 1 : 2)));
                 }
             }
             options.SetGraphColors(graphColors);
@@ -1070,7 +1070,7 @@ void Grapher::OnLineWidthPropertyChanged(double oldValue, double newValue)
         UpdateGraphOptions(m_graph->GetOptions(), GetGraphableEquations());
         if (m_renderMain)
         {
-            m_renderMain->SetPointRadius(LineWidth + 1);
+            m_renderMain->SetPointRadius(static_cast<float>(LineWidth + 1));
             m_renderMain->RunRenderPass();
 
             TraceLogger::GetInstance()->LogLineWidthChanged();

--- a/src/GraphControl/Control/Grapher.h
+++ b/src/GraphControl/Control/Grapher.h
@@ -228,7 +228,6 @@ public enum class GraphViewChangedReason
                 {
                     if (auto render = m_graph->GetRenderer())
                     {
-                        Concurrency::critical_section::scoped_lock lock(m_renderMain->GetCriticalSection());
                         render->GetDisplayRanges(*xMin, *xMax, *yMin, *yMax);
                     }
                 }
@@ -280,7 +279,7 @@ public enum class GraphViewChangedReason
         void OnEquationsPropertyChanged(EquationCollection ^ oldValue, EquationCollection ^ newValue);
         void OnAxesColorPropertyChanged(Windows::UI::Color oldValue, Windows::UI::Color newValue);
         void OnGraphBackgroundPropertyChanged(Windows::UI::Color oldValue, Windows::UI::Color newValue);
-        void OnGridLinesColorPropertyChanged(Windows::UI::Color /*oldValue*/, Windows::UI::Color newValue);
+        winrt::fire_and_forget OnGridLinesColorPropertyChanged(Windows::UI::Color /*oldValue*/, Windows::UI::Color newValue);
         void OnLineWidthPropertyChanged(double oldValue, double newValue);
         void OnEquationChanged(Equation ^ equation);
         void OnEquationStyleChanged(Equation ^ equation);

--- a/src/GraphControl/DirectX/RenderMain.cpp
+++ b/src/GraphControl/DirectX/RenderMain.cpp
@@ -30,11 +30,10 @@ namespace
 namespace GraphControl::DX
 {
     RenderMain::RenderMain(SwapChainPanel ^ panel)
-        : m_deviceResources{ panel }
-        , m_nearestPointRenderer{ &m_deviceResources }
-        , m_backgroundColor{ {} }
-        , m_swapChainPanel{ panel }
-        , m_TraceLocation(Point(0, 0))
+        : m_deviceResources(panel)
+        , m_nearestPointRenderer(&m_deviceResources)
+        , m_swapChainPanel(panel)
+        , m_TraceLocation(Point{ 0, 0 })
         , m_Tracing(false)
     {
         // Register to be notified if the Device is lost or recreated
@@ -47,6 +46,7 @@ namespace GraphControl::DX
 
     RenderMain::~RenderMain()
     {
+        m_renderPassCts.cancel();
         UnregisterEventHandlers();
     }
 
@@ -212,8 +212,8 @@ namespace GraphControl::DX
         }
         m_renderPassCts = concurrency::cancellation_token_source{};
 
-        bool result = true;
-        co_await CoreWindow::GetForCurrentThread()->Dispatcher->RunAsync(
+        bool result = false;
+        co_await m_coreWindow->Dispatcher->RunAsync(
             CoreDispatcherPriority::High,
             ref new DispatchedHandler(
                 [this, &result, cancel = m_renderPassCts.get_token()]

--- a/src/GraphControl/DirectX/RenderMain.h
+++ b/src/GraphControl/DirectX/RenderMain.h
@@ -175,10 +175,6 @@ namespace GraphControl::DX
         Windows::Foundation::EventRegistrationToken m_tokenOrientationChanged;
         Windows::Foundation::EventRegistrationToken m_tokenDisplayContentsInvalidated;
 
-        // Track our independent input on a background worker thread.
-        Windows::Foundation::IAsyncAction ^ m_inputLoopWorker = nullptr;
-        Windows::UI::Core::CoreIndependentInputSource ^ m_coreInput = nullptr;
-
         double m_XTraceValue;
         double m_YTraceValue;
 

--- a/src/GraphControl/DirectX/RenderMain.h
+++ b/src/GraphControl/DirectX/RenderMain.h
@@ -184,7 +184,7 @@ namespace GraphControl::DX
         // Are we currently showing the tracing value
         bool m_Tracing;
 
-        concurrency::cancellation_token_source m_renderPassCts;
+        unsigned m_renderPassVer = 0;
 
         HRESULT m_HResult;
     };

--- a/src/GraphControl/DirectX/RenderMain.h
+++ b/src/GraphControl/DirectX/RenderMain.h
@@ -51,17 +51,7 @@ namespace GraphControl::DX
 
         bool RunRenderPass();
 
-        Windows::Foundation::IAsyncAction ^ RunRenderPassAsync(bool allowCancel = true);
-
-        Concurrency::critical_section& GetCriticalSection()
-        {
-            return m_criticalSection;
-        }
-
-        bool IsRenderPassSuccesful()
-        {
-            return m_isRenderPassSuccesful;
-        }
+        concurrency::task<bool> RunRenderPassAsync(bool allowCancel = true);
 
         HRESULT GetRenderError();
 
@@ -198,11 +188,7 @@ namespace GraphControl::DX
         // Are we currently showing the tracing value
         bool m_Tracing;
 
-        Concurrency::critical_section m_criticalSection;
-
-        Windows::Foundation::IAsyncAction ^ m_renderPass = nullptr;
-
-        bool m_isRenderPassSuccesful;
+        concurrency::cancellation_token_source m_renderPassCts;
 
         HRESULT m_HResult;
     };


### PR DESCRIPTION
## What
We've observed some app crash session happening around the graphing calculator. A high-repro-rate approach is launching Calculator twice to the Graphing mode. Tips: using the gflags tool to inspect pageheap can have almost 100% repro.

## Root cause
Graphing mode may render curves in two different threads. See more at `RenderMain::RunRenderPass()` and `RenderMain::RunRenderPassAsync()`. The former is always executed in the UI thread, while the latter is always going to run on a background thread. Such implementation introduces a complexity of managing inter-thread synchronization, and the current is codebase is not doing good on that.
A minimum fix is do not run render passes on different threads. It helps us get rid of the problem of race condition and data race. It also eliminates the needs of managing the *happens-before* relationship between the store/load operations over the same piece of memory on different threads, which cannot be achieve by simply locking a *critical section*.
It's hard to believe that this minimum could lead to a performance problem on rendering, because:
1. `RunRenderInternal()` is and must be an efficient function for it's the bottleneck of image presenting.
2. Render passes are mostly run synchronously in UI thread, in some cases they may run in a background thread. If we are not seeing any problems of rendering performance, we will not see any of them when doing the same work in UI thread asynchronously.
3. All the graphics are rendered on demand. There is not a stable FPS render running behind the scenes. Hence, if there's any defects in this fix, it won't be amplified.

## Changes
- Always run render passes on the same thread, i.e. the UI thread.
- Use `concurrency::task<bool>` as coroutine to return the result of `RunRenderPassInternal`.
- Remove the *critical_section* - `RenderMain::m_criticalSection`
- Removed some unused fields.
- Fix some wrong use of `IAsyncAction`
- Add `std::` back to *Grapher.cpp*.

