### PR TITLE
Changed the use of FrameworkElement.Tag to RadixButton.Label

### DIFF
--- a/src/Calculator/Controls/RadixButton.cs
+++ b/src/Calculator/Controls/RadixButton.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using CalculatorApp.ViewModel.Common;
+using Windows.UI.Xaml;
 
 namespace CalculatorApp
 {
@@ -17,6 +18,15 @@ namespace CalculatorApp
                 string radixContent = Content?.ToString();
                 return LocalizationSettings.GetInstance().RemoveGroupSeparators(radixContent);
             }
+
+            public string Label
+            {
+                get => (string)GetValue(LabelProperty);
+                set => SetValue(LabelProperty, value);
+            }
+
+            public static readonly DependencyProperty LabelProperty =
+                DependencyProperty.Register(nameof(Label), typeof(string), typeof(RadixButton), new PropertyMetadata(default(string)));
         }
     }
 }

--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -145,19 +145,19 @@
     <value>AppUpdate2</value>
     <comment>{Locked}This will Update Resources.pri File, Resource is not used in the app</comment>
   </data>
-  <data name="decimalButton.Tag" xml:space="preserve">
+  <data name="decimalButton.Label" xml:space="preserve">
     <value>DEC</value>
     <comment>{Locked}The Decimal button</comment>
   </data>
-  <data name="binaryButton.Tag" xml:space="preserve">
+  <data name="binaryButton.Label" xml:space="preserve">
     <value>BIN</value>
     <comment>{Locked}The Binary button</comment>
   </data>
-  <data name="hexButton.Tag" xml:space="preserve">
+  <data name="hexButton.Label" xml:space="preserve">
     <value>HEX</value>
     <comment>{Locked}The Hex button</comment>
   </data>
-  <data name="octButton.Tag" xml:space="preserve">
+  <data name="octButton.Label" xml:space="preserve">
     <value>OCT</value>
     <comment>{Locked}The Oct button</comment>
   </data>

--- a/src/Calculator/Views/CalculatorProgrammerOperators.xaml
+++ b/src/Calculator/Views/CalculatorProgrammerOperators.xaml
@@ -17,7 +17,7 @@
 
     <UserControl.Resources>
         <!-- Programmer mode display radio button -->
-        <Style x:Key="ProgModeRadioButtonStyle" TargetType="RadioButton">
+        <Style x:Key="ProgModeRadioButtonStyle" TargetType="controls:RadixButton">
             <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}"/>
             <Setter Property="MinHeight" Value="12"/>
             <Setter Property="MinWidth" Value="280"/>
@@ -32,7 +32,7 @@
             <Setter Property="FocusVisualMargin" Value="-3"/>
             <Setter Property="Template">
                 <Setter.Value>
-                    <ControlTemplate TargetType="RadioButton">
+                    <ControlTemplate TargetType="controls:RadixButton">
                         <Grid x:Name="ControlRoot"
                               VerticalAlignment="Stretch"
                               Background="{ThemeResource SubtleFillColorTransparentBrush}"
@@ -106,7 +106,7 @@
                                            FontWeight="{TemplateBinding FontWeight}"
                                            AutomationProperties.AccessibilityView="Raw"
                                            IsTextScaleFactorEnabled="{TemplateBinding IsTextScaleFactorEnabled}"
-                                           Text="{TemplateBinding Tag}"/>
+                                           Text="{TemplateBinding Label}"/>
                             </Grid>
                             <Grid x:Name="CheckedStatesGrid"
                                   Background="{ThemeResource SystemControlHighlightTransparentBrush}"
@@ -149,7 +149,7 @@
                                            FontWeight="{TemplateBinding FontWeight}"
                                            AutomationProperties.AccessibilityView="Raw"
                                            IsTextScaleFactorEnabled="{TemplateBinding IsTextScaleFactorEnabled}"
-                                           Text="{TemplateBinding Tag}"/>
+                                           Text="{TemplateBinding Label}"/>
                             </Grid>
                         </Grid>
                     </ControlTemplate>
@@ -158,10 +158,10 @@
         </Style>
         <contract7NotPresent:Style x:Key="ConditionalProgModeRadioButtonStyle"
                                    BasedOn="{StaticResource ProgModeRadioButtonStyle}"
-                                   TargetType="RadioButton"/>
+                                   TargetType="controls:RadixButton"/>
         <contract7Present:Style x:Key="ConditionalProgModeRadioButtonStyle"
                                 BasedOn="{StaticResource ProgModeRadioButtonStyle}"
-                                TargetType="RadioButton">
+                                TargetType="controls:RadixButton">
             <Setter Property="CornerRadius" Value="{ThemeResource ControlCornerRadius}"/>
         </contract7Present:Style>
 
@@ -214,7 +214,7 @@
                               Content="{x:Bind Model.HexDisplayValue, Mode=OneWay}"
                               ContextFlyout="{StaticResource ProgrammerOperatorsContextMenu}"
                               GroupName="BaseConversion"
-                              Tag="{utils:ResourceString Name=hexButton/Tag}"/>
+                              Label="{utils:ResourceString Name=hexButton/Label}"/>
         <controls:RadixButton x:Name="DecimalButton"
                               Grid.Row="1"
                               HorizontalAlignment="Stretch"
@@ -227,7 +227,7 @@
                               ContextFlyout="{StaticResource ProgrammerOperatorsContextMenu}"
                               GroupName="BaseConversion"
                               IsChecked="true"
-                              Tag="{utils:ResourceString Name=decimalButton/Tag}"/>
+                              Label="{utils:ResourceString Name=decimalButton/Label}"/>
         <controls:RadixButton x:Name="OctButton"
                               Grid.Row="2"
                               HorizontalAlignment="Stretch"
@@ -239,7 +239,7 @@
                               Content="{x:Bind Model.OctalDisplayValue, Mode=OneWay}"
                               ContextFlyout="{StaticResource ProgrammerOperatorsContextMenu}"
                               GroupName="BaseConversion"
-                              Tag="{utils:ResourceString Name=octButton/Tag}"/>
+                              Label="{utils:ResourceString Name=octButton/Label}"/>
         <controls:RadixButton x:Name="BinaryButton"
                               Grid.Row="3"
                               HorizontalAlignment="Stretch"
@@ -251,6 +251,6 @@
                               Content="{x:Bind Model.BinaryDisplayValue, Mode=OneWay}"
                               ContextFlyout="{StaticResource ProgrammerOperatorsContextMenu}"
                               GroupName="BaseConversion"
-                              Tag="{utils:ResourceString Name=binaryButton/Tag}"/>
+                              Label="{utils:ResourceString Name=binaryButton/Label}"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
## Fixes ##
- It was recommended to use internal logic instead of Tag usage for codebase quality:
- https://github.com/microsoft/calculator/issues/56
- This pull request is aimed to help with that.

### Description of the changes:
- Added a Dependency property to RadixButton.cs that is called Label. I chose the name of the variable based on the Radix button style used in CalculatorProgrammerOperators.xaml. TextBlock x:Name="LabelPresenter" was used in there to display the label text.
- Changed en-US/Resources.resw file to keep the variable names aligned, from "Tag" to "Label".
- Changed "CalculatorProgrammerOperators.xaml" file to use new Label variable and new resource string. I believe it was necessary to change "TargetType" of "ProgModeRadioButtonStyle" and the templates inside to be able to use Label variable.

Note: I honestly am not sure if changing "TargetType="RadioButton"" to TargetType="controls:RadixButton" is completely correct. It works when compiled, and i didn't see any problems. Since RadixButton is inherited from RadioButton and this style was only used for RadixButtons, this change should also be fine.

### How changes were validated:

- The number of changes were limited, so i only validated the changes by hand. I tried compiling the Calculator with each change seperately and observed the changes.

### Lastly
- The issue suggests the fix for other places for the use of FrameworkElement.Tag . Since this is my first pull request i wanted to know if I'm on the right path. I'll try to find a solution for the other ones too.