### PR TITLE
Add astronomical units to length unit convert

### DIFF
--- a/src/CalcViewModel/DataLoaders/UnitConverterDataConstants.h
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataConstants.h
@@ -167,7 +167,10 @@ namespace CalculatorApp
             Energy_Kilowatthour = UnitStart + 166,
             Data_Nibble = UnitStart + 167,
             Length_Angstrom = UnitStart + 168,
-            UnitEnd = Length_Angstrom
+            Length_AstronomicalUnit = UnitStart + 169,
+            Length_LightYear = UnitStart + 170,
+            Length_Parsec = UnitStart + 171,
+            UnitEnd = Length_Parsec
         };
     }
 }

--- a/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/UnitConverterDataLoader.cpp
@@ -401,6 +401,12 @@ void UnitConverterDataLoader::GetUnits(_In_ unordered_map<ViewMode, vector<Order
 
     vector<OrderedUnit> lengthUnits;
     lengthUnits.push_back(OrderedUnit{
+        UnitConverterUnits::Length_AstronomicalUnit, GetLocalizedStringName(L"UnitName_AstronomicalUnit"), GetLocalizedStringName(L"UnitAbbreviation_AstronomicalUnit"), 16 });
+    lengthUnits.push_back(OrderedUnit{
+        UnitConverterUnits::Length_LightYear, GetLocalizedStringName(L"UnitName_LightYear"), GetLocalizedStringName(L"UnitAbbreviation_LightYear"), 17 });
+    lengthUnits.push_back(OrderedUnit{
+        UnitConverterUnits::Length_Parsec, GetLocalizedStringName(L"UnitName_Parsec"), GetLocalizedStringName(L"UnitAbbreviation_Parsec"), 18 });
+    lengthUnits.push_back(OrderedUnit{
         UnitConverterUnits::Length_Angstrom, GetLocalizedStringName(L"UnitName_Angstrom"), GetLocalizedStringName(L"UnitAbbreviation_Angstrom"), 1 });
     lengthUnits.push_back(OrderedUnit{ UnitConverterUnits::Length_Centimeter,
                                        GetLocalizedStringName(L"UnitName_Centimeter"),
@@ -858,6 +864,9 @@ void UnitConverterDataLoader::GetConversionData(_In_ unordered_map<ViewMode, uno
                                                    { ViewMode::Length, UnitConverterUnits::Length_Millimeter, 0.001 },
                                                    { ViewMode::Length, UnitConverterUnits::Length_Nanometer, 0.000000001 },
                                                    { ViewMode::Length, UnitConverterUnits::Length_Angstrom, 0.0000000001 },
+                                                   { ViewMode::Length, UnitConverterUnits::Length_AstronomicalUnit, 149597870700 },
+                                                   { ViewMode::Length, UnitConverterUnits::Length_LightYear, 9460730472580800 },
+                                                   { ViewMode::Length, UnitConverterUnits::Length_Parsec, 30856775814913672.789139379577965 },
                                                    { ViewMode::Length, UnitConverterUnits::Length_Centimeter, 0.01 },
                                                    { ViewMode::Length, UnitConverterUnits::Length_Meter, 1 },
                                                    { ViewMode::Length, UnitConverterUnits::Length_Kilometer, 1000 },

--- a/src/Calculator/Resources/af-ZA/Resources.resw
+++ b/src/Calculator/Resources/af-ZA/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,25 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Kon nie hierdie skermskoot teruglaai nie.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AE</value>
+    <comment>An abbreviation for a measurement unit of length</comment>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+    <comment>An abbreviation for a measurement unit of length</comment>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>Astronomiese eenheid</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ligjaar</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>lj</value>
   </data>
 </root>

--- a/src/Calculator/Resources/am-ET/Resources.resw
+++ b/src/Calculator/Resources/am-ET/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,25 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>ይህን ቅጽበታዊ ገጽ እይታ ወደነበረበት መመለስ አልተቻለም።</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AU</value>
+    <comment>An abbreviation for a measurement unit of length</comment>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>ፓ</value>
+    <comment>An abbreviation for a measurement unit of length</comment>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>የአስትሮኖሚያ አምድ</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>የብርሃን ዓመት</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>ፓርሴክ</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ዓ/ብ</value>
   </data>
 </root>

--- a/src/Calculator/Resources/ar-SA/Resources.resw
+++ b/src/Calculator/Resources/ar-SA/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>تعذرت استعادة هذه اللقطة.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>وَ.ف</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>فرسخ فلكي</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>وحدة فلكية</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>سنة ضوئية</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>فرسخ فلكي</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>س.ض</value>
   </data>
 </root>

--- a/src/Calculator/Resources/az-Latn-AZ/Resources.resw
+++ b/src/Calculator/Resources/az-Latn-AZ/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Bu ani görüntünü bərpa etmək mümkün olmadı.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AV</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>ps</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomik vahid</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>işıq ili</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsek</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>İİ</value>
   </data>
 </root>

--- a/src/Calculator/Resources/bg-BG/Resources.resw
+++ b/src/Calculator/Resources/bg-BG/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Неуспешно възстановяване на тази моментна снимка.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>АЕ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>пк</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>астрономическа единица</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>светлинна година</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>парсек</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>св.г</value>
   </data>
 </root>

--- a/src/Calculator/Resources/ca-ES/Resources.resw
+++ b/src/Calculator/Resources/ca-ES/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>No s'ha pogut restaurar aquesta instantània.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unitat astronòmica</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>any llum</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>al</value>
   </data>
 </root>

--- a/src/Calculator/Resources/cs-CZ/Resources.resw
+++ b/src/Calculator/Resources/cs-CZ/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Tento snímek se nepovedlo obnovit.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AJ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomická jednotka</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>světelný rok</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsek</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>sv. r.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/da-DK/Resources.resw
+++ b/src/Calculator/Resources/da-DK/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Kunne ikke gendanne dette snapshot.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AE</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>	astronomisk enhed</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>lysår</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ly</value>
   </data>
 </root>

--- a/src/Calculator/Resources/de-DE/Resources.resw
+++ b/src/Calculator/Resources/de-DE/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Diese Momentaufnahme konnte nicht wiederhergestellt werden.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AE</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomische Einheit</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>Lichtjahr</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>Parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>Lj</value>
   </data>
 </root>

--- a/src/Calculator/Resources/el-GR/Resources.resw
+++ b/src/Calculator/Resources/el-GR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Δεν ήταν δυνατή η επαναφορά του παρόντος στιγμιότυπου.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>ΑΜ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>παρσ</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>αστρονομική μονάδα</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>έτος φωτός</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>παράσεκ</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>έφ</value>
   </data>
 </root>

--- a/src/Calculator/Resources/en-GB/Resources.resw
+++ b/src/Calculator/Resources/en-GB/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Couldn't restore this snapshot.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AU</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>	Astronomical unit</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>light‑year</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ly</value>
   </data>
 </root>

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -4770,4 +4770,28 @@
     <value>Couldn't restore this snapshot.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
   </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AU</value>
+    <comment>An abbreviation for a measurement unit of length</comment>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+    <comment>An abbreviation for a measurement unit of length</comment>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>	Astronomical unit</value>
+    <comment>A unit of length, Approximately equals the average Earth-Sun distance.</comment>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>light-year</value>
+    <comment>A unit of length, equals the distance that light travels in vacuum in one Julian year.</comment>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+    <comment>A unit of length used to measure the large distances to astronomical objects outside the Solar System.</comment>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ly</value>
+    <comment>An abbreviation for a measurement unit of length</comment>
+  </data>
 </root>

--- a/src/Calculator/Resources/es-ES/Resources.resw
+++ b/src/Calculator/Resources/es-ES/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>No se pudo restaurar esta instantánea.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unidad astronómica</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>año luz</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>al</value>
   </data>
 </root>

--- a/src/Calculator/Resources/es-MX/Resources.resw
+++ b/src/Calculator/Resources/es-MX/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>No se pudo restaurar esta instantánea.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unidad astronómica</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>año luz</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/Calculator/Resources/et-EE/Resources.resw
+++ b/src/Calculator/Resources/et-EE/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Seda hetktõmmist ei saanud taastada.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>a.e.</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronoomiline ühik</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>valgusaasta</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>va</value>
   </data>
 </root>

--- a/src/Calculator/Resources/eu-ES/Resources.resw
+++ b/src/Calculator/Resources/eu-ES/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4198,5 +4198,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Ezin izan da leheneratu argazkia.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unitate astronomikoa</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>argi‑urte</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>a.l.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/fa-IR/Resources.resw
+++ b/src/Calculator/Resources/fa-IR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>این عکس فوری بازیابی نمی‌شود.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> وَ.ف</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>پ.س</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>واحد نجومی</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>سال نوری</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>پارسک</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>س.ن</value>
   </data>
 </root>

--- a/src/Calculator/Resources/fi-FI/Resources.resw
+++ b/src/Calculator/Resources/fi-FI/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Tätä tilannevedosta ei voitu palauttaa.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> AU</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronominen yksikkö</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>valovuosi</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsek</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>vv</value>
   </data>
 </root>

--- a/src/Calculator/Resources/fil-PH/Resources.resw
+++ b/src/Calculator/Resources/fil-PH/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Hindi maipanumbalik ang snapshot na ito.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AU</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomical unit</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>sinag‑taon</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ly</value>
   </data>
 </root>

--- a/src/Calculator/Resources/fr-CA/Resources.resw
+++ b/src/Calculator/Resources/fr-CA/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Désolé, nous ne pouvons pas restaurer cette capture instantanée.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unité astronomique</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>année‑lumière</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>a.l.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/fr-FR/Resources.resw
+++ b/src/Calculator/Resources/fr-FR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Impossible de restaurer cet instantané.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unité astronomique</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>année‑lumière</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>a.l.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/gl-ES/Resources.resw
+++ b/src/Calculator/Resources/gl-ES/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Non se puido restaurar esta instantánea.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unidade astronómica</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ano luz</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>al</value>
   </data>
 </root>

--- a/src/Calculator/Resources/he-IL/Resources.resw
+++ b/src/Calculator/Resources/he-IL/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>לא הצלחנו לשחזר צילום זה.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>י"א</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>פרסק</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>יחידת אסטרונומיה</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>שנת אור</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>פרסק</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ש"א</value>
   </data>
 </root>

--- a/src/Calculator/Resources/hi-IN/Resources.resw
+++ b/src/Calculator/Resources/hi-IN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>इस स्नैपशॉट को पुनर्स्थापित नहीं किया जा सका.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>ख.इ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>पा.</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>खगोलीय इकाई</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>प्रकाशवर्ष</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>पार्सेक</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>प्र.व</value>
   </data>
 </root>

--- a/src/Calculator/Resources/hr-HR/Resources.resw
+++ b/src/Calculator/Resources/hr-HR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Nije moguće vratiti ovu snimku stanja.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AJ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronom‑jedinica</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>svjetlosna godina</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsek</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>sg</value>
   </data>
 </root>

--- a/src/Calculator/Resources/hu-HU/Resources.resw
+++ b/src/Calculator/Resources/hu-HU/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Nem sikerült visszaállítani ezt a pillanatképet.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>CsE</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>psc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>csillagászati egység</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>fényév</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>fé</value>
   </data>
 </root>

--- a/src/Calculator/Resources/id-ID/Resources.resw
+++ b/src/Calculator/Resources/id-ID/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Tidak dapat memulihkan snapshot ini.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>SA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>satuan astronomi</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>tahun cahaya</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>tc</value>
   </data>
 </root>

--- a/src/Calculator/Resources/is-IS/Resources.resw
+++ b/src/Calculator/Resources/is-IS/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Ekki tókst að endurheimta þessa skyndimynd.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>SO</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>stjarnfræðileg eining</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ljósár</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ljósár</value>
   </data>
 </root>

--- a/src/Calculator/Resources/it-IT/Resources.resw
+++ b/src/Calculator/Resources/it-IT/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Non è possibile ripristinare questo snapshot.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unità astronomica</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>anno luce</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>a.l.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/ja-JP/Resources.resw
+++ b/src/Calculator/Resources/ja-JP/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>このスナップショットを復元できませんでした。</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>天文単位</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>パーセク</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>天文単位</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>光年</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>パーセク</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>光年</value>
   </data>
 </root>

--- a/src/Calculator/Resources/kk-KZ/Resources.resw
+++ b/src/Calculator/Resources/kk-KZ/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Бұл есеп суретін қалпына келтіру мүмкін болмады.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> а.б</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>пк</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>	астрономиялық бірлік</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>жарық жылы</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>парсек</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ж.ж</value>
   </data>
 </root>

--- a/src/Calculator/Resources/km-KH/Resources.resw
+++ b/src/Calculator/Resources/km-KH/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>មិនអាចស្ដាររូបថតរហ័សនេះ​ឡើងវិញបានទេ។</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>ឯក.អាស្ត្រ.</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>បា.សេក</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>ឯកតាអាស្ត្រូណូមិច</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ពេលអ៊ឺរូបភ្លឺ</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/Calculator/Resources/kn-IN/Resources.resw
+++ b/src/Calculator/Resources/kn-IN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>ಈ ಸ್ನ್ಯಾಪ್‌ಶಾಟ್ ಅನ್ನು ಪುನಃಸ್ಥಾಪಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>ಖಒ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value> ಪಾ.</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>ಖಗೋಳೀಯ ಒಗ್ಗಟ್ಟು</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ಜ್ಯೋತಿರ್ವರ್ಷ</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>ಪಾರ್ಸೆಕ್</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ಜ್.ವ</value>
   </data>
 </root>

--- a/src/Calculator/Resources/ko-KR/Resources.resw
+++ b/src/Calculator/Resources/ko-KR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>이 스냅샷을 복원할 수 없습니다.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>천문단위</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>파섹</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>천문단위</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>광년</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>파섹</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>광년</value>
   </data>
 </root>

--- a/src/Calculator/Resources/lo-LA/Resources.resw
+++ b/src/Calculator/Resources/lo-LA/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>ພວກເຮົາບໍ່ສາມາດກູ້ສະແນັບຊັອດນີ້ໄດ້.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> ຫ.ດ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>ພາ.ເຊັກ</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>	ຫນ່ວຍດາວທຽມ</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ປີແສງ</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ປປ</value>
   </data>
 </root>

--- a/src/Calculator/Resources/lt-LT/Resources.resw
+++ b/src/Calculator/Resources/lt-LT/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Mums nepavyko atkurti šios momentinės kopijos.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> AV</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>ps</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronominis vienetas</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>šviesmėtis</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsekas</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>šm</value>
   </data>
 </root>

--- a/src/Calculator/Resources/lv-LV/Resources.resw
+++ b/src/Calculator/Resources/lv-LV/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Nevarēja atjaunot šo momentuzņēmumu.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> AV</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>ps</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomiskā vienība</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>gaismas gads</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parseks</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/Calculator/Resources/mk-MK/Resources.resw
+++ b/src/Calculator/Resources/mk-MK/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Блиц-извештајот не може да се обнови.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>АЕ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value> пс</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>	астрономска единица</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>светлосна година</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>парсек</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>св.г</value>
   </data>
 </root>

--- a/src/Calculator/Resources/ml-IN/Resources.resw
+++ b/src/Calculator/Resources/ml-IN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>ഈ സ്നാപ്പ്ഷോട്ട് പുനഃസ്ഥാപിക്കാനായില്ല.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>എ.യു</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value> പാ.</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>ആകാശമSkipping</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>പ്രകാശവർഷം</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>പ്ര.വ</value>
   </data>
 </root>

--- a/src/Calculator/Resources/ms-MY/Resources.resw
+++ b/src/Calculator/Resources/ms-MY/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Tidak dapat memulihkan petikan ini.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AU</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unit astronomi</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>tahun cahaya</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>th.c</value>
   </data>
 </root>

--- a/src/Calculator/Resources/nb-NO/Resources.resw
+++ b/src/Calculator/Resources/nb-NO/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Kan ikke gjenopprette dette øyeblikksbildet.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AE</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomisk enhet</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>lysår</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsek</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>lysår</value>
   </data>
 </root>

--- a/src/Calculator/Resources/nl-NL/Resources.resw
+++ b/src/Calculator/Resources/nl-NL/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Kan deze momentopname niet herstellen.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> AE</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomische eenheid</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>lichtjaar</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>lj</value>
   </data>
 </root>

--- a/src/Calculator/Resources/pl-PL/Resources.resw
+++ b/src/Calculator/Resources/pl-PL/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Nie można przywrócić tej migawki.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> j.a.</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>jednostka astronomiczna</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>rok świetlny</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsek</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>lś</value>
   </data>
 </root>

--- a/src/Calculator/Resources/pt-BR/Resources.resw
+++ b/src/Calculator/Resources/pt-BR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Não foi possível restaurar este instantâneo.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unidade astronômica</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ano‑luz</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>al</value>
   </data>
 </root>

--- a/src/Calculator/Resources/pt-PT/Resources.resw
+++ b/src/Calculator/Resources/pt-PT/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Não foi possível restaurar este instantâneo.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>unidade astronómica</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ano‑luz</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>al</value>
   </data>
 </root>

--- a/src/Calculator/Resources/ro-RO/Resources.resw
+++ b/src/Calculator/Resources/ro-RO/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Nu s-a putut restaura acest instantaneu.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>UA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>	unitate astronomică</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>an‑lumină</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>a.l.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/ru-RU/Resources.resw
+++ b/src/Calculator/Resources/ru-RU/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Не удалось восстановить этот моментальный снимок.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>а.е.</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value> пк</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>астрономическая единица</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>световой год</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>парсек</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>св.г</value>
   </data>
 </root>

--- a/src/Calculator/Resources/sk-SK/Resources.resw
+++ b/src/Calculator/Resources/sk-SK/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Túto snímku sa nepodarilo obnoviť.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> AJ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomická jednotka</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>svetelný rok</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>sv. r.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/sl-SI/Resources.resw
+++ b/src/Calculator/Resources/sl-SI/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Tega posnetka ni bilo mogoče obnoviti.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> AE</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomska enota</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>svetlobno leto</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value />
   </data>
 </root>

--- a/src/Calculator/Resources/sq-AL/Resources.resw
+++ b/src/Calculator/Resources/sq-AL/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Nuk mund të rikthejmë këtë fotografi.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>NJA</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>ps</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>njësi astronomike</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>dritëviti</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>v.d.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/sr-Latn-RS/Resources.resw
+++ b/src/Calculator/Resources/sr-Latn-RS/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Nije moguće vratiti ovaj snimak u prethodno stanje.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AJ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomijska jedinica</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>svetlosna godina</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsek</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>sg</value>
   </data>
 </root>

--- a/src/Calculator/Resources/sv-SE/Resources.resw
+++ b/src/Calculator/Resources/sv-SE/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Det gick inte att återställa den här ögonblicksbilden.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> AE</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomisk enhet	</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ljusår</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ljusår</value>
   </data>
 </root>

--- a/src/Calculator/Resources/ta-IN/Resources.resw
+++ b/src/Calculator/Resources/ta-IN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4198,5 +4198,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>இந்த நொடிப்புச்சேமிப்பை மீட்டெடுக்க முடியவில்லை.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value> வி.அ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>பா.</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>விண்மீனியல் அலகு</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ஒளியாண்டு (oḷiyāṇṭu)</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>பர்செக்</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ஒ.ஆ</value>
   </data>
 </root>

--- a/src/Calculator/Resources/te-IN/Resources.resw
+++ b/src/Calculator/Resources/te-IN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>ఈ స్నాప్‌షాట్‌ని పునరుద్ధరించడం సాధ్యపడలేదు.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>ఖ.ఐ</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value> పా.</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>ఖగోళశాస్త్రమ ఏకకం</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>కాంతిసంవత్సరము</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>పార్సెక్</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>కా.సం</value>
   </data>
 </root>

--- a/src/Calculator/Resources/th-TH/Resources.resw
+++ b/src/Calculator/Resources/th-TH/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>ไม่สามารถคืนค่าสแนปช็อตนี้ได้</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>หน.ดา</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>พาร์เซก</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>	หน่วยดาราศาสตร์</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ปีแสง</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>พาร์เซก</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ปีแสง</value>
   </data>
 </root>

--- a/src/Calculator/Resources/tr-TR/Resources.resw
+++ b/src/Calculator/Resources/tr-TR/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Bu anlık görüntü geri yüklenemedi.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AB</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value> ps</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>astronomik birim</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>ışık yılı</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsek</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>i.y.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/uk-UA/Resources.resw
+++ b/src/Calculator/Resources/uk-UA/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Не вдалося відновити цей знімок.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>а.о.</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value> пс</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>астрономічна одиниця</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>світловий рік</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>парсек</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>с.р.</value>
   </data>
 </root>

--- a/src/Calculator/Resources/vi-VN/Resources.resw
+++ b/src/Calculator/Resources/vi-VN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>Không thể khôi phục ảnh chụp nhanh này.</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>ĐVTV</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>đơn vị thiên văn</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>năm ánh sáng</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>parsec</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>nă.l</value>
   </data>
 </root>

--- a/src/Calculator/Resources/zh-CN/Resources.resw
+++ b/src/Calculator/Resources/zh-CN/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,26 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>无法还原此快照。</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AU</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>秒差距</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>天文单位</value>
+    <comment>长度单位，近似等于地球与太阳的平均距离。</comment>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>光年</value>
+    <comment>长度单位，等于光在真空中传播一儒略年的距离。</comment>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>秒差距</value>
+    <comment>长度单位，用于测量太阳系外天文物体的大距离。</comment>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>光年</value>
   </data>
 </root>

--- a/src/Calculator/Resources/zh-TW/Resources.resw
+++ b/src/Calculator/Resources/zh-TW/Resources.resw
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -4197,5 +4197,23 @@
   <data name="SnapshotRestoreError" xml:space="preserve">
     <value>無法還原此快照。</value>
     <comment>The error message to notify user that restoring from snapshot has failed.</comment>
+  </data>
+  <data name="UnitAbbreviation_AstronomicalUnit" xml:space="preserve">
+    <value>AU</value>
+  </data>
+  <data name="UnitAbbreviation_Parsec" xml:space="preserve">
+    <value>pc</value>
+  </data>
+  <data name="UnitName_AstronomicalUnit" xml:space="preserve">
+    <value>天文單位</value>
+  </data>
+  <data name="UnitName_LightYear" xml:space="preserve">
+    <value>光年</value>
+  </data>
+  <data name="UnitName_Parsec" xml:space="preserve">
+    <value>秒差距</value>
+  </data>
+  <data name="UnitAbbreviation_LightYear" xml:space="preserve">
+    <value>ly</value>
   </data>
 </root>

--- a/src/CalculatorUnitTests/Test.resw
+++ b/src/CalculatorUnitTests/Test.resw
@@ -327,6 +327,15 @@
     <data name="Meters-Angstroms">
         <value>0.0000000001</value>
     </data>
+    <data name="Meters-LightYears">
+        <value>9460730472580800</value>
+    </data>
+    <data name="Meters-AstronomicalUnits">
+        <value>149597870700</value>
+    </data>
+    <data name="AstronomicalUnits-Parsecs">
+        <value>206264.80624709635515647335733078</value>
+    </data>
     <data name="Meters-Centimeters">
         <value>0.01</value>
     </data>


### PR DESCRIPTION
### Description of the changes:
-Add Light year (ly) and Astronomical unit (AU) and Parsec (pc) to length unit convert, with all language localizations generated by ChatGPT. 1ly = 9460730472580800 m, 1AU=149597870700 m. 1pc = 648000/π AU. #2359 

### How changes were validated:
Run tests. If you like, check ISO standard defintion about these units.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Manual test, validate au/pc/ly to meters converted value.
- Add test case to src\CalculatorUnitTests\Test.resw, and run tests.

