### PR TITLE
Fix Settings page text not adopting High Contrast Aquatic/Desert themes

### DIFF
--- a/src/Calculator/Views/Settings.xaml
+++ b/src/Calculator/Views/Settings.xaml
@@ -13,6 +13,13 @@
 
     <UserControl.Resources>
         <ResourceDictionary>
+            <ResourceDictionary.ThemeDictionaries>
+                <ResourceDictionary x:Key="HighContrast">
+                    <SolidColorBrush x:Key="TextFillColorPrimaryBrush" Color="{ThemeResource SystemColorWindowTextColor}"/>
+                    <SolidColorBrush x:Key="TextFillColorSecondaryBrush" Color="{ThemeResource SystemColorWindowTextColor}"/>
+                </ResourceDictionary>
+            </ResourceDictionary.ThemeDictionaries>
+
             <Style x:Key="SettingsContentScrollViewStyle" TargetType="ScrollViewer">
                 <Setter Property="HorizontalAlignment" Value="Stretch"/>
                 <Setter Property="VerticalAlignment" Value="Stretch"/>
@@ -27,7 +34,7 @@
 
             <Style x:Key="SettingsRichTextBlockStyle" TargetType="RichTextBlock">
                 <Setter Property="HorizontalAlignment" Value="Left"/>
-                <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimary}"/>
+                <Setter Property="Foreground" Value="{ThemeResource TextFillColorPrimaryBrush}"/>
                 <Setter Property="FontSize" Value="{ThemeResource BodyFontSize}"/>
                 <Setter Property="TextWrapping" Value="Wrap"/>
             </Style>


### PR DESCRIPTION
## Fixes
Text are not adopting the high contrast aquatic and desert mode in settings page.

### Description of the changes
Add HighContrast theme dictionary to Settings.xaml that overrides TextFillColorPrimaryBrush and TextFillColorSecondaryBrush to use SystemColorWindowTextColor. Also fix SettingsRichTextBlockStyle using TextFillColorPrimary (a Color) instead of TextFillColorPrimaryBrush (a Brush) for the Foreground property.


### How changes were validated
Manual testing with accessibility themes
Before
<img width="458" height="635" alt="aquatic_before" src="https://github.com/user-attachments/assets/f41627f5-f80e-4846-986e-9780a24d8cda" />

<img width="458" height="634" alt="desert_before" src="https://github.com/user-attachments/assets/b60c6320-1f3b-4230-9fdb-92d07c692f0b" />

After
<img width="479" height="596" alt="aquatic_after" src="https://github.com/user-attachments/assets/1b80f936-da82-4129-80dc-11be39dcf41b" />
<img width="482" height="604" alt="desert_after" src="https://github.com/user-attachments/assets/f23f1841-5f57-47b8-8b3c-287c9ea6c9da" />

