### PR TITLE
Use authentication with FC for localization pipeline

### DIFF
--- a/build/pipelines/azure-pipelines.loc.yaml
+++ b/build/pipelines/azure-pipelines.loc.yaml
@@ -54,7 +54,7 @@ jobs:
 
   - task: PublishPipelineArtifact@0
     displayName: Publish patch file as artifact
-    condition: eq(variables['hasChanges'], '1')
+    condition: and(eq(variables['hasChanges'], '1'), eq(variables['isMainBranch'], true))
     inputs:
       artifactName: Patch
       targetPath: $(Build.ArtifactStagingDirectory)

--- a/build/pipelines/azure-pipelines.loc.yaml
+++ b/build/pipelines/azure-pipelines.loc.yaml
@@ -5,8 +5,6 @@
 # resources to run.
 #
 
-# Expects a variable called LocServiceKey to contain the OAuth client secret for Touchdown.
-
 schedules:
 - cron: "0 5 * * *"
   displayName: Daily sync
@@ -20,6 +18,9 @@ pr: none
 
 name: $(BuildDefinitionName)_$(date:yyMM).$(date:dd)$(rev:rrr)
 
+variables:
+  isMainBranch: ${{ eq(variables['Build.SourceBranch'], 'refs/heads/main') }}
+
 jobs:
 - job: Localize
   pool:
@@ -29,16 +30,19 @@ jobs:
   steps:
   - checkout: self
     clean: true
-    
-  - task: MicrosoftTDBuild.tdbuild-task.tdbuild-task.TouchdownBuildTask@2
+
+  - task: MicrosoftTDBuild.tdbuild-task.tdbuild-task.TouchdownBuildTask@4
     displayName: Send resources to Touchdown Build
     inputs:
       teamId: 86
-      TDBuildServiceConnection: EE-TDBuild-Localization
+      authType: FederatedIdentity
+      FederatedIdentityServiceConnection: EE-TDBuild-Localization-FC
       isPreview: false
       relativePathRoot: src/Calculator/Resources/en-US/
       resourceFilePath: '*.resw'
       outputDirectoryRoot: src/Calculator/Resources/
+      ${{ if eq(variables['isMainBranch'], false) }}:
+        localizationTarget: false
 
   - script: |
       cd $(Build.SourcesDirectory)


### PR DESCRIPTION
### Description of the changes:
- Migrate TouchdownBuildTask to version 4 to use authentication
with Federated Credentials for localization pipeline
- Add a check to make sure that only changes from main branch
can trigger localization and create patch file

### How changes were validated:
Manually triggered the pipeline

