### PR TITLE
Return a fresh copy to prevent use after free

### DIFF
--- a/src/CalcManager/Ratpack/conv.cpp
+++ b/src/CalcManager/Ratpack/conv.cpp
@@ -1354,13 +1354,16 @@ PNUMBER gcd(_In_ PNUMBER a, _In_ PNUMBER b)
     PNUMBER larger = nullptr;
     PNUMBER smaller = nullptr;
 
+    // Always return a fresh copy so callers can safely free the result.
     if (zernum(a))
     {
-        return b;
+        DUPNUM(r, b);
+        return r;
     }
     else if (zernum(b))
     {
-        return a;
+        DUPNUM(r, a);
+        return r;
     }
 
     if (lessnum(a, b))


### PR DESCRIPTION
If a or b is 0, the pointer to a or b is assigned out, which means it can be called by destroynum