### PR TITLE
Fix duplicate Alt+C access keys on Clear history/memory buttons (a11y)

### DIFF
--- a/src/Calculator/Resources/en-US/Resources.resw
+++ b/src/Calculator/Resources/en-US/Resources.resw
@@ -3232,11 +3232,11 @@
     <comment>AccessKey for the temperature converter navbar item. {StringCategory="Accelerator"}</comment>
   </data>
   <data name="ClearHistory.AccessKey" xml:space="preserve">
-    <value>C</value>
+    <value>Y</value>
     <comment>Access key for the Clear history button.{StringCategory="Accelerator"}</comment>
   </data>
   <data name="ClearMemory.AccessKey" xml:space="preserve">
-    <value>C</value>
+    <value>R</value>
     <comment>Access key for the Clear memory button. {StringCategory="Accelerator"}</comment>
   </data>
   <data name="ClearMemory.[using:Windows.UI.Xaml.Controls]ToolTipService.ToolTip" xml:space="preserve">


### PR DESCRIPTION
 ## Description

 Accessibility Insights flagged a duplicate access key: three controls all declared `Alt+C` in `en-US/Resources.resw`:

 - `CategoryName_CurrencyAccessKey` — Currency converter nav item
 - `ClearHistory.AccessKey` — Clear all history
 - `ClearMemory.AccessKey` — Clear all memory

 Microsoft accessibility guidelines require access keys to be unique across the visual tree. This PR keeps `C` for Currency (the  natural mnemonic) and assigns unique, mnemonic access keys to the two Clear buttons:

 - `ClearHistory.AccessKey`: `C` → `Y` (clear histor**Y**)
 - `ClearMemory.AccessKey`: `C` → `R` (clea**R** memory)

 Both replacement letters appear in the visible button label, so the underlined mnemonic renders sensibly, and neither collides with  any other access key in the resource set or with any `Alt`-based keyboard accelerator (only `Alt+Up`/`Alt+Down` exist).

 Only `en-US/Resources.resw` is changed; the other locale files are updated separately by the localized-strings pipeline, per existing  repo convention.

 ## How changes were validated

 - Enumerated every `*.AccessKey` value in `Resources.resw` and every hardcoded `AccessKey="..."` in XAML, grouped by value: `C` now  appears once (Currency), and `Y`/`R` each appear once — no duplicates introduced.
 - Confirmed no C++/C#/test code depends on the previous literal values; existing UI tests invoke these buttons by `AutomationId`  (`ClearHistoryButton`, `PanelClearMemoryButton`), unaffected by the access-key change.
 - No automated test added: this is a static resource-string uniqueness change with no behavioral surface, consistent with recent  resource-only fixes in this repo. Existing CI checks cover the build.