### PR TITLE
Fix F-E toggle not resetting on Clear/Clear-Entry in Scientific mode

### DIFF
--- a/src/CalcViewModel/StandardCalculatorViewModel.h
+++ b/src/CalcViewModel/StandardCalculatorViewModel.h
@@ -71,7 +71,7 @@ namespace CalculatorApp
             OBSERVABLE_PROPERTY_RW(bool, IsDecimalEnabled);
             OBSERVABLE_PROPERTY_R(Windows::Foundation::Collections::IVector<MemoryItemViewModel ^> ^, MemorizedNumbers);
             OBSERVABLE_NAMED_PROPERTY_RW(bool, IsMemoryEmpty);
-            OBSERVABLE_PROPERTY_R(bool, IsFToEChecked);
+            OBSERVABLE_PROPERTY_RW(bool, IsFToEChecked);
             OBSERVABLE_PROPERTY_R(bool, IsFToEEnabled);
             OBSERVABLE_PROPERTY_R(bool, AreHEXButtonsEnabled);
             OBSERVABLE_PROPERTY_R(Platform::String ^, CalculationResultAutomationName);

--- a/src/Calculator/Views/CalculatorScientificAngleButtons.xaml
+++ b/src/Calculator/Views/CalculatorScientificAngleButtons.xaml
@@ -107,7 +107,7 @@
                       AutomationProperties.Name="{utils:ResourceString Name=ftoeButton/[using:Windows.UI.Xaml.Automation]AutomationProperties/Name}"
                       Checked="FToEButton_Toggled"
                       Content="F-E"
-                      IsChecked="{x:Bind Model.IsFToEChecked, Mode=OneWay}"
+                      IsChecked="{x:Bind Model.IsFToEChecked, Mode=TwoWay}"
                       Unchecked="FToEButton_Toggled"
                       IsEnabled="{x:Bind Model.IsFToEEnabled, Mode=OneWay}">
             <ToggleButton.CommandParameter>

--- a/src/CalculatorUITests/ScientificModeFunctionalTests.cs
+++ b/src/CalculatorUITests/ScientificModeFunctionalTests.cs
@@ -4,6 +4,7 @@
 using CalculatorUITestFramework;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using OpenQA.Selenium;
 using System;
 
 namespace CalculatorUITests
@@ -689,6 +690,69 @@ namespace CalculatorUITests
             page.StandardOperators.EqualButton.Click();
             Assert.IsTrue(page.CalculatorResults.GetCalculatorResultText().StartsWith("0.549306"));
 
+        }
+        #endregion
+
+        #region F-E Tests
+
+        /// <summary>
+        /// In Scientific mode, pressing Clear (C) while the F-E toggle is on
+        /// resets both the button state to off and the display format back to
+        /// fixed-point. The next digit entered renders in fixed form.
+        /// </summary>
+        [TestMethod]
+        [Priority(1)]
+        public void FixedToExponentialResetsOnClear()
+        {
+            // C and CE share a button slot in Scientific mode (visibility on
+            // Model.IsInputEmpty, mutually exclusive). Use the Escape hotkey
+            // to invoke Clear unconditionally — it routes through the same
+            // KeyboardShortcutManager → OnButtonPressed(Clear) path as the
+            // visible button (Resources.resw:clearButton.VirtualKey = Escape).
+            page.ScientificOperators.FixedToExponentialButton.Click();
+
+            // Press Clear via the Escape hotkey.
+            CalculatorApp.EnsureCalculatorHasFocus();
+            CalculatorApp.Window.SendKeys(Keys.Escape);
+
+            // Button-visual invariant: F-E toggle is off immediately after Clear.
+            Assert.AreEqual(
+                "0",
+                page.ScientificOperators.FixedToExponentialButton.GetAttribute("Toggle.ToggleState"),
+                "F-E button should be untoggled after Clear in Scientific mode.");
+
+            // Display invariant: the next digit renders in fixed form, not exponent form.
+            page.StandardOperators.NumberPad.Input(2);
+            Assert.AreEqual(
+                "2",
+                page.CalculatorResults.GetCalculatorResultText(),
+                "Display should render in fixed form after Clear resets F-E.");
+        }
+
+        /// <summary>
+        /// In Scientific mode, pressing Clear-Entry (CE) while the F-E toggle
+        /// is on resets both the button state to off and the display format
+        /// back to fixed-point. The next digit entered renders in fixed form.
+        /// </summary>
+        [TestMethod]
+        [Priority(1)]
+        public void FixedToExponentialResetsOnClearEntry()
+        {
+            page.ScientificOperators.FixedToExponentialButton.Click();
+            page.StandardOperators.NumberPad.Input(2);
+
+            page.StandardOperators.ClearEntryButton.Click();
+
+            Assert.AreEqual(
+                "0",
+                page.ScientificOperators.FixedToExponentialButton.GetAttribute("Toggle.ToggleState"),
+                "F-E button should be untoggled after Clear-Entry in Scientific mode.");
+
+            page.StandardOperators.NumberPad.Input(2);
+            Assert.AreEqual(
+                "2",
+                page.CalculatorResults.GetCalculatorResultText(),
+                "Display should render in fixed form after Clear-Entry resets F-E.");
         }
         #endregion
     }


### PR DESCRIPTION
## Description

In Scientific mode, after toggling the F-E (Fixed-to-Exponent) button on and entering a value, pressing `C` (Clear) or `CE` (Clear-Entry) did not reset the F-E toggle. The button stayed visually toggled and the next digit entered rendered in scientific notation, breaking parity with the desktop Calculator.

This PR restores the design documented by the existing maintainer comment in `StandardCalculatorViewModel::OnButtonPressed` (lines 692-695): on Clear/Clear-Entry in Scientific mode, the F-E toggle resets to off and the display returns to fixed-point form.

### Background

Two unrelated historical changes combined to produce this regression:

1. Commit 86307f2 (PR #799) demoted `IsFToEChecked` from `OBSERVABLE_PROPERTY_RW` to `OBSERVABLE_PROPERTY_R` as part of a property-cleanup sweep. The XAML still bound `{Binding IsFToEChecked, Mode=TwoWay}`; under the C++/CX runtime binding that silently no-op'd against the private setter, severing the UI→VM sync.
2. Commit fdae100 (PR #1598, C++/CX → C# migration) migrated the binding to x:Bind ... Mode=OneWay`. `x:Bind ... Mode=TwoWay` against a private setter is a compile error, so the migration was constrained to `Mode=OneWay` given the `_R` declaration it inherited from (1).

This PR restores both the writable property and the `TwoWay` binding, reactivating the dead-code path at `StandardCalculatorViewModel.cpp:697-700`. The test framework's existing `ScientificOperatorsPanel::ResetFEButton` helper (called from `ScientificModeFunctionalTests.TestInit`) was added to work around this bug between test runs; it now becomes defensive rather than load-bearing.

A small known beneficial side effect: the conditional `CommandFE` send at `StandardCalculatorViewModel.cpp:1458-1461` (previously dead) becomes live and now preserves F-E state across recalculation/history-load, which matches user expectation.

## How changes were validated

Added two WinAppDriver regression tests in `ScientificModeFunctionalTests.cs`, covering Clear and Clear-Entry independently (they route through separate `NumbersAndOperatorsEnum` values). Each test asserts both invariants:

- the F-E button's `Toggle.ToggleState` is `"0"` immediately after C/CE
- the next digit entered renders in fixed form (`"2"`, not `"2.e+0"`)

Validated via CI (Build x64, Run unit tests x64, Run UI tests x64).
