### PR TITLE
Fixes issue #2326

### DIFF
--- a/src/CalcManager/CEngine/scicomm.cpp
+++ b/src/CalcManager/CEngine/scicomm.cpp
@@ -832,6 +832,40 @@ void CCalcEngine::ProcessCommandWorker(OpCode wParam)
         break;
 
     case IDC_PNT:
+
+        // Check if the last command was a closing parenthesis
+        if (m_nLastCom == IDC_CLOSEP)
+        {
+            // Treat this as an implicit multiplication
+            m_nOpCode = IDC_MUL;
+            m_lastVal = m_currentVal;
+
+            // We need to clear any previous state from last calculation
+            m_holdVal = Rational(0);
+            m_bNoPrevEqu = true;
+
+            // Add the operand to history before adding the implicit multiplication
+            if (!m_HistoryCollector.FOpndAddedToHistory())
+            {
+                m_HistoryCollector.AddOpenBraceToHistory();
+                m_HistoryCollector.AddOpndToHistory(m_numberString, m_currentVal);
+                m_HistoryCollector.AddCloseBraceToHistory();
+            }
+
+            // Add the implicit multiplication to history
+            m_HistoryCollector.AddBinOpToHistory(m_nOpCode, m_fIntegerMode);
+
+            m_bChangeOp = true;
+            m_nPrevOpCode = 0;
+
+            // Clear any pending operations in the precedence stack
+            while (m_precedenceOpCount > 0)
+            {
+                m_precedenceOpCount--;
+                m_nPrecOp[m_precedenceOpCount] = 0;
+            }
+        }
+
         if (m_bRecord && !m_fIntegerMode && m_input.TryAddDecimalPt())
         {
             DisplayNum();

--- a/src/CalculatorUITests/ScientificModeFunctionalTests.cs
+++ b/src/CalculatorUITests/ScientificModeFunctionalTests.cs
@@ -173,6 +173,40 @@ namespace CalculatorUITests
             var historyItems1 = page.HistoryPanel.GetAllHistoryListViewItems();
             Assert.IsTrue(historyItems1[0].GetValue().Equals("28", StringComparison.InvariantCultureIgnoreCase));
             Assert.IsTrue(historyItems1[0].GetExpression().Equals("(7 \x00D7 2) \x00D7 2=", StringComparison.InvariantCultureIgnoreCase));
+
+            /*
+             * TEST #3
+             */
+            page.ScientificOperators.ParenthesisLeftButton.Click();
+            page.StandardOperators.NumberPad.Input(8);
+            page.ScientificOperators.ParenthesisRightButton.Click();
+            page.StandardOperators.NumberPad.Input(0.5);
+            page.StandardOperators.EqualButton.Click();
+
+            // Assert calculator & history results
+            Assert.AreEqual("4", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("(8) \x00D7 0.5=", page.CalculatorResults.GetCalculatorExpressionText());
+
+            var historyItems2 = page.HistoryPanel.GetAllHistoryListViewItems();
+            Assert.IsTrue(historyItems2[0].GetValue().Equals("4", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems2[0].GetExpression().Equals("(8) \x00D7 0.5=", StringComparison.InvariantCultureIgnoreCase));
+
+            /*
+             * TEST #4
+             */
+            page.ScientificOperators.ParenthesisLeftButton.Click();
+            page.StandardOperators.NumberPad.Input(8);
+            page.ScientificOperators.ParenthesisRightButton.Click();
+            page.StandardOperators.NumberPad.Input(.5);
+            page.StandardOperators.EqualButton.Click();
+
+            // Assert calculator & history results
+            Assert.AreEqual("4", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("(8) \x00D7 0.5=", page.CalculatorResults.GetCalculatorExpressionText());
+
+            var historyItems3 = page.HistoryPanel.GetAllHistoryListViewItems();
+            Assert.IsTrue(historyItems3[0].GetValue().Equals("4", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems3[0].GetExpression().Equals("(8) \x00D7 0.5=", StringComparison.InvariantCultureIgnoreCase));
         }
 
         [TestMethod]

--- a/src/CalculatorUITests/ScientificModeFunctionalTests.cs
+++ b/src/CalculatorUITests/ScientificModeFunctionalTests.cs
@@ -4,6 +4,7 @@
 using CalculatorUITestFramework;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
 
 namespace CalculatorUITests
 {
@@ -131,6 +132,47 @@ namespace CalculatorUITests
             page.ScientificOperators.ParenthesisRightButton.Click();
             page.StandardOperators.EqualButton.Click();
             Assert.AreEqual("12", page.CalculatorResults.GetCalculatorResultText());
+        }
+
+        [TestMethod]
+        [Priority(0)]
+        public void SmokeTest_CloseParenthesis()
+        {
+            /*
+             * TEST #1
+             */
+            page.ScientificOperators.ParenthesisLeftButton.Click();
+            page.StandardOperators.NumberPad.Input(8);
+            page.ScientificOperators.ParenthesisRightButton.Click();
+            page.StandardOperators.NumberPad.Input(2);
+            page.StandardOperators.EqualButton.Click();
+
+            // Assert calculator & history results
+            Assert.AreEqual("16", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("(8) \x00D7 2=", page.CalculatorResults.GetCalculatorExpressionText());
+
+            var historyItems0 = page.HistoryPanel.GetAllHistoryListViewItems();
+            Assert.IsTrue(historyItems0[0].GetValue().Equals("16", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems0[0].GetExpression().Equals("(8) \x00D7 2=", StringComparison.InvariantCultureIgnoreCase));
+
+            /*
+             * TEST #2
+             */
+            page.ScientificOperators.ParenthesisLeftButton.Click();
+            page.StandardOperators.NumberPad.Input(7);
+            page.StandardOperators.MultiplyButton.Click();
+            page.StandardOperators.NumberPad.Input(2);
+            page.ScientificOperators.ParenthesisRightButton.Click();
+            page.StandardOperators.NumberPad.Input(2);
+            page.StandardOperators.EqualButton.Click();
+
+            // Assert calculator & history results
+            Assert.AreEqual("28", page.CalculatorResults.GetCalculatorResultText());
+            Assert.AreEqual("(7 \x00D7 2) \x00D7 2=", page.CalculatorResults.GetCalculatorExpressionText());
+
+            var historyItems1 = page.HistoryPanel.GetAllHistoryListViewItems();
+            Assert.IsTrue(historyItems1[0].GetValue().Equals("28", StringComparison.InvariantCultureIgnoreCase));
+            Assert.IsTrue(historyItems1[0].GetExpression().Equals("(7 \x00D7 2) \x00D7 2=", StringComparison.InvariantCultureIgnoreCase));
         }
 
         [TestMethod]

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -655,6 +655,14 @@ namespace CalculatorManagerTest
                                 Command::CommandCLOSEP, Command::Command2, Command::CommandEQU,
                                 Command::CommandOPENP, Command::Command1, Command::Command4, Command::CommandCLOSEP, Command::Command2, Command::CommandEQU, Command::CommandNULL};
         TestDriver::Test(L"28", L"(14) \x00D7 2=", commands8, true, true);
+
+        Command commands9[] = { Command::CommandOPENP, Command::Command8, Command::CommandCLOSEP,
+                                Command::Command0, Command::CommandPNT, Command::Command5, Command::CommandEQU, Command::CommandNULL };
+        TestDriver::Test(L"4", L"(8) \x00D7 0.5=", commands9, true, true);
+
+        Command commands10[] = { Command::CommandOPENP, Command::Command8, Command::CommandCLOSEP,
+                                 Command::CommandPNT, Command::Command5, Command::CommandEQU, Command::CommandNULL };
+        TestDriver::Test(L"4", L"(8) \x00D7 0.5=", commands10, true, true);
     }
 
     void CalculatorManagerTest::CalculatorManagerTestScientificError()

--- a/src/CalculatorUnitTests/CalculatorManagerTest.cpp
+++ b/src/CalculatorUnitTests/CalculatorManagerTest.cpp
@@ -643,6 +643,18 @@ namespace CalculatorManagerTest
         Command commands5[] = { Command::Command2,   Command::CommandOPENP, Command::Command2,   Command::CommandCLOSEP,
                                 Command::CommandADD, Command::CommandEQU,   Command::CommandNULL };
         TestDriver::Test(L"8", L"2 \x00D7 (2) + 4=", commands5, true, true);
+
+        Command commands6[] = { Command::CommandOPENP, Command::Command8, Command::CommandCLOSEP, Command::Command2, Command::CommandEQU, Command::CommandNULL };
+        TestDriver::Test(L"16", L"(8) \x00D7 2=", commands6, true, true);
+
+        Command commands7[] = { Command::CommandOPENP,  Command::Command7, Command::CommandMUL, Command::Command2,
+                                Command::CommandCLOSEP, Command::Command2, Command::CommandEQU, Command::CommandNULL };
+        TestDriver::Test(L"28", L"(7 \x00D7 2) \x00D7 2=", commands7, true, true);
+
+        Command commands8[] = { Command::CommandOPENP,  Command::Command7, Command::CommandMUL, Command::Command2,
+                                Command::CommandCLOSEP, Command::Command2, Command::CommandEQU,
+                                Command::CommandOPENP, Command::Command1, Command::Command4, Command::CommandCLOSEP, Command::Command2, Command::CommandEQU, Command::CommandNULL};
+        TestDriver::Test(L"28", L"(14) \x00D7 2=", commands8, true, true);
     }
 
     void CalculatorManagerTest::CalculatorManagerTestScientificError()


### PR DESCRIPTION
## Fixes issue #2326


### Description of the changes:
- In the `CCalcEngine::ProcessCommandWorker` method, added a condition so that `CheckAndAddLastBinOpToHistory()` is only triggered if the last command is **_not_** a closing parenthesis.  This addresses the issue where the calculator would prematurely insert a record into the "History" tab, when typing `)` followed by a number.
- Added an additional condition for closing parenthesis, to ultimately treat this implicitly as multiplication, and to maintain this behavior within calculator and history results.
- Minor update of the `IDC_EQU` case as well


### How changes were validated:
- Ran several manual tests, and verified that the calculator results and history results are displayed correctly
- Updated the existing `CalculatorManagerTest::CalculatorManagerTestScientificParenthesis()` unit test, to account for scenarios involving any numbers input **after** closing parenthesis.
- Added a new UI automation test called `SmokeTest_CloseParenthesis()`, to verify the UI behavior of my changes, and ensuring that the calculator and history results are displayed correctly.
- Ran all unit tests and UI tests - before and after code changes - to ensure that my solution did not introduce other defects in the process.

>- Unit test results **_before_** code changes:
![CalculatorUnitTestResults_BeforeCodeChange](https://github.com/user-attachments/assets/ae975d62-760c-4fbf-b23e-27dd0b3c8a89)

>- UI test results **_before_** code changes:
![CalculatorUITestResults_BeforeCodeChange](https://github.com/user-attachments/assets/c440bc08-b2c7-44cc-801e-fd3f6c9b16b3)

>- Unit test results **_after_** code changes:
![CalculatorUnitTestResults_AfterCodeChange](https://github.com/user-attachments/assets/f3ed4cba-9524-4519-814d-f2c4a2d18d01)

>- UI test results **_after_** code changes:
![CalculatorUITestResults_AfterCodeChange](https://github.com/user-attachments/assets/0e94c844-93a1-43ab-9836-011e3f4d558c)

## Sample testing steps (after code changes):

1.) Open the calculator app, and from the hamburger menu, select "Scientific".
2.) Input `(` `8` `)`.
![Issue1_Step2_AfterCodeChange](https://github.com/user-attachments/assets/990ca398-7cf2-4127-8a34-f6d55cede2e2)

3.) Input `2` (without any operator being specified, including the multiplication operator).  Observe how the calculator results are displayed as `(8) x 2`, and that there are no "History" tab results yet.
![Issue1_Step3_AfterCodeChange](https://github.com/user-attachments/assets/ad3c3116-8941-44fc-81cd-44f36efbc604)

4.) Click the `=` button.  Observe the calculator results are correctly displayed as `(8) x 2 = 16`, and that there is a "History" tab result of the same as well
![Issue1_Step4_AfterCodeChange](https://github.com/user-attachments/assets/3bbbee7c-8c92-44c2-bc3d-2984c4eb7050)

## Additional Details: 

- There are 5 existing UI tests that fail before & after my code changes.  Additionally, there are also a couple additional UI tests as well (called `Aot_EnterExitKeepOnTop` and `AoT_Tootip`) which fail intermittently before & after code changes, due to flakiness.  These tests have nothing to do with my changes.
- Though I originally discovered this issue by accident while looking into issue [#1678](https://github.com/microsoft/calculator/issues/1678), the solution in this ticket does **not** address that issue at all.  In other words, if you were to input `(8)2=` into the calculator, the output would be displayed with the operator (for example, as  `(8) x 2 =`).  I purposely did this to remain consistent with how the calculator displays results from other use cases today. 
- Regarding the new `SmokeTest_CloseParenthesis()` UI test that I added, I made this separate from the existing `SmokeTest_Parentheses()` test, as the latter seemed to be designed to actually input the `x` operator in the tests (which is different from the use cases described in issue [#2326](https://github.com/microsoft/calculator/issues/2326) and [#1498](https://github.com/microsoft/calculator/issues/1498), which do **not** input the `x` operator between parenthesis).  For this reason, I made `SmokeTest_CloseParenthesis()` a separate test, with a focus on the "CloseParenthesis" use cases for now.  
- **Note**: I also feel it could be valuable to have a separate `SmokeTest_OpenParenthesis()` test as well (with a focus on the "OpenParenthesis" use cases from [#1498](https://github.com/microsoft/calculator/issues/1498)), but chose not to perform that as part of this issue to avoid scope creep.  I would be happy to submit another issue and work on this separately, if desired.
- **Note**: For the sake of consistency, I named my separate UI test as `SmokeTest_CloseParenthesis` and set it as "Priority 0" for now.  However, I'm not fully familiar with how test priority or the testing strategy is structured, so please feel free to provide feedback if the priority and/or testing name should be updated, if it should be redesigned or consolidated with another test, etc.

