### PR TITLE
Edit UnitConverterTestUnitTypeSwitching (Edit UnitConverterTest.cpp)

### DIFF
--- a/src/CalculatorUnitTests/UnitConverterTest.cpp
+++ b/src/CalculatorUnitTests/UnitConverterTest.cpp
@@ -347,13 +347,15 @@ namespace UnitConverterUnitTests
     // Test switching of unit types
     void UnitConverterTest::UnitConverterTestUnitTypeSwitching()
     {
-        // Enter 57 into the from field, then switch focus to the to field (making it the new from field)
-        s_unitConverter->SendCommand(Command::Five);
-        s_unitConverter->SendCommand(Command::Seven);
-        s_unitConverter->SwitchActive(wstring(L"57"));
-        // Now set unit conversion to go from kilograms to pounds
+        // Now set unit conversion to go from pounds to kilograms
         s_unitConverter->SetCurrentCategory(s_testWeight);
-        s_unitConverter->SetCurrentUnitTypes(s_testKilograms, s_testPounds);
+        s_unitConverter->SetCurrentUnitTypes(s_testPounds, s_testKilograms);
+        // Enter 5 into the from field, then switch focus to the to field (making it the new from field) (switch focus to kilograms)
+        s_unitConverter->SendCommand(Command::Five);
+        s_unitConverter->SwitchActive(wstring(L"2.26796"));
+        VERIFY_IS_TRUE(s_testVMCallback->CheckDisplayValues(wstring(L"5"), wstring(L"2.26796")));
+        VERIFY_IS_TRUE(s_testVMCallback->CheckSuggestedValues(vector<tuple<wstring, Unit>>()));
+        // Enter 5 again into the to field
         s_unitConverter->SendCommand(Command::Five);
         VERIFY_IS_TRUE(s_testVMCallback->CheckDisplayValues(wstring(L"5"), wstring(L"11.0231")));
         VERIFY_IS_TRUE(s_testVMCallback->CheckSuggestedValues(vector<tuple<wstring, Unit>>()));


### PR DESCRIPTION
The test has been improved in the code.

## Fixes #.
Edit UnitConverterTestUnitTypeSwitching in UnitConverterTest.cpp

### Description of the changes:
- Now UnitConverterTestUnitTypeSwitching checks for changes after the function of SwitchActive and fits a new value separately into the to field after the function of SwitchActive.
- When I tried to edit the SwitchActive function, I removed the swap of fromType and toType.

![2024-12-07_16-06-38](https://github.com/user-attachments/assets/576f7aa5-4aed-43ed-8b5b-fd065d4b9609)

And I ran all the tests. And only UnitConverterTestScientificInputs detected a value error when using the SwitchActive function.

![2024-12-07_13-03-36](https://github.com/user-attachments/assets/cf7a9009-8b15-470b-8692-73f939cc34ed)

Without changing the SwitchActive function code 
![Without changing](https://github.com/user-attachments/assets/efb21dc1-0743-4650-b6fa-f6c3f355e7dc)

With changes in the SwitchActive function code (deleting swap(m_fromType, m_toType);)
![With changes](https://github.com/user-attachments/assets/c363dcf0-4b5c-4a35-b24e-3f085ca3f5a3)

### How changes were validated:
- Previously, the test of the SwitchActive function worked before the specified category - Weight, now the SwitchActive function works after the specified category and changes in the field selection are taken into account.

