### PR TITLE
Fix: mini window size at the very first launch

### DIFF
--- a/src/Calculator/App.xaml.cs
+++ b/src/Calculator/App.xaml.cs
@@ -96,14 +96,17 @@ namespace CalculatorApp
             var minWindowWidth = Convert.ToSingle(Resources["AppMinWindowWidth"]);
             var minWindowHeight = Convert.ToSingle(Resources["AppMinWindowHeight"]);
             var minWindowSize = SizeHelper.FromDimensions(minWindowWidth, minWindowHeight);
+            var appView = ApplicationView.GetForCurrentView();
+            var localSettings = ApplicationData.Current.LocalSettings;
 
-            ApplicationView appView = ApplicationView.GetForCurrentView();
-            ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+            // SetPreferredMinSize should always be called before Window.Activate
+            appView.SetPreferredMinSize(minWindowSize);
+
             // For very first launch, set the size of the calc as size of the default standard mode
             if (!localSettings.Values.ContainsKey("VeryFirstLaunch"))
             {
                 localSettings.Values["VeryFirstLaunch"] = false;
-                appView.TryResizeView(minWindowSize);
+                appView.TryResizeView(minWindowSize); // the requested size must not be less than the min size.
             }
             else
             {
@@ -135,9 +138,6 @@ namespace CalculatorApp
                 // stack to debug
                 throw new SystemException("6d430286-eb5d-4f8d-95d2-3d1059552968");
             }
-
-            // SetPreferredMinSize should always be called before Window.Activate
-            appView.SetPreferredMinSize(minWindowSize);
 
             // Place the frame in the current Window
             Window.Current.Content = rootFrame;


### PR DESCRIPTION
## What
Fix a regression introduced by #2161.

## Root cause
Per [the document words](https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.applicationview.tryresizeview?view=winrt-22621), `ApplicationView.TryResizeView()` doesn't take effect if The requested size is less than the view's minimum size. (See [SetPreferredMinSize](https://learn.microsoft.com/en-us/uwp/api/windows.ui.viewmanagement.applicationview.setpreferredminsize?view=winrt-22621#windows-ui-viewmanagement-applicationview-setpreferredminsize(windows-foundation-size)).)
