### PR TITLE
Comment out unused variable

### DIFF
--- a/src/GraphingImpl/Mocks/Graph.h
+++ b/src/GraphingImpl/Mocks/Graph.h
@@ -44,7 +44,7 @@ namespace MockGraphingImpl
             return m_variables;
         }
 
-        virtual void SetArgValue(std::wstring variableName, double /*value*/)
+        virtual void SetArgValue(std::wstring /*variableName*/, double /*value*/)
         {
         }
 


### PR DESCRIPTION
With the 17.14 release of Visual Studio 2022, I see the following error:
```
...\src\GraphingImpl\Mocks\Graph.h(47,47): warning C4100: 'variableName': unreferenced parameter [...\src\GraphingImpl\GraphingImpl.vcxproj
...
...\src\GraphingImpl\Mocks\Graph.h(47,47): error C2220: the following warning is treated as an error [...\src\GraphingImpl\GraphingImpl.vcxproj
```
Comment out the unused variable to resolve this.

## Fixes #.


### Description of the changes:
-
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

