### PR TITLE
Cherry-pick: Fix the broken always-on-top mode

### DIFF
--- a/src/Calculator.ManagedViewModels/ApplicationViewModel.cs
+++ b/src/Calculator.ManagedViewModels/ApplicationViewModel.cs
@@ -196,7 +196,7 @@ namespace CalculatorApp.ManagedViewModels
             }
         }
 
-        public async Task ToggleAlwaysOnTop(float width, float height)
+        public async Task ToggleAlwaysOnTop(double width, double height)
         {
             var DefaultSize = new Size(320, 394);
             const string LaunchedSettingsKey = "calculatorAlwaysOnTopLaunched";
@@ -223,7 +223,7 @@ namespace CalculatorApp.ManagedViewModels
                     if (settings.Values.TryGetValue(WidthLocalSettingsKey, out var oldWidth) &&
                         settings.Values.TryGetValue(HeightLocalSettingsKey, out var oldHeight))
                     {
-                        compactOptions.CustomSize = new Size((float)oldWidth, (float)oldHeight);
+                        compactOptions.CustomSize = new Size((double)oldWidth, (double)oldHeight);
                     }
                     else
                     {

--- a/src/Calculator/Views/MainPage.xaml.cs
+++ b/src/Calculator/Views/MainPage.xaml.cs
@@ -440,7 +440,7 @@ namespace CalculatorApp
         private void TitleBarAlwaysOnTopButtonClick(object sender, RoutedEventArgs e)
         {
             var bounds = Window.Current.Bounds;
-            Model.ToggleAlwaysOnTop((float)bounds.Width, (float)bounds.Height);
+            Model.ToggleAlwaysOnTop(bounds.Width, bounds.Height);
         }
 
         private void ShowHideControls(ViewMode mode)


### PR DESCRIPTION
> ## Root cause
>
> The types for width and height saved in local settings is not matched universally for all the reads and writes. This leads to a type casting failure which blocks the logics to toggle the AOT mode.
>
> ## Fix
>
> Change the signature of function `ToggleAlwaysOnTop` from `Task (float, float)` to `Task (double, double)`
