### PR TITLE
GitHub: Disable blank issue

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
Typically when a author reports a black issue, the managers have to label or change titles. Having them decide and make a proper title could be a good idea for the managers.