### PR TITLE
Improve the "about equal to" for Data Converter 

### DIFF
--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -833,7 +833,7 @@ void UnitConverterDataLoader::GetConversionData(_In_ unordered_map<ViewMode, uno
                                                    { ViewMode::Data, UnitConverterUnits::Data_Yobibits, 151115727451828646.838272 },
                                                    { ViewMode::Data, UnitConverterUnits::Data_Yobibytes, 1208925819614629174.706176 },
                                                    { ViewMode::Data, UnitConverterUnits::Data_FloppyDisk, 1.474560 },
-                                                   { ViewMode::Data, UnitConverterUnits::Data_CD, 734.003200 },
+                                                   { ViewMode::Data, UnitConverterUnits::Data_CD, 700 },
                                                    { ViewMode::Data, UnitConverterUnits::Data_DVD, 4700 },
 
                                                    { ViewMode::Energy, UnitConverterUnits::Energy_Calorie, 4.184 },

--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -834,7 +834,7 @@ void UnitConverterDataLoader::GetConversionData(_In_ unordered_map<ViewMode, uno
                                                    { ViewMode::Data, UnitConverterUnits::Data_Yobibytes, 1208925819614629174.706176 },
                                                    { ViewMode::Data, UnitConverterUnits::Data_FloppyDisk, 1.474560 },
                                                    { ViewMode::Data, UnitConverterUnits::Data_CD, 734.003200 },
-                                                   { ViewMode::Data, UnitConverterUnits::Data_DVD, 5046.586573 },
+                                                   { ViewMode::Data, UnitConverterUnits::Data_DVD, 4700 },
 
                                                    { ViewMode::Energy, UnitConverterUnits::Energy_Calorie, 4.184 },
                                                    { ViewMode::Energy, UnitConverterUnits::Energy_Kilocalorie, 4184 },


### PR DESCRIPTION
## Fixes # Na

### Description of the changes:

As DVD size is 4700 megabytes. However, current converter's "about equal to" is only showing 0.93 DVDs when 4700 megabytes is entered.
![image](https://github.com/microsoft/calculator/assets/138377930/d85194fe-411c-4462-9e5b-42cd05453178)

Therefore, { ViewMode::Data, UnitConverterUnits::Data_DVD, 5046.586573 } is revised to { ViewMode::Data, UnitConverterUnits::Data_DVD, 4700 }, under UnitConverterDataLoader.cpp
![image](https://github.com/microsoft/calculator/assets/138377930/2d88128d-679a-4bd3-81b0-3fb3c3ff23b8)

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

Manual testing was done. 1 DVDs is shown when 4700 megabytes was entered.

