### PR TITLE
Fix exception when setting content to clipboard

### DIFF
--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -67,7 +67,7 @@ void CopyPasteManager::CopyToClipboard(String ^ stringToCopy)
     // Copy the string to the clipboard
     auto dataPackage = ref new DataPackage();
     dataPackage->SetText(stringToCopy);
-    Clipboard::SetContentWithOptions(dataPackage, ref new ClipboardContentOptions());
+    Clipboard::SetContentWithOptions(dataPackage, nullptr);
 }
 
 IAsyncOperation<String ^> ^ CopyPasteManager::GetStringToPaste(ViewMode mode, CategoryGroupType modeType, NumberBase programmerNumberBase, BitLength bitLengthType)

--- a/src/CalcViewModel/Common/CopyPasteManager.cpp
+++ b/src/CalcViewModel/Common/CopyPasteManager.cpp
@@ -67,7 +67,7 @@ void CopyPasteManager::CopyToClipboard(String ^ stringToCopy)
     // Copy the string to the clipboard
     auto dataPackage = ref new DataPackage();
     dataPackage->SetText(stringToCopy);
-    Clipboard::SetContent(dataPackage);
+    Clipboard::SetContentWithOptions(dataPackage, ref new ClipboardContentOptions());
 }
 
 IAsyncOperation<String ^> ^ CopyPasteManager::GetStringToPaste(ViewMode mode, CategoryGroupType modeType, NumberBase programmerNumberBase, BitLength bitLengthType)


### PR DESCRIPTION
## Fixes #.
35286216

### Description of the changes:
When setting content to clipboard, it may throw exception sometimes. Use SetContentWithOptions() instead of SetContent() to avoid exception. The default options allow the content to be eligible for clipboard history as well as to be synced to other devices, which is the same as SetContent().

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
Manually tested the copy/paste functionality.

