### PR TITLE
Fix: AOT doesn't work after upgrading from versions less than 11.2508.1.0

### DIFF
--- a/src/Calculator.ManagedViewModels/ApplicationViewModel.cs
+++ b/src/Calculator.ManagedViewModels/ApplicationViewModel.cs
@@ -220,12 +220,19 @@ namespace CalculatorApp.ManagedViewModels
                 }
                 else
                 {
-                    if (settings.Values.TryGetValue(WidthLocalSettingsKey, out var oldWidth) &&
-                        settings.Values.TryGetValue(HeightLocalSettingsKey, out var oldHeight))
+                    try
                     {
-                        compactOptions.CustomSize = new Size((double)oldWidth, (double)oldHeight);
+                        if (settings.Values.TryGetValue(WidthLocalSettingsKey, out var oldWidth) &&
+                            settings.Values.TryGetValue(HeightLocalSettingsKey, out var oldHeight))
+                        {
+                            compactOptions.CustomSize = new Size((double)oldWidth, (double)oldHeight);
+                        }
+                        else
+                        {
+                            compactOptions.CustomSize = DefaultSize;
+                        }
                     }
-                    else
+                    catch (InvalidCastException)
                     {
                         compactOptions.CustomSize = DefaultSize;
                     }


### PR DESCRIPTION
## Root cause

11.2508.0.0 started to store AOT window size with the `double` type, while it used to be the `float` type.
Unfortunately, C# unboxing will throw casting failure if the expected type doesn't match, which caused the broken control flow of the opening of the AOT mode.



