### PR TITLE
Fix compiler warnings in calc.cpp and trans.cpp

### DIFF
--- a/src/CalcManager/CEngine/calc.cpp
+++ b/src/CalcManager/CEngine/calc.cpp
@@ -146,7 +146,7 @@ std::wstring CCalcEngine::GetMaxDecimalValueString() const
 // of CCalcEngine. Otherwise it will get destructed with the CalcEngine
 unique_ptr<Rational> CCalcEngine::PersistedMemObject()
 {
-    return move(m_memoryValue);
+    return std::move(m_memoryValue);
 }
 
 void CCalcEngine::PersistedMemObject(Rational const& memObject)

--- a/src/CalcManager/Ratpack/trans.cpp
+++ b/src/CalcManager/Ratpack/trans.cpp
@@ -104,6 +104,8 @@ void sinanglerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t 
     scalerat(pa, angletype, radix, precision);
     switch (angletype)
     {
+    case AngleType::Radians:
+        break;
     case AngleType::Degrees:
         if (rat_gt(*pa, rat_180, precision))
         {
@@ -199,6 +201,8 @@ void cosanglerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t 
     scalerat(pa, angletype, radix, precision);
     switch (angletype)
     {
+    case AngleType::Radians:
+        break;
     case AngleType::Degrees:
         if (rat_gt(*pa, rat_180, precision))
         {
@@ -269,6 +273,8 @@ void tananglerat(_Inout_ PRAT* pa, AngleType angletype, uint32_t radix, int32_t 
     scalerat(pa, angletype, radix, precision);
     switch (angletype)
     {
+    case AngleType::Radians:
+        break;
     case AngleType::Degrees:
         if (rat_gt(*pa, rat_180, precision))
         {


### PR DESCRIPTION
- Use std::move prefix for move() call in calc.cpp
- Add explicit AngleType::Radians cases to switch statements in trans.cpp


