### PR TITLE
Resolve an existing defect when restoring from snapshots

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.cpp
+++ b/src/CalcViewModel/StandardCalculatorViewModel.cpp
@@ -1839,6 +1839,10 @@ void CalculatorApp::ViewModel::StandardCalculatorViewModel::Snapshot::set(Calcul
             {
                 m_standardCalculatorManager.SendCommand(static_cast<Command>(cmd));
             }
+            if (snapshot->PrimaryDisplay->IsError)
+            {
+                SetPrimaryDisplay(snapshot->PrimaryDisplay->DisplayValue, true);
+            }
         }
     }
     else


### PR DESCRIPTION
## Verified test cases:
1. empty state.
1. `number`
1. `number` + `operator`
1. `number` + `operator` + `=`
1. error without expressions
1. error with expressions