### PR TITLE
Fix assignment in conditional expression in Grapher.cpp

### DIFF
--- a/src/GraphControl/Control/Grapher.cpp
+++ b/src/GraphControl/Control/Grapher.cpp
@@ -373,7 +373,7 @@ namespace GraphControl
                 request += s_getGraphClosingTags;
             }
 
-            if (graphExpression = m_solver->ParseInput(request, m_errorCode, m_errorType))
+            if (graphExpression == m_solver->ParseInput(request, m_errorCode, m_errorType))
             {
                 initResult = TryInitializeGraph(keepCurrentView, graphExpression.get());
 


### PR DESCRIPTION
**Fixes**


**Description of the changes:**
Replaced the assignment operator (=) with the equality operator (==) in the if condition within Grapher::TryUpdateGraph.
This change addresses a potential coding error where a
variable was being assigned inside a conditional check instead of being compared.

How changes were validated:
Manual code review of the syntax change, and building and running the application

