### PR TITLE
Fix alignment of number pad buttons

### DIFF
--- a/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerRadixOperators.xaml
@@ -727,7 +727,8 @@
                              Grid.Row="2"
                              Grid.RowSpan="4"
                              Grid.Column="1"
-                             Grid.ColumnSpan="3"
+                             Grid.ColumnSpan="4"
+                             ExtraColumns="1"
                              ButtonStyle="{StaticResource NumericButtonStyle18}"
                              CurrentRadixType="{x:Bind Model.CurrentRadixType, Mode=OneWay}"/>
         </Grid>

--- a/src/Calculator/Views/CalculatorScientificOperators.xaml
+++ b/src/Calculator/Views/CalculatorScientificOperators.xaml
@@ -1303,7 +1303,8 @@
                          Grid.Row="4"
                          Grid.RowSpan="4"
                          Grid.Column="1"
-                         Grid.ColumnSpan="3"
+                         Grid.ColumnSpan="4"
+                         ExtraColumns="1"
                          AutomationProperties.HeadingLevel="Level1"
                          AutomationProperties.Name="{utils:ResourceString Name=NumberPad/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name}"
                          ButtonStyle="{StaticResource NumericButtonStyle24}"/>

--- a/src/Calculator/Views/CalculatorStandardOperators.xaml
+++ b/src/Calculator/Views/CalculatorStandardOperators.xaml
@@ -329,7 +329,8 @@
                          Grid.Row="2"
                          Grid.RowSpan="4"
                          Grid.Column="2"
-                         Grid.ColumnSpan="3"
+                         Grid.ColumnSpan="4"
+                         ExtraColumns="1"
                          AutomationProperties.HeadingLevel="Level1"
                          AutomationProperties.Name="{utils:ResourceString Name=NumberPad/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name}"
                          ButtonStyle="{StaticResource NumericButtonStyle24}"/>

--- a/src/Calculator/Views/NumberPad.xaml.cs
+++ b/src/Calculator/Views/NumberPad.xaml.cs
@@ -1,5 +1,6 @@
 using CalculatorApp.ViewModel.Common;
 
+using System;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
@@ -28,6 +29,20 @@ namespace CalculatorApp
             Num8Button.Content = localizationSettings.GetDigitSymbolFromEnUsDigit('8');
             Num9Button.Content = localizationSettings.GetDigitSymbolFromEnUsDigit('9');
         }
+
+        // Extra empty columns to the right so that column widths are calculated consistently with the rest of the button panel.
+
+        public int ExtraColumns
+        {
+            get => (int)GetValue(ExtraColumnsProperty);
+            set => SetValue(ExtraColumnsProperty, value);
+        }
+
+        public static readonly DependencyProperty ExtraColumnsProperty =
+            DependencyProperty.Register(nameof(ExtraColumns), typeof(int), typeof(NumberPad), new PropertyMetadata(0, (sender, args) =>
+            {
+                ((NumberPad)sender).OnExtraColumnsPropertyChanged((int)args.OldValue, (int)args.NewValue);
+            }));
 
         public Windows.UI.Xaml.Style ButtonStyle
         {
@@ -63,6 +78,29 @@ namespace CalculatorApp
                     m_isErrorVisualState = value;
                     string newState = m_isErrorVisualState ? "ErrorLayout" : "NoErrorLayout";
                     VisualStateManager.GoToState(this, newState, false);
+                }
+            }
+        }
+
+        private void OnExtraColumnsPropertyChanged(int oldValue, int newValue)
+        {
+            if (newValue < 0)
+            {
+                throw new ArgumentException($"ExtraColumns of value {newValue} is smaller than 0.");
+            }
+            var columnDefinitions = Root.ColumnDefinitions;
+            if (newValue > oldValue)
+            {
+                for (int i = oldValue; i < newValue; ++i)
+                {
+                    columnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) });
+                }
+            }
+            else
+            {
+                for (int i = oldValue; i > newValue; --i)
+                {
+                    columnDefinitions.RemoveAt(columnDefinitions.Count - 1);
                 }
             }
         }


### PR DESCRIPTION
## Fixes another instance of #127

### Description of the changes
- Add `ExtraColumns` property to `NumberPad` control.
- Add an extra column to `NumberPad` control instances in standard, scientific and programmer button panels.

### Additional information

The `NumberPad` control is placed as sort of a "subgrid" within the button panels' grids, on a subset of columns. This causes slight differences in how the column widths are computed in the outer button panel and in the number pad control (see [`CGrid::DistributeStarSpace`](https://github.com/microsoft/microsoft-ui-xaml/blob/d74a0332cf0d5e58f12eddce1070fa7a79b4c2db/src/dxaml/xcp/core/core/elements/Grid.cpp#L894)). Adding extra empty columns to the right of the `NumberPad` so that it reaches the right side of the button panel fixes this inconsistency.

### How changes were validated
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->

Manual testing.
