### PR TITLE
Refine snapping condition for _snaprat

### DIFF
--- a/src/CalcManager/Ratpack/rat.cpp
+++ b/src/CalcManager/Ratpack/rat.cpp
@@ -377,8 +377,8 @@ void _snaprat(_Inout_ PRAT* pr, _In_ PRAT a, _In_opt_ PRAT b, int32_t precision)
     DUPRAT(absR, *pr);
     ABSRAT(absR);
 
-    // if absResult < threshold => snap to zero
-    if (rat_lt(absR, threshold, precision))
+    // if absResult < threshold && absResult < rat_smallest => snap to zero
+    if (rat_lt(absR, threshold, precision) && rat_lt(absR, rat_smallest, precision))
     {
         DUPRAT(*pr, rat_zero);
     }


### PR DESCRIPTION
Fixes #2439, Fixes #2484
In the specific case of natural logarithms, _snaprat does not work correctly and returns 0 for values ⪆ 7.9e+33. This affects not only ln, but also log and logyx, as these also use natural logarithms.
Examples:
ln of 7.8e+33 = 78.039 -> ok
ln of 7.9e+33 = 0 -> wrong, should be 78.052
log of 7.9e+33 = 0 -> wrong, should be 33.898
log of 1.e+50 = 0 -> wrong, should be 50
logyx of 7.9e+33 base 2 = 0 -> wrong, should be 112.605
logyx of 7.9e+33 base 7.9e+33 = result is undefined -> wrong, should be 1
logyx of 2 base 7.9e+33 = cannot divide by zero -> wrong, should be 0.009

This PR helps to mitigate these calculation errors by adding an additional check to _snaprat. A result with an absolute value greater or equal than rat_smallest should not be set to zero anyway.
