### PR TITLE
Migrate to C++20 standard coroutines, drop deprecated /await

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -85,7 +85,7 @@ jobs:
           -t:Publish `
           -p:PublishDir=${{ github.workspace }}\output\publish\
       shell: pwsh
-      name: Build calculator.sln
+      name: Build calculator.slnx
     - uses: actions/upload-artifact@v4
       name: Upload build outputs
       with:

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -72,7 +72,6 @@ jobs:
       shell: pwsh
       name: Set version number in AppxManifest
     - run: |
-        $env:CL = '/D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS /wd9047'
         msbuild ./src/Calculator.slnx `
           -restore `
           -p:RestorePackagesConfig=true `

--- a/src/CalcManager/CalcManager.vcxproj
+++ b/src/CalcManager/CalcManager.vcxproj
@@ -114,7 +114,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <AdditionalOptions>/Zm250 /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm250 /std:c++20 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -131,7 +131,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <AdditionalOptions>/Zm250 /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm250 /std:c++20 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -149,7 +149,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <AdditionalOptions>/Zm250 /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm250 /std:c++20 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <PreprocessorDefinitions>_UNICODE;UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
@@ -167,7 +167,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <AdditionalOptions>/Zm250 /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm250 /std:c++20 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -185,7 +185,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <AdditionalOptions>/Zm250 /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm250 /std:c++20 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -202,7 +202,7 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
       <SDLCheck>true</SDLCheck>
-      <AdditionalOptions>/Zm250 /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/Zm250 /std:c++20 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>

--- a/src/CalcManager/UnitConverter.cpp
+++ b/src/CalcManager/UnitConverter.cpp
@@ -10,6 +10,7 @@
 #include "NumberFormattingUtils.h"
 
 using namespace std;
+using namespace concurrency;
 using namespace UnitConversionManager;
 using namespace UnitConversionManager::NumberFormattingUtils;
 
@@ -555,23 +556,20 @@ void UnitConverter::SetViewModelCurrencyCallback(_In_ const shared_ptr<IViewMode
     }
 }
 
-future<pair<bool, wstring>> UnitConverter::RefreshCurrencyRatios()
+task<pair<bool, wstring>> UnitConverter::RefreshCurrencyRatios()
 {
     shared_ptr<ICurrencyConverterDataLoader> currencyDataLoader = GetCurrencyConverterDataLoader();
-    future<bool> loadDataResult;
+    task<bool> loadDataResult;
     if (currencyDataLoader != nullptr)
     {
         loadDataResult = currencyDataLoader->TryLoadDataFromWebOverrideAsync();
     }
     else
     {
-        loadDataResult = async([] { return false; });
+        loadDataResult = task_from_result(false);
     }
 
-    shared_future<bool> sharedLoadResult = loadDataResult.share();
-    return async([currencyDataLoader, sharedLoadResult]() {
-        sharedLoadResult.wait();
-        bool didLoad = sharedLoadResult.get();
+    return loadDataResult.then([currencyDataLoader](bool didLoad) {
         wstring timestamp;
         if (currencyDataLoader != nullptr)
         {

--- a/src/CalcManager/UnitConverter.h
+++ b/src/CalcManager/UnitConverter.h
@@ -5,7 +5,7 @@
 
 #include <vector>
 #include <unordered_map>
-#include <future>
+#include <ppltasks.h>
 #include "sal_cross_platform.h" // for SAL
 #include <memory>               // for std::shared_ptr
 
@@ -195,9 +195,9 @@ namespace UnitConversionManager
         GetCurrencyRatioEquality(_In_ const UnitConversionManager::Unit& unit1, _In_ const UnitConversionManager::Unit& unit2) = 0;
         virtual std::wstring GetCurrencyTimestamp() = 0;
 
-        virtual std::future<bool> TryLoadDataFromCacheAsync() = 0;
-        virtual std::future<bool> TryLoadDataFromWebAsync() = 0;
-        virtual std::future<bool> TryLoadDataFromWebOverrideAsync() = 0;
+        virtual concurrency::task<bool> TryLoadDataFromCacheAsync() = 0;
+        virtual concurrency::task<bool> TryLoadDataFromWebAsync() = 0;
+        virtual concurrency::task<bool> TryLoadDataFromWebOverrideAsync() = 0;
     };
 
     class IUnitConverterVMCallback
@@ -227,7 +227,7 @@ namespace UnitConversionManager
         virtual void SendCommand(Command command) = 0;
         virtual void SetViewModelCallback(_In_ const std::shared_ptr<IUnitConverterVMCallback>& newCallback) = 0;
         virtual void SetViewModelCurrencyCallback(_In_ const std::shared_ptr<IViewModelCurrencyCallback>& newCallback) = 0;
-        virtual std::future<std::pair<bool, std::wstring>> RefreshCurrencyRatios() = 0;
+        virtual concurrency::task<std::pair<bool, std::wstring>> RefreshCurrencyRatios() = 0;
         virtual void Calculate() = 0;
         virtual void ResetCategoriesAndRatios() = 0;
     };
@@ -251,7 +251,7 @@ namespace UnitConversionManager
         void SendCommand(Command command) override;
         void SetViewModelCallback(_In_ const std::shared_ptr<IUnitConverterVMCallback>& newCallback) override;
         void SetViewModelCurrencyCallback(_In_ const std::shared_ptr<IViewModelCurrencyCallback>& newCallback) override;
-        std::future<std::pair<bool, std::wstring>> RefreshCurrencyRatios() override;
+        concurrency::task<std::pair<bool, std::wstring>> RefreshCurrencyRatios() override;
         void Calculate() override;
         void ResetCategoriesAndRatios() override;
         // IUnitConverter

--- a/src/CalcManager/pch.h
+++ b/src/CalcManager/pch.h
@@ -13,7 +13,7 @@
 #include <cassert>
 #include <intsafe.h>
 #include <list>
-#include <future>
+#include <ppltasks.h>
 #include <regex>
 #include <sstream>
 #include <string>

--- a/src/CalcViewModel/CalcViewModel.vcxproj
+++ b/src/CalcViewModel/CalcViewModel.vcxproj
@@ -123,7 +123,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <WarningLevel>Level4</WarningLevel>
@@ -142,7 +142,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ControlFlowGuard>Guard</ControlFlowGuard>
@@ -162,7 +162,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <WarningLevel>Level4</WarningLevel>
@@ -181,7 +181,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ControlFlowGuard>Guard</ControlFlowGuard>
@@ -201,7 +201,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <WarningLevel>Level4</WarningLevel>
@@ -220,7 +220,7 @@
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204;4453</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <ControlFlowGuard>Guard</ControlFlowGuard>

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.cpp
@@ -250,7 +250,7 @@ void CurrencyDataLoader::LoadData()
         create_task(
             [this]() -> task<bool>
             {
-                vector<function<future<bool>()>> loadFunctions = {
+                vector<function<task<bool>()>> loadFunctions = {
                     [this]() { return TryLoadDataFromCacheAsync(); },
                     [this]() { return TryLoadDataFromWebAsync(); },
                 };
@@ -378,7 +378,7 @@ pair<wstring, wstring> CurrencyDataLoader::GetCurrencyRatioEquality(_In_ const U
 }
 
 #pragma optimize("", off) // Turn off optimizations to work around DevDiv 393321
-future<bool> CurrencyDataLoader::TryLoadDataFromCacheAsync()
+task<bool> CurrencyDataLoader::TryLoadDataFromCacheAsync()
 {
     try
     {
@@ -420,7 +420,7 @@ future<bool> CurrencyDataLoader::TryLoadDataFromCacheAsync()
     }
 }
 
-future<bool> CurrencyDataLoader::TryFinishLoadFromCacheAsync()
+task<bool> CurrencyDataLoader::TryFinishLoadFromCacheAsync()
 {
     auto localSettings = ApplicationData::Current->LocalSettings;
     if (localSettings == nullptr)
@@ -457,7 +457,7 @@ future<bool> CurrencyDataLoader::TryFinishLoadFromCacheAsync()
     co_return true;
 }
 
-future<bool> CurrencyDataLoader::TryLoadDataFromWebAsync()
+task<bool> CurrencyDataLoader::TryLoadDataFromWebAsync()
 {
     try
     {
@@ -525,7 +525,7 @@ future<bool> CurrencyDataLoader::TryLoadDataFromWebAsync()
     }
 }
 
-future<bool> CurrencyDataLoader::TryLoadDataFromWebOverrideAsync()
+task<bool> CurrencyDataLoader::TryLoadDataFromWebOverrideAsync()
 {
     m_meteredOverrideSet = true;
     bool didLoad = co_await TryLoadDataFromWebAsync();

--- a/src/CalcViewModel/DataLoaders/CurrencyDataLoader.h
+++ b/src/CalcViewModel/DataLoaders/CurrencyDataLoader.h
@@ -77,9 +77,9 @@ namespace CalculatorApp
             std::wstring GetCurrencyTimestamp() override;
             static double RoundCurrencyRatio(double ratio);
 
-            std::future<bool> TryLoadDataFromCacheAsync() override;
-            std::future<bool> TryLoadDataFromWebAsync() override;
-            std::future<bool> TryLoadDataFromWebOverrideAsync() override;
+            concurrency::task<bool> TryLoadDataFromCacheAsync() override;
+            concurrency::task<bool> TryLoadDataFromWebAsync() override;
+            concurrency::task<bool> TryLoadDataFromWebOverrideAsync() override;
             // ICurrencyConverterDataLoader
 
             void OnNetworkBehaviorChanged(CalculatorApp::ViewModel::Common::NetworkAccessBehavior newBehavior);
@@ -88,7 +88,7 @@ namespace CalculatorApp
             void ResetLoadStatus();
             void NotifyDataLoadFinished(bool didLoad);
 
-            std::future<bool> TryFinishLoadFromCacheAsync();
+            concurrency::task<bool> TryFinishLoadFromCacheAsync();
 
             bool TryParseWebResponses(
                 _In_ Platform::String ^ staticDataJson,

--- a/src/CalcViewModel/DataLoaders/CurrencyHttpClient.cpp
+++ b/src/CalcViewModel/DataLoaders/CurrencyHttpClient.cpp
@@ -133,19 +133,15 @@ namespace CalculatorApp::ViewModel::DataLoaders
         m_responseLanguage = responseLanguage;
     }
 
-    std::future<Platform::String ^> CurrencyHttpClient::GetCurrencyMetadataAsync() const
+    concurrency::task<Platform::String ^> CurrencyHttpClient::GetCurrencyMetadataAsync() const
     {
         (void)m_responseLanguage; // to be used in production.
-        std::promise<Platform::String ^> mockedTask;
-        mockedTask.set_value(ref new Platform::String(MockCurrencyStaticData));
-        return mockedTask.get_future();
+        return concurrency::task_from_result<Platform::String ^>(ref new Platform::String(MockCurrencyStaticData));
     }
 
-    std::future<Platform::String ^> CurrencyHttpClient::GetCurrencyRatiosAsync() const
+    concurrency::task<Platform::String ^> CurrencyHttpClient::GetCurrencyRatiosAsync() const
     {
         (void)m_sourceCurrencyCode; // to be used in production.
-        std::promise<Platform::String ^> mockedTask;
-        mockedTask.set_value(ref new Platform::String(MockCurrencyConverterData));
-        return mockedTask.get_future();
+        return concurrency::task_from_result<Platform::String ^>(ref new Platform::String(MockCurrencyConverterData));
     }
 } // namespace CalculatorApp::ViewModel::DataLoaders

--- a/src/CalcViewModel/DataLoaders/CurrencyHttpClient.h
+++ b/src/CalcViewModel/DataLoaders/CurrencyHttpClient.h
@@ -3,7 +3,7 @@
 
 #pragma once
 #include <cassert>
-#include <future>
+#include <ppltasks.h>
 
 namespace CalculatorApp::ViewModel::DataLoaders
 {
@@ -15,8 +15,8 @@ namespace CalculatorApp::ViewModel::DataLoaders
 #endif
         void Initialize(Platform::String ^ sourceCurrencyCode, Platform::String ^ responseLanguage);
 
-        std::future<Platform::String ^> GetCurrencyMetadataAsync() const;
-        std::future<Platform::String ^> GetCurrencyRatiosAsync() const;
+        concurrency::task<Platform::String ^> GetCurrencyMetadataAsync() const;
+        concurrency::task<Platform::String ^> GetCurrencyRatiosAsync() const;
 
     private:
         Platform::String ^ m_sourceCurrencyCode;

--- a/src/CalcViewModelCopyForUT/CalcViewModelCopyForUT.vcxproj
+++ b/src/CalcViewModelCopyForUT/CalcViewModelCopyForUT.vcxproj
@@ -108,7 +108,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;$(SolutionDir)CalcViewModel\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>VIEWMODEL_FOR_UT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -129,7 +129,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;$(SolutionDir)CalcViewModel\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>VIEWMODEL_FOR_UT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -150,7 +150,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcViewModel\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>VIEWMODEL_FOR_UT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -171,7 +171,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;$(SolutionDir)CalcViewModel\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>VIEWMODEL_FOR_UT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -192,7 +192,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;$(SolutionDir)CalcViewModel\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>VIEWMODEL_FOR_UT;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -213,7 +213,7 @@
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>$(SolutionDir)..\src\;$(SolutionDir)CalcViewModel\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4453</DisableSpecificWarnings>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
       <PreprocessorDefinitions>VIEWMODEL_FOR_UT;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/src/CalcViewModelCopyForUT/DataLoaders/CurrencyHttpClient.cpp
+++ b/src/CalcViewModelCopyForUT/DataLoaders/CurrencyHttpClient.cpp
@@ -21,28 +21,23 @@ namespace CalculatorApp::ViewModel::DataLoaders
         m_responseLanguage = responseLanguage;
     }
 
-    std::future<Platform::String ^> CurrencyHttpClient::GetCurrencyMetadataAsync() const
+    concurrency::task<Platform::String ^> CurrencyHttpClient::GetCurrencyMetadataAsync() const
     {
         if (ForceWebFailure)
         {
             throw ref new Platform::Exception(E_FAIL, L"Mocked Network Failure: failed to load currency metadata");
         }
         (void)m_responseLanguage; // to be used in production.
-        std::promise<Platform::String ^> mockedTask;
-        mockedTask.set_value(ref new Platform::String(MockCurrencyStaticData));
-        return mockedTask.get_future();
+        return concurrency::task_from_result<Platform::String ^>(ref new Platform::String(MockCurrencyStaticData));
     }
 
-    std::future<Platform::String ^> CurrencyHttpClient::GetCurrencyRatiosAsync() const
+    concurrency::task<Platform::String ^> CurrencyHttpClient::GetCurrencyRatiosAsync() const
     {
         if (ForceWebFailure)
         {
             throw ref new Platform::Exception(E_FAIL, L"Mocked Network Failure: failed to load currency metadata");
         }
         (void)m_sourceCurrencyCode; // to be used in production.
-
-        std::promise<Platform::String ^> mockedTask;
-        mockedTask.set_value(ref new Platform::String(MockCurrencyConverterData));
-        return mockedTask.get_future();
+        return concurrency::task_from_result<Platform::String ^>(ref new Platform::String(MockCurrencyConverterData));
     }
 } // namespace CalculatorApp::ViewModel::DataLoaders

--- a/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
+++ b/src/CalculatorUnitTests/CalculatorUnitTests.vcxproj
@@ -104,7 +104,7 @@
   </ImportGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <ClCompile>
-      <AdditionalOptions>/bigobj /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
@@ -114,7 +114,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <ClCompile>
-      <AdditionalOptions>/bigobj /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
@@ -125,7 +125,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <AdditionalOptions>/bigobj /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
@@ -135,7 +135,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <AdditionalOptions>/bigobj /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
@@ -146,7 +146,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <AdditionalOptions>/bigobj /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
@@ -156,7 +156,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <AdditionalOptions>/bigobj /await /std:c++17 /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /permissive- /Zc:twoPhase- /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>4453;28204</DisableSpecificWarnings>
       <AdditionalIncludeDirectories>$(SolutionDir);$(SolutionDir)CalcManager;$(SolutionDir)CalcViewModel;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>

--- a/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.h
+++ b/src/CalculatorUnitTests/UnitConverterViewModelUnitTests.h
@@ -53,7 +53,7 @@ namespace CalculatorUnitTests
         void ResetCategoriesAndRatios() override
         {
         }
-        std::future<std::pair<bool, std::wstring>> RefreshCurrencyRatios() override
+        concurrency::task<std::pair<bool, std::wstring>> RefreshCurrencyRatios() override
         {
             co_return std::make_pair(true, L"");
         }

--- a/src/CalculatorUnitTests/pch.h
+++ b/src/CalculatorUnitTests/pch.h
@@ -33,7 +33,6 @@
 #include <deque>
 #include <regex>
 #include <concurrent_vector.h>
-#include <experimental/resumable>
 #include <pplawait.h>
 #include <unordered_map>
 #include <mutex>

--- a/src/GraphControl/GraphControl.vcxproj
+++ b/src/GraphControl/GraphControl.vcxproj
@@ -113,7 +113,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /w44242 /await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir);$(GraphingInterfaceDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -135,7 +135,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /w44242 /await /d2CoroOptsWorkaround %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir);$(GraphingInterfaceDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -158,7 +158,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /w44242 /await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir);$(GraphingInterfaceDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -180,7 +180,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /w44242 /await /d2CoroOptsWorkaround %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir);$(GraphingInterfaceDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -203,7 +203,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /w44242 /await %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir);$(GraphingInterfaceDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -225,7 +225,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /w44242 /await /d2CoroOptsWorkaround %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /await:strict /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <AdditionalIncludeDirectories>$(ProjectDir);$(GraphingInterfaceDir);$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/src/GraphControl/pch.h
+++ b/src/GraphControl/pch.h
@@ -15,7 +15,7 @@
 #include <ppltasks.h>
 #include <pplawait.h>
 #include <concrt.h>
-#include <future>
+#include <ppltasks.h>
 #include <memory>
 #include <cassert>
 #include <functional>

--- a/src/GraphControl/pch.h
+++ b/src/GraphControl/pch.h
@@ -15,7 +15,6 @@
 #include <ppltasks.h>
 #include <pplawait.h>
 #include <concrt.h>
-#include <ppltasks.h>
 #include <memory>
 #include <cassert>
 #include <functional>

--- a/src/GraphingImpl/GraphingImpl.vcxproj
+++ b/src/GraphingImpl/GraphingImpl.vcxproj
@@ -106,7 +106,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
@@ -122,7 +122,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ControlFlowGuard>Guard</ControlFlowGuard>
@@ -139,7 +139,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
@@ -155,7 +155,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ControlFlowGuard>Guard</ControlFlowGuard>
@@ -172,7 +172,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WarningLevel>Level4</WarningLevel>
@@ -188,7 +188,7 @@
     <ClCompile>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <CompileAsWinRT>false</CompileAsWinRT>
-      <LanguageStandard>stdcpp17</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/DGRAPHING_ENGINE_IMPL /w44242 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(ProjectDir);$(ProjectDir)\..\;$(GeneratedFilesDir);$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <ControlFlowGuard>Guard</ControlFlowGuard>

--- a/src/TraceLogging/TraceLogging.vcxproj
+++ b/src/TraceLogging/TraceLogging.vcxproj
@@ -122,7 +122,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -139,7 +139,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <WarningLevel>Level4</WarningLevel>
@@ -157,7 +157,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <WarningLevel>Level4</WarningLevel>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -174,7 +174,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <WarningLevel>Level4</WarningLevel>
@@ -192,7 +192,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <TreatWarningAsError>true</TreatWarningAsError>
       <WarningLevel>Level4</WarningLevel>
@@ -209,7 +209,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)pch.pch</PrecompiledHeaderOutputFile>
       <AdditionalUsingDirectories>$(WindowsSDK_WindowsMetadata);$(AdditionalUsingDirectories)</AdditionalUsingDirectories>
-      <AdditionalOptions>/bigobj /await /std:c++17 /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /std:c++17 /await:strict /utf-8 /w44242 %(AdditionalOptions)</AdditionalOptions>
       <DisableSpecificWarnings>28204</DisableSpecificWarnings>
       <ControlFlowGuard>Guard</ControlFlowGuard>
       <WarningLevel>Level4</WarningLevel>


### PR DESCRIPTION
VS2026's STL hard-errors (STL1011 / C2338) on <experimental/coroutine> and <experimental/resumable>. Replace MSVC's deprecated TS coroutines with the supported standard coroutine machinery at the source, instead of suppressing the warning.

### Description of the changes

Compiler flags (7 native projects):
- CalcManager, GraphingImpl (no /ZW): /std:c++17 -> /std:c++20.
- CalcViewModel, CalcViewModelCopyForUT, CalculatorUnitTests, GraphControl, TraceLogging (use /ZW for C++/CX, incompatible with /std:c++20 per D8016): keep /std:c++17, swap /await for /await:strict.
- /await:strict is the non-deprecated MSVC switch that enables standard C++20 coroutines (<coroutine>, __cpp_impl_coroutine) under C++17, so pplawait.h's #ifdef __cpp_impl_coroutine path is taken in all projects and <experimental/resumable> is no longer pulled in.
- Drop the /d2CoroOptsWorkaround flag (Release-only MSVC coroutine optimizer crash workaround) that no longer applies under the standard coroutine codegen path.

Source refactor: std::future<T> -> concurrency::task<T>:
- Standard C++20 does not provide coroutine_traits<std::future<T>> or operator co_await(std::future<T>) (those were MSVC TS extensions), so future-returning coroutines fail with C2039 "promise_type is not a member of std::coroutine_traits<std::future<...>>" once /await is dropped. Migrate the affected APIs to concurrency::task<T>, which is a coroutine return type and an awaitable in both /await:strict and /std:c++20 modes via pplawait.h.
- CalcManager/UnitConverter.{h,cpp,pch.h}: RefreshCurrencyRatios() and three ICurrencyConverterDataLoader::Try*Async virtuals now return concurrency::task<...>. RefreshCurrencyRatios reimplemented with task_from_result + .then() instead of std::async/shared_future.
- CalcViewModel/DataLoaders/CurrencyDataLoader.{h,cpp}: four Try*Async coroutines now return concurrency::task<bool>; bodies (co_await/co_return) unchanged.
- CalcViewModel + CalcViewModelCopyForUT DataLoaders/CurrencyHttpClient.{h,cpp}: mock async getters return concurrency::task<Platform::String^>; std::promise/get_future pattern replaced with concurrency::task_from_result.
- CalculatorUnitTests/UnitConverterViewModelUnitTests.h: mock RefreshCurrencyRatios override updated to the new return type.

Header / include cleanup:
- CalculatorUnitTests/pch.h: remove #include <experimental/resumable>
  (the last direct experimental include in the tree).
- GraphControl/pch.h, CalcManager/pch.h: <future> -> <ppltasks.h>.

CI cleanup:
- .github/workflows/action-ci.yml: drop the defensive $env:CL = '/D_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS /wd9047' line; the deprecation no longer fires anywhere.

### How changes were validated
- Debug|x64 builds clean with VS2026 (MSVC 14.51) - no STL1011, no C2338, no warnings.
- Smoke test: app launches, Standard arithmetic works (2+3=5), Volume unit converter loads (exercises the refactored concurrency::task<> IUnitConverter interface).


