### PR TITLE
Fix -Wdangling-capture warning in CalcEngine::GetString()

### DIFF
--- a/src/CalcManager/Header Files/CalcEngine.h
+++ b/src/CalcManager/Header Files/CalcEngine.h
@@ -97,7 +97,8 @@ public:
     // returns the ptr to string representing the operator. Mostly same as the button, but few special cases for x^y etc.
     static std::wstring_view GetString(int ids)
     {
-        return s_engineStrings[std::to_wstring(ids)];
+        std::wstring key = std::to_wstring(ids);
+        return s_engineStrings.at(key);
     }
     static std::wstring_view GetString(std::wstring_view ids)
     {


### PR DESCRIPTION
Store the temporary std::wstring object in a local variable before using it as a key for the unordered_map lookup. This prevents the compiler warning about capturing a reference to an object that will be destroyed at the end of the full-expression.