### PR TITLE
Fix #2146: SWIPE DELETE FUNCTION FREEZES APP

### DIFF
--- a/src/Calculator/Views/Calculator.xaml.cs
+++ b/src/Calculator/Views/Calculator.xaml.cs
@@ -189,7 +189,6 @@ namespace CalculatorApp
             }
         }
 
-
         public void UpdatePanelViewState()
         {
             UpdateHistoryState();
@@ -772,7 +771,10 @@ namespace CalculatorApp
 
         private void SetChildAsMemory()
         {
-            DockMemoryHolder.Child = GetMemory();
+            if (DockMemoryHolder.Child!= GetMemory())
+            {
+                DockMemoryHolder.Child = GetMemory();
+            }
         }
 
         private void SetChildAsHistory()
@@ -782,7 +784,10 @@ namespace CalculatorApp
                 InitializeHistoryView(Model.HistoryVM);
             }
 
-            DockHistoryHolder.Child = m_historyList;
+            if (DockHistoryHolder.Child != m_historyList)
+            {
+                DockHistoryHolder.Child = m_historyList;
+            }
         }
 
         private Memory GetMemory()

--- a/src/Calculator/Views/Calculator.xaml.cs
+++ b/src/Calculator/Views/Calculator.xaml.cs
@@ -771,7 +771,7 @@ namespace CalculatorApp
 
         private void SetChildAsMemory()
         {
-            if (DockMemoryHolder.Child!= GetMemory())
+            if (DockMemoryHolder.Child != GetMemory())
             {
                 DockMemoryHolder.Child = GetMemory();
             }


### PR DESCRIPTION
Fix #2146 

## Root cause
Stackoverflow when removing a history item by swiping.
`SetChildAsHistory()` has side effects even if the current panel is History already. PR #2116 added `UpdateHistoryState` into the callback of propertychanged, which forms a cycle of the implicit invocations trigged by databinding.

## Fix
Make sure `SetChildAsHistory()` has no side effects if there nothing to change.
Updated `SetChildAsMemory()` accordingly.