### PR TITLE
Silence experimental coroutine deprecation warnings for local builds

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,4 +2,10 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/wd9047 %(AdditionalOptions)</AdditionalOptions>
+    </ClCompile>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
VS2026's MSVC STL emits a hard error (C2338 / STL1011) when <experimental/coroutine> is included without _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS. CI already sets this via $env:CL, but local/IDE builds did not.

### Description of changes

Add the define (and /wd9047 for the matching command-line warning) to src/Directory.Build.props via ItemDefinitionGroup/ClCompile so every C++ project in the solution inherits it. C# projects ignore ClCompile, so this is safe at solution scope.

Will fast follow with more robust solution.

### How changes were validated:
Specify how you tested your changes (i.e. manual/ad-hoc testing, automated testing, new automated tests added)-->
- Verified local build/deploy + Manual smoke test


