### PR TITLE
Increment minor version from 2605 to 2606 in main

### DIFF
--- a/build/pipelines/azure-pipelines.release.yaml
+++ b/build/pipelines/azure-pipelines.release.yaml
@@ -11,7 +11,7 @@ variables:
   - name: versionMajor
     value: 11
   - name: versionMinor
-    value: 2605
+    value: 2606
   - name: versionBuild
     value: $[counter(format('{0}.{1}.*', variables['versionMajor'], variables['versionMinor']), 0)]
   - name: versionPatch


### PR DESCRIPTION
## Fixes #.
N/A

### Description of the changes:
- incrementing main's minor version from 2605 to 2606
-
-

### How changes were validated:
<!--Review https://github.com/Microsoft/calculator/blob/main/CONTRIBUTING.md and ensure all contributing requirements are met.

Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
-
-
-

