### PR TITLE
Fix azure pipeline

### DIFF
--- a/build/pipelines/templates/build-single-architecture.yaml
+++ b/build/pipelines/templates/build-single-architecture.yaml
@@ -49,7 +49,7 @@ jobs:
         downloadDirectory: $(Build.SourcesDirectory)
         vstsFeed: WindowsInboxApps
         vstsFeedPackage: calculator-internals
-        vstsPackageVersion: 0.0.120
+        vstsPackageVersion: 0.0.122
 
   - task: NuGetToolInstaller@1
     displayName: Use NuGet 6.x

--- a/build/pipelines/templates/package-msixbundle.yaml
+++ b/build/pipelines/templates/package-msixbundle.yaml
@@ -1,5 +1,5 @@
 # This template contains a job which takes .msix packages which were built separately for each
-# architecture (arm, x86, etc.) and combines them into a single .msixbundle. In release builds,
+# architecture (arm64, x86, etc.) and combines them into a single .msixbundle. In release builds,
 # this job also signs the bundle and creates StoreBroker packages.
 
 parameters:
@@ -11,14 +11,12 @@ jobs:
   dependsOn:
     - Buildx64
     - Buildx86
-    - BuildARM
     - BuildARM64
   condition: |
     and
     (
       in(dependencies.Buildx64.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
       in(dependencies.Buildx86.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
-      in(dependencies.BuildARM.result, 'Succeeded', 'SucceededWithIssues', 'Skipped'),
       in(dependencies.BuildARM64.result, 'Succeeded', 'SucceededWithIssues', 'Skipped')
     )
   variables:
@@ -27,7 +25,6 @@ jobs:
     StoreBrokerPackagePath: $(Build.ArtifactStagingDirectory)\storeBrokerPayload
     PackageX86: $[in(dependencies.Buildx86.result, 'Succeeded', 'SucceededWithIssues')]
     PackageX64: $[in(dependencies.Buildx64.result, 'Succeeded', 'SucceededWithIssues')]
-    PackageARM: $[in(dependencies.BuildARM.result, 'Succeeded', 'SucceededWithIssues')]
     PackageARM64: $[in(dependencies.BuildARM64.result, 'Succeeded', 'SucceededWithIssues')]
   templateContext:
     outputs:
@@ -83,7 +80,7 @@ jobs:
         downloadDirectory: $(Build.SourcesDirectory)
         vstsFeed: WindowsInboxApps
         vstsFeedPackage: calculator-internals
-        vstsPackageVersion: 0.0.120
+        vstsPackageVersion: 0.0.122
 
   - task: PowerShell@2
     displayName: Generate MsixBundle mapping

--- a/build/pipelines/templates/release-vpack.yaml
+++ b/build/pipelines/templates/release-vpack.yaml
@@ -44,7 +44,7 @@ jobs:
       downloadDirectory: $(Build.SourcesDirectory)
       vstsFeed: WindowsInboxApps
       vstsFeedPackage: calculator-internals
-      vstsPackageVersion: 0.0.120
+      vstsPackageVersion: 0.0.122
 
   - pwsh: |
       $configPath = "$(Build.SourcesDirectory)\Tools\Build\Signing\ESRP-auth.json"


### PR DESCRIPTION
## What
Azure pipeline is broken because there's no job named `BuildARM`

## How
1. Remove the dependency on `BuildARM`
2. Update the internal package version to 122.