### PR TITLE
Bugfix: Division Bug in Programmer Dec Mode

### DIFF
--- a/src/CalcManager/Ratpack/support.cpp
+++ b/src/CalcManager/Ratpack/support.cpp
@@ -303,6 +303,12 @@ void intrat(_Inout_ PRAT* px, uint32_t radix, int32_t precision)
         DUPRAT(pret, *px);
         remrat(&pret, rat_one);
 
+        // Flatten pret in case it's not aligned with px after remrat operation
+        if (!equnum((*px)->pq, pret->pq))
+        {
+            flatrat(pret, radix, precision);
+        }
+
         subrat(px, pret, precision);
         destroyrat(pret);
 

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -752,6 +752,11 @@ namespace CalculatorManagerTest
 
         Command commands10[] = { Command::ModeProgrammer, Command::Command1, Command::CommandRORC, Command::CommandRORC, Command::CommandNULL };
         TestDriver::Test(L"-9,223,372,036,854,775,808", L"RoR(RoR(1))", commands10, true, false);
+
+        Command commands11[] = { Command::ModeProgrammer, Command::CommandDec, Command::Command4, Command::Command2, Command::Command9,   Command::Command4,
+                                Command::Command9,       Command::Command6,   Command::Command7, Command::Command2, Command::Command9,   Command::Command6,
+                                Command::CommandDIV,     Command::Command2,   Command::Command5, Command::Command5, Command::CommandEQU, Command::CommandNULL };
+        TestDriver::Test(L"16,843,009", L"4294967296 \x00F7 255=", commands11, true, false);
     }
 
     void CalculatorManagerTest::CalculatorManagerTestMemory()

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -757,6 +757,26 @@ namespace CalculatorManagerTest
                                 Command::Command9,       Command::Command6,   Command::Command7, Command::Command2, Command::Command9,   Command::Command6,
                                 Command::CommandDIV,     Command::Command2,   Command::Command5, Command::Command5, Command::CommandEQU, Command::CommandNULL };
         TestDriver::Test(L"16,843,009", L"4294967296 \x00F7 255=", commands11, true, false);
+
+        Command commands12[] = {
+            Command::ModeProgrammer, Command::CommandDec, Command::Command4, Command::Command2, Command::Command9,   Command::Command4,
+            Command::Command9,       Command::Command6,   Command::Command7, Command::Command3, Command::Command0,   Command::Command3,
+            Command::CommandDIV,     Command::Command2,   Command::Command5, Command::Command5, Command::CommandEQU, Command::CommandNULL
+        };
+        TestDriver::Test(L"16,843,009", L"4294967303 \x00F7 255=", commands12, true, false);
+
+        Command commands13[] = {
+            Command::ModeProgrammer, Command::CommandDec, Command::Command1, Command::Command0, Command::Command0, Command::Command0,
+            Command::Command0, Command::Command0, Command::Command0, Command::Command0, Command::Command0, Command::Command0, Command::CommandDIV,
+            Command::Command6, Command::Command4, Command::Command4, Command::Command8, Command::Command7, Command::CommandEQU, Command::CommandNULL
+        };
+        TestDriver::Test(L"15,507", L"1000000000 \x00F7 64487=", commands13, true, false);
+
+        Command commands14[] = { Command::ModeProgrammer, Command::CommandDec, Command::Command1,   Command::Command0,   Command::Command0,
+                                 Command::Command0,       Command::Command0,   Command::Command0,   Command::Command0,   Command::Command0,
+                                 Command::Command0,       Command::Command0,   Command::CommandDIV, Command::Command6,   Command::Command4,
+                                 Command::Command4,       Command::Command8,   Command::Command8,   Command::CommandEQU, Command::CommandNULL };
+        TestDriver::Test(L"15,506", L"1000000000 \x00F7 64488=", commands14, true, false);
     }
 
     void CalculatorManagerTest::CalculatorManagerTestMemory()


### PR DESCRIPTION
## Fixes #.
This PR fixes a division bug in the Programmer Dec mode. The bug is described in #1583, #1788, and #1993.

### Description of the changes:
- Added a check in the [_intrat_ function](https://github.com/ishuah/calculator/blob/224ccdf885b2f4a10722c9cb529a8a782727a7cb/src/CalcManager/Ratpack/support.cpp#L307) that ensures ***px** and **pret** have the same denominator.
- Added a [test case for this particular scenario](https://github.com/ishuah/calculator/blob/224ccdf885b2f4a10722c9cb529a8a782727a7cb/src/CalculatorUnitTests/CalculatorManagerTest.cpp#L756C9-L759C93).

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Added a test case for this scenario
- Ran the test suite locally

