### PR TITLE
Modernize .editorconfig and enforce IDE0003 in CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,10 +1,149 @@
-## IDE-independent coding style via EditorConfig: https://editorconfig.org/
-
+# top-most EditorConfig file
 root = true
 
+###############################################################################
+# Universal defaults (all files)
+###############################################################################
 [*]
+charset = utf-8
 indent_style = space
 indent_size = 4
-charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+###############################################################################
+# XML / MSBuild project & config files
+###############################################################################
+[*.{xml,props,targets,csproj,vcxproj,vcxproj.filters,appxmanifest,manifest,resw,resx,config,nuspec,vsixmanifest,slnx}]
+indent_size = 2
+
+###############################################################################
+# JSON / YAML config files
+###############################################################################
+[*.{json,json5,yml,yaml}]
+indent_size = 2
+
+###############################################################################
+# Markdown (preserve trailing whitespace for hard line breaks)
+###############################################################################
+[*.md]
+trim_trailing_whitespace = false
+
+###############################################################################
+# C# style and analyzer policy
+###############################################################################
+[*.cs]
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_indent_labels = one_less_than_current
+csharp_style_throw_expression = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+csharp_style_prefer_top_level_statements = true:silent
+
+# 'this.' qualification: prefer no qualifier (IDE0003). Promoted to warning and
+# enforced in CI via build\scripts\VerifyCodeStyle.ps1 (dotnet format), since
+# csc does not reliably surface IDE-prefixed analyzers at build time.
+dotnet_style_qualification_for_field = false:warning
+dotnet_style_qualification_for_property = false:warning
+dotnet_style_qualification_for_method = false:warning
+dotnet_style_qualification_for_event = false:warning
+dotnet_diagnostic.IDE0003.severity = warning
+
+###############################################################################
+# .NET naming & code-style (C# and VB)
+###############################################################################
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers =
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers =
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+#### .NET code-style preferences ####
+
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_compound_assignment = true:suggestion
+dotnet_style_prefer_simplified_interpolation = true:suggestion
+dotnet_style_namespace_match_folder = true:suggestion
+tab_width = 4
+indent_size = 4
+
+###############################################################################
+# C++ - Visual C++ Include Cleanup settings
+###############################################################################
+[*.{c++,cc,cpp,cppm,cxx,h,h++,hh,hpp,hxx,inl,ipp,ixx,tlh,tli}]
+
+cpp_include_cleanup_add_missing_error_tag_type = suggestion
+cpp_include_cleanup_remove_unused_error_tag_type = dimmed
+cpp_include_cleanup_sort_after_edits = true
+cpp_sort_includes_error_tag_type = warning
+cpp_sort_includes_priority_case_sensitive = false
+cpp_sort_includes_priority_style = angle_brackets
+cpp_includes_style = default
+cpp_includes_use_forward_slash = true

--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -7,6 +7,19 @@ on:
     branches: [main, release/**, feature/**]
   workflow_dispatch:
 jobs:
+  verifyCodeStyle:
+    name: Verify code style (IDE0003)
+    runs-on: windows-2025-vs2026
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      name: Setup .NET SDK
+      with:
+        dotnet-version: '10.0.x'
+    - run: ./build/scripts/VerifyCodeStyle.ps1
+      shell: pwsh
+      name: Verify no unnecessary this. (IDE0003)
+
   defineBuilds:
     name: Define builds
     runs-on: windows-2025-vs2026

--- a/build/scripts/VerifyCodeStyle.ps1
+++ b/build/scripts/VerifyCodeStyle.ps1
@@ -18,9 +18,11 @@
     rules. The allowlist is a positive list, so new projects are
     safe-by-default until explicitly added.
 
-    Restore is intentionally NOT skipped: the allowlisted projects carry
-    PackageReference dependencies and must be restored to load in the
-    workspace.
+    Restore is performed explicitly per project (and its exit code checked)
+    before formatting: the allowlisted projects carry PackageReference
+    dependencies that must be restored to load in the workspace, and a restore
+    failure should fail the gate loudly rather than letting 'dotnet format'
+    proceed against a partially loaded workspace.
 
 .PARAMETER Diagnostics
     Comma-separated diagnostic IDs to enforce. Defaults to 'IDE0003'.
@@ -75,7 +77,20 @@ foreach ($relPath in $sdkProjects)
 
     Write-Host "Checking: $relPath"
 
+    # Restore explicitly first so a restore/feed failure fails the gate loudly,
+    # rather than letting 'dotnet format' run against a partially loaded
+    # workspace and report success without analyzing anything.
+    & dotnet restore $projPath
+
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Host "##[error]Restore failed for: $relPath"
+        $failed = $true
+        continue
+    }
+
     & dotnet format style $projPath `
+        --no-restore `
         --verify-no-changes `
         --severity warn `
         --diagnostics $Diagnostics

--- a/build/scripts/VerifyCodeStyle.ps1
+++ b/build/scripts/VerifyCodeStyle.ps1
@@ -1,0 +1,100 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+<#
+.SYNOPSIS
+    Verifies that the C# source is free of unnecessary 'this.' qualifications
+    (IDE0003), enforcing the '.editorconfig' single-source-of-truth policy.
+
+.DESCRIPTION
+    The Roslyn IDE-prefixed analyzers (IDE0003 et al.) ship with the .NET SDK
+    but are not reliably surfaced by csc.exe at build time. The 'dotnet format
+    style' host runs the same Roslyn analyzer and honors the '.editorconfig'
+    severity ('dotnet_diagnostic.IDE0003.severity = warning'), so this script
+    uses it as the build-time enforcement gate.
+
+    'dotnet format' uses the SDK MSBuild workspace loader, which cannot load
+    old-style UWP projects (the main Calculator app and its managed view
+    models) or the native C++ test projects. Only SDK-style C# projects are
+    listed in the allowlist below; all projects share the same '.editorconfig'
+    rules. The allowlist is a positive list, so new projects are
+    safe-by-default until explicitly added.
+
+    Restore is intentionally NOT skipped: the allowlisted projects carry
+    PackageReference dependencies and must be restored to load in the
+    workspace.
+
+.PARAMETER Diagnostics
+    Comma-separated diagnostic IDs to enforce. Defaults to 'IDE0003'.
+
+.EXAMPLE
+    .\build\scripts\VerifyCodeStyle.ps1
+    Verifies the allowlisted SDK-style C# projects against IDE0003.
+
+.EXAMPLE
+    .\build\scripts\VerifyCodeStyle.ps1 -Diagnostics 'IDE0003,IDE0005'
+    Also enforces IDE0005 (remove unnecessary usings).
+#>
+[CmdletBinding()]
+param(
+    [string] $Diagnostics = 'IDE0003'
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve the repo root (this script lives in <root>\build\scripts).
+$root = if ($env:BUILD_SOURCESDIRECTORY) { $env:BUILD_SOURCESDIRECTORY } else { (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path }
+
+# SDK-style C# projects that 'dotnet format' can load. The old-style UWP
+# projects (Calculator, Calculator.ManagedViewModels) and the native C++ test
+# projects (CalculatorUnitTests) are excluded because the dotnet CLI workspace
+# loader cannot evaluate them.
+$sdkProjects = @(
+    'src\CalculatorUITestFramework\CalculatorUITestFramework.csproj',
+    'src\CalculatorUITests\CalculatorUITests.csproj'
+)
+
+Write-Host "Verifying code style for diagnostics: $Diagnostics"
+Write-Host "Tooling: dotnet $(dotnet --version)"
+Write-Host "Repo root: $root"
+Write-Host ""
+Write-Host "SDK-style projects to check:"
+$sdkProjects | ForEach-Object { Write-Host "  $_" }
+Write-Host ""
+
+$failed = $false
+
+foreach ($relPath in $sdkProjects)
+{
+    $projPath = Join-Path $root $relPath
+
+    if (-not (Test-Path $projPath))
+    {
+        Write-Host "##[error]Allowlisted project not found: $relPath"
+        $failed = $true
+        continue
+    }
+
+    Write-Host "Checking: $relPath"
+
+    & dotnet format style $projPath `
+        --verify-no-changes `
+        --severity warn `
+        --diagnostics $Diagnostics
+
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Host "##[error]Code style violation ($Diagnostics) in: $relPath"
+        $failed = $true
+    }
+}
+
+if ($failed)
+{
+    Write-Host ''
+    Write-Host "##[error]Code style violations detected ($Diagnostics)."
+    Write-Host '##[error]Run the following locally to fix:'
+    Write-Host "##[error]  dotnet format style <project.csproj> --severity warn --diagnostics $Diagnostics"
+    exit 1
+}
+
+Write-Host ''
+Write-Host "##[section]Code style verification passed (no $Diagnostics violations)."

--- a/src/CalculatorUITestFramework/CalculatorDriver.cs
+++ b/src/CalculatorUITestFramework/CalculatorDriver.cs
@@ -38,10 +38,10 @@ namespace CalculatorUITestFramework
 
         public void SetupCalculatorSession(TestContext context)
         {
-            this.server = new WinAppDriverLocalServer();
+            server = new WinAppDriverLocalServer();
 
             // Launch Calculator application if it is not yet launched
-            if (this.CalculatorSession == null)
+            if (CalculatorSession == null)
             {
                 // Create a new  WinAppDriver session to bring up an instance of the Calculator application
                 // Note: Multiple calculator windows (instances) share the same process Id
@@ -57,25 +57,25 @@ namespace CalculatorUITestFramework
                 }
 
                 options.AddAdditionalCapability("deviceName", "WindowsPC");
-                this.CalculatorSession = new WindowsDriver<WindowsElement>(this.server.ServiceUrl, options);
-                this.CalculatorSession.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
-                Assert.IsNotNull(this.CalculatorSession);
+                CalculatorSession = new WindowsDriver<WindowsElement>(server.ServiceUrl, options);
+                CalculatorSession.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
+                Assert.IsNotNull(CalculatorSession);
             }
         }
 
         public void TearDownCalculatorSession()
         {
             // Close the application and delete the session
-            if (this.CalculatorSession != null)
+            if (CalculatorSession != null)
             {
-                this.CalculatorSession.Quit();
-                this.CalculatorSession = null;
+                CalculatorSession.Quit();
+                CalculatorSession = null;
             }
 
-            if (this.server != null)
+            if (server != null)
             {
-                this.server.Dispose();
-                this.server = null;
+                server.Dispose();
+                server = null;
             }
         }
     }

--- a/src/CalculatorUITestFramework/CalculatorResults.cs
+++ b/src/CalculatorUITestFramework/CalculatorResults.cs
@@ -11,9 +11,9 @@ namespace CalculatorUITestFramework
     public class CalculatorResults
     {
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
-        private WindowsElement CalculatorAlwaysOnTopResults => this.session.TryFindElementByAccessibilityId("CalculatorAlwaysOnTopResults");
-        private WindowsElement CalculatorResult => this.session.TryFindElementByAccessibilityId("CalculatorResults");
-        private WindowsElement CalculatorExpression => this.session.TryFindElementByAccessibilityId("CalculatorExpression");
+        private WindowsElement CalculatorAlwaysOnTopResults => session.TryFindElementByAccessibilityId("CalculatorAlwaysOnTopResults");
+        private WindowsElement CalculatorResult => session.TryFindElementByAccessibilityId("CalculatorResults");
+        private WindowsElement CalculatorExpression => session.TryFindElementByAccessibilityId("CalculatorExpression");
 
         /// <summary>
         /// Gets the text from the display control in AoT mode and removes the narrator text that is not displayed in the UI.
@@ -21,7 +21,7 @@ namespace CalculatorUITestFramework
         /// <returns>The string shown in the UI.</returns>
         public string GetAoTCalculatorResultText()
         {
-            return this.CalculatorAlwaysOnTopResults.Text.Replace("Display is", string.Empty).Trim();
+            return CalculatorAlwaysOnTopResults.Text.Replace("Display is", string.Empty).Trim();
         }
 
         /// <summary>
@@ -30,7 +30,7 @@ namespace CalculatorUITestFramework
         /// <returns>The string shown in the UI.</returns>
         public string GetCalculatorResultText()
         {
-            return this.CalculatorResult.Text.Replace("Display is", string.Empty).Trim();
+            return CalculatorResult.Text.Replace("Display is", string.Empty).Trim();
         }
 
         /// <summary>
@@ -39,7 +39,7 @@ namespace CalculatorUITestFramework
         /// <returns>The string shown in the UI.</returns>
         public string GetCalculatorExpressionText()
         {
-            return this.CalculatorExpression.Text.Replace("Expression is", string.Empty).Trim();
+            return CalculatorExpression.Text.Replace("Expression is", string.Empty).Trim();
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace CalculatorUITestFramework
         /// <returns>The string shown in the UI.</returns>
         public void IsResultsDisplayPresent()
         {
-            Assert.IsNotNull(this.CalculatorResult);
+            Assert.IsNotNull(CalculatorResult);
         }
 
         /// <summary>

--- a/src/CalculatorUITestFramework/HistoryPanel.cs
+++ b/src/CalculatorUITestFramework/HistoryPanel.cs
@@ -13,22 +13,22 @@ namespace CalculatorUITestFramework
 {
     public class HistoryPanel
     {
-        public WindowsElement HistoryButton => this.session.TryFindElementByAccessibilityId("HistoryButton");
-        public WindowsElement ListViewItem => this.session.FindElementByClassName("ListViewItem");
-        public WindowsElement ClearHistoryButton => this.session.TryFindElementByAccessibilityId("ClearHistory");
+        public WindowsElement HistoryButton => session.TryFindElementByAccessibilityId("HistoryButton");
+        public WindowsElement ListViewItem => session.FindElementByClassName("ListViewItem");
+        public WindowsElement ClearHistoryButton => session.TryFindElementByAccessibilityId("ClearHistory");
 
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
-        private WindowsElement HistoryLabel => this.session.TryFindElementByAccessibilityId("HistoryLabel");
-        private WindowsElement HistoryListView => this.session.TryFindElementByAccessibilityId("HistoryListView");
-        private WindowsElement HistoryFlyout => this.session.TryFindElementByAccessibilityId("HistoryFlyout");
+        private WindowsElement HistoryLabel => session.TryFindElementByAccessibilityId("HistoryLabel");
+        private WindowsElement HistoryListView => session.TryFindElementByAccessibilityId("HistoryListView");
+        private WindowsElement HistoryFlyout => session.TryFindElementByAccessibilityId("HistoryFlyout");
 
         /// <summary>
         /// Opens the History Pane by clicking the History pivot label.
         /// </summary>
         public void OpenHistoryPanel()
         {
-            this.ResizeWindowToDisplayHistoryLabel();
-            this.HistoryLabel.Click();
+            ResizeWindowToDisplayHistoryLabel();
+            HistoryLabel.Click();
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace CalculatorUITestFramework
         public List<HistoryItem> GetAllHistoryListViewItems()
         {
             OpenHistoryPanel();
-            return (from item in this.HistoryListView.FindElementsByClassName("ListViewItem") select new HistoryItem(item)).ToList();
+            return (from item in HistoryListView.FindElementsByClassName("ListViewItem") select new HistoryItem(item)).ToList();
         }
 
         /// <summary>
@@ -47,11 +47,11 @@ namespace CalculatorUITestFramework
         public void ClearHistory()
         {
 
-            this.HistoryLabel.Click();
-            string source = this.session.PageSource;
+            HistoryLabel.Click();
+            string source = session.PageSource;
             if (source.Contains("ClearHistory"))
             {
-                this.ClearHistoryButton.Click();
+                ClearHistoryButton.Click();
             }
         }
 
@@ -81,7 +81,7 @@ namespace CalculatorUITestFramework
         /// </summary>
         public void OpenHistoryFlyout()
         {
-            this.ResizeWindowToDisplayHistoryButton();
+            ResizeWindowToDisplayHistoryButton();
             CalculatorApp.EnsureCalculatorHasFocus();
             CalculatorApp.Window.SendKeys(Keys.Control + "h" + Keys.Control);
             Actions moveToHistoryFlyout = new Actions(CalculatorDriver.Instance.CalculatorSession);
@@ -96,7 +96,7 @@ namespace CalculatorUITestFramework
         public List<HistoryItem> GetAllHistoryFlyoutListViewItems()
         {
             OpenHistoryFlyout();
-            return (from item in this.HistoryListView.FindElementsByClassName("ListViewItem") select new HistoryItem(item)).ToList();
+            return (from item in HistoryListView.FindElementsByClassName("ListViewItem") select new HistoryItem(item)).ToList();
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace CalculatorUITestFramework
                 throw new NotFoundException("Could not the History Label");
             }
 
-            if (!this.session.PageSource.Contains("HistoryLabel"))
+            if (!session.PageSource.Contains("HistoryLabel"))
             {
                 var height = CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size.Height;
                 CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size = new Size(width, height);
@@ -129,7 +129,7 @@ namespace CalculatorUITestFramework
                 throw new NotFoundException("Could not find the History Button");
             }
 
-            if (!this.session.PageSource.Contains("HistoryButton"))
+            if (!session.PageSource.Contains("HistoryButton"))
             {
                 var height = CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size.Height;
                 CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size = new Size(width, height);

--- a/src/CalculatorUITestFramework/MemoryPanel.cs
+++ b/src/CalculatorUITestFramework/MemoryPanel.cs
@@ -15,30 +15,30 @@ namespace CalculatorUITestFramework
 {
     public class MemoryPanel
     {
-        public WindowsElement NumberpadMCButton => this.session.TryFindElementByAccessibilityId("ClearMemoryButton");
-        public WindowsElement NumberpadMRButton => this.session.TryFindElementByAccessibilityId("MemRecall");
-        public WindowsElement NumberpadMPlusButton => this.session.TryFindElementByAccessibilityId("MemPlus");
-        public WindowsElement NumberpadMMinusButton => this.session.TryFindElementByAccessibilityId("MemMinus");
-        public WindowsElement NumberpadMSButton => this.session.TryFindElementByAccessibilityId("memButton");
-        public WindowsElement MemoryFlyoutButton => this.session.TryFindElementByAccessibilityId("MemoryButton");
-        public WindowsElement PanelClearMemoryButton => this.session.TryFindElementByAccessibilityId("ClearMemory");
-        public WindowsElement ListViewItem => this.session.FindElementByClassName("ListViewItem");
+        public WindowsElement NumberpadMCButton => session.TryFindElementByAccessibilityId("ClearMemoryButton");
+        public WindowsElement NumberpadMRButton => session.TryFindElementByAccessibilityId("MemRecall");
+        public WindowsElement NumberpadMPlusButton => session.TryFindElementByAccessibilityId("MemPlus");
+        public WindowsElement NumberpadMMinusButton => session.TryFindElementByAccessibilityId("MemMinus");
+        public WindowsElement NumberpadMSButton => session.TryFindElementByAccessibilityId("memButton");
+        public WindowsElement MemoryFlyoutButton => session.TryFindElementByAccessibilityId("MemoryButton");
+        public WindowsElement PanelClearMemoryButton => session.TryFindElementByAccessibilityId("ClearMemory");
+        public WindowsElement ListViewItem => session.FindElementByClassName("ListViewItem");
 
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
-        private WindowsElement MemoryPane => this.session.TryFindElementByAccessibilityId("MemoryPanel");
-        private WindowsElement MemoryLabel => this.session.TryFindElementByAccessibilityId("MemoryLabel");
-        private WindowsElement MemoryListView => this.session.TryFindElementByAccessibilityId("MemoryListView");
-        private WindowsElement MemoryPaneEmptyLabel => this.session.TryFindElementByAccessibilityId("MemoryPaneEmpty");
-        private WindowsElement MemoryFlyout => this.session.TryFindElementByAccessibilityId("MemoryFlyout");
+        private WindowsElement MemoryPane => session.TryFindElementByAccessibilityId("MemoryPanel");
+        private WindowsElement MemoryLabel => session.TryFindElementByAccessibilityId("MemoryLabel");
+        private WindowsElement MemoryListView => session.TryFindElementByAccessibilityId("MemoryListView");
+        private WindowsElement MemoryPaneEmptyLabel => session.TryFindElementByAccessibilityId("MemoryPaneEmpty");
+        private WindowsElement MemoryFlyout => session.TryFindElementByAccessibilityId("MemoryFlyout");
 
         /// <summary>
         /// Opens the Memory Pane by clicking the Memory pivot label.
         /// </summary>
         public void OpenMemoryPanel()
         {
-            this.ResizeWindowToDisplayMemoryLabel();
-            this.MemoryLabel.Click();
-            this.MemoryPane.WaitForDisplayed();
+            ResizeWindowToDisplayMemoryLabel();
+            MemoryLabel.Click();
+            MemoryPane.WaitForDisplayed();
         }
 
         /// <summary>
@@ -48,7 +48,7 @@ namespace CalculatorUITestFramework
         public List<MemoryItem> GetAllMemoryListViewItems()
         {
             OpenMemoryPanel();
-            return (from item in this.MemoryListView.FindElementsByClassName("ListViewItem") select new MemoryItem(item)).ToList();
+            return (from item in MemoryListView.FindElementsByClassName("ListViewItem") select new MemoryItem(item)).ToList();
         }
 
         /// <summary>
@@ -56,13 +56,13 @@ namespace CalculatorUITestFramework
         /// </summary>
         public void ClearMemoryPanel()
         {
-            this.MemoryLabel.Click();
+            MemoryLabel.Click();
 
             try
             {
-                if (this.session.PageSource.Contains("ClearMemoryButton"))
+                if (session.PageSource.Contains("ClearMemoryButton"))
                 {
-                    this.PanelClearMemoryButton.Click();
+                    PanelClearMemoryButton.Click();
                 }
                 else
                 {
@@ -73,7 +73,7 @@ namespace CalculatorUITestFramework
             {
                 if (ex.Message.Contains("element could not be located"))
                 {
-                    Assert.IsNotNull(this.MemoryPaneEmptyLabel);
+                    Assert.IsNotNull(MemoryPaneEmptyLabel);
                     return;
                 }
                 throw;
@@ -106,7 +106,7 @@ namespace CalculatorUITestFramework
         /// </summary>
         public void OpenMemoryFlyout()
         {
-            this.ResizeWindowToDisplayMemoryButton();
+            ResizeWindowToDisplayMemoryButton();
             CalculatorApp.EnsureCalculatorHasFocus();
             Actions moveToMemoryButton = new Actions(CalculatorDriver.Instance.CalculatorSession);
             moveToMemoryButton.MoveToElement(MemoryFlyoutButton);
@@ -124,7 +124,7 @@ namespace CalculatorUITestFramework
         public List<MemoryItem> GetAllMemoryFlyoutListViewItems()
         {
             OpenMemoryFlyout();
-            return (from item in this.MemoryListView.FindElementsByClassName("ListViewItem") select new MemoryItem(item)).ToList();
+            return (from item in MemoryListView.FindElementsByClassName("ListViewItem") select new MemoryItem(item)).ToList();
         }
 
         /// <summary>
@@ -137,7 +137,7 @@ namespace CalculatorUITestFramework
                 throw new NotFoundException("Could not the Memory Label");
             }
 
-            if (!this.session.PageSource.Contains("MemoryLabel"))
+            if (!session.PageSource.Contains("MemoryLabel"))
             {
                 var height = CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size.Height;
                 CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size = new Size(width, height);
@@ -158,7 +158,7 @@ namespace CalculatorUITestFramework
             }
 
             //Page source contains differnt memory button types, using hotkey info is for this specific memory button
-            if (!this.session.PageSource.Contains("Alt, M"))
+            if (!session.PageSource.Contains("Alt, M"))
             {
                 var height = CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size.Height;
                 CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size = new Size(width, height);

--- a/src/CalculatorUITestFramework/NavigationMenu.cs
+++ b/src/CalculatorUITestFramework/NavigationMenu.cs
@@ -30,8 +30,8 @@ namespace CalculatorUITestFramework
 
     public class NavigationMenu
     {
-        public WindowsElement NavigationMenuButton => this.session.TryFindElementByAccessibilityId("TogglePaneButton");
-        public WindowsElement NavigationMenuPane => this.session.TryFindElementByClassName("SplitViewPane");
+        public WindowsElement NavigationMenuButton => session.TryFindElementByAccessibilityId("TogglePaneButton");
+        public WindowsElement NavigationMenuPane => session.TryFindElementByClassName("SplitViewPane");
 
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
 
@@ -63,9 +63,9 @@ namespace CalculatorUITestFramework
                 _ => throw (new ArgumentException("The mode is not valid"))
             };
 
-            this.NavigationMenuButton.Click();
-            this.NavigationMenuPane.WaitForDisplayed();
-            this.session.TryFindElementByAccessibilityId(modeAccessibilityId).Click();
+            NavigationMenuButton.Click();
+            NavigationMenuPane.WaitForDisplayed();
+            session.TryFindElementByAccessibilityId(modeAccessibilityId).Click();
         }
     }
 }

--- a/src/CalculatorUITestFramework/NumberPad.cs
+++ b/src/CalculatorUITestFramework/NumberPad.cs
@@ -10,18 +10,18 @@ namespace CalculatorUITestFramework
 {
     public class NumberPad
     {
-        public WindowsElement Num0Button => this.session.TryFindElementByAccessibilityId("num0Button");
-        public WindowsElement Num1Button => this.session.TryFindElementByAccessibilityId("num1Button");
-        public WindowsElement Num2Button => this.session.TryFindElementByAccessibilityId("num2Button");
-        public WindowsElement Num3Button => this.session.TryFindElementByAccessibilityId("num3Button");
-        public WindowsElement Num4Button => this.session.TryFindElementByAccessibilityId("num4Button");
-        public WindowsElement Num5Button => this.session.TryFindElementByAccessibilityId("num5Button");
-        public WindowsElement Num6Button => this.session.TryFindElementByAccessibilityId("num6Button");
-        public WindowsElement Num7Button => this.session.TryFindElementByAccessibilityId("num7Button");
-        public WindowsElement Num8Button => this.session.TryFindElementByAccessibilityId("num8Button");
-        public WindowsElement Num9Button => this.session.TryFindElementByAccessibilityId("num9Button");
-        public WindowsElement DecimalButton => this.session.TryFindElementByAccessibilityId("decimalSeparatorButton");
-        public WindowsElement NegateButton => this.session.TryFindElementByAccessibilityId("negateButton");
+        public WindowsElement Num0Button => session.TryFindElementByAccessibilityId("num0Button");
+        public WindowsElement Num1Button => session.TryFindElementByAccessibilityId("num1Button");
+        public WindowsElement Num2Button => session.TryFindElementByAccessibilityId("num2Button");
+        public WindowsElement Num3Button => session.TryFindElementByAccessibilityId("num3Button");
+        public WindowsElement Num4Button => session.TryFindElementByAccessibilityId("num4Button");
+        public WindowsElement Num5Button => session.TryFindElementByAccessibilityId("num5Button");
+        public WindowsElement Num6Button => session.TryFindElementByAccessibilityId("num6Button");
+        public WindowsElement Num7Button => session.TryFindElementByAccessibilityId("num7Button");
+        public WindowsElement Num8Button => session.TryFindElementByAccessibilityId("num8Button");
+        public WindowsElement Num9Button => session.TryFindElementByAccessibilityId("num9Button");
+        public WindowsElement DecimalButton => session.TryFindElementByAccessibilityId("decimalSeparatorButton");
+        public WindowsElement NegateButton => session.TryFindElementByAccessibilityId("negateButton");
 
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
 
@@ -41,40 +41,40 @@ namespace CalculatorUITestFramework
                 switch (digit)
                 {
                     case '0':
-                        this.Num0Button.Click();
+                        Num0Button.Click();
                         break;
                     case '1':
-                        this.Num1Button.Click();
+                        Num1Button.Click();
                         break;
                     case '2':
-                        this.Num2Button.Click();
+                        Num2Button.Click();
                         break;
                     case '3':
-                        this.Num3Button.Click();
+                        Num3Button.Click();
                         break;
                     case '4':
-                        this.Num4Button.Click();
+                        Num4Button.Click();
                         break;
                     case '5':
-                        this.Num5Button.Click();
+                        Num5Button.Click();
                         break;
                     case '6':
-                        this.Num6Button.Click();
+                        Num6Button.Click();
                         break;
                     case '7':
-                        this.Num7Button.Click();
+                        Num7Button.Click();
                         break;
                     case '8':
-                        this.Num8Button.Click();
+                        Num8Button.Click();
                         break;
                     case '9':
-                        this.Num9Button.Click();
+                        Num9Button.Click();
                         break;
                     case '.':
-                        this.DecimalButton.Click();
+                        DecimalButton.Click();
                         break;
                     case '-':
-                        this.NegateButton.Click();
+                        NegateButton.Click();
                         break;
                     default:
                         throw (new ArgumentException($"{digit} is not valid"));

--- a/src/CalculatorUITestFramework/ProgrammerCalculatorPage.cs
+++ b/src/CalculatorUITestFramework/ProgrammerCalculatorPage.cs
@@ -17,7 +17,7 @@ namespace CalculatorUITestFramework
         public MemoryPanel MemoryPanel = new MemoryPanel();
         public HistoryPanel HistoryPanel = new HistoryPanel();
         public NavigationMenu NavigationMenu = new NavigationMenu();
-        public WindowsElement Header => this.session.TryFindElementByAccessibilityId("Header");
+        public WindowsElement Header => session.TryFindElementByAccessibilityId("Header");
 
         public CalculatorResults CalculatorResults = new CalculatorResults();
 
@@ -32,7 +32,7 @@ namespace CalculatorUITestFramework
         /// </summary>
         public void ClearAll()
         {
-            string source = this.session.PageSource;
+            string source = session.PageSource;
 
             if (source.Contains("clearEntryButton"))
             {

--- a/src/CalculatorUITestFramework/ProgrammerOperatorsPanel.cs
+++ b/src/CalculatorUITestFramework/ProgrammerOperatorsPanel.cs
@@ -14,110 +14,110 @@ namespace CalculatorUITestFramework
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
         public NumberPad NumberPad = new NumberPad();
 
-        public WindowsElement HexButton => this.session.TryFindElementByAccessibilityId("hexButton");
-        public WindowsElement DecButton => this.session.TryFindElementByAccessibilityId("decimalButton");
-        public WindowsElement OctButton => this.session.TryFindElementByAccessibilityId("octolButton");
-        public WindowsElement BinButton => this.session.TryFindElementByAccessibilityId("binaryButton");
-        public WindowsElement FullKeypad => this.session.TryFindElementByAccessibilityId("fullKeypad");
-        public WindowsElement BitFlip => this.session.TryFindElementByAccessibilityId("bitFlip");
-        public WindowsElement WordButton => this.session.TryFindElementByAccessibilityId("wordButton");
-        public WindowsElement QWordButton => this.session.TryFindElementByAccessibilityId("qwordButton");
-        public WindowsElement DWordButton => this.session.TryFindElementByAccessibilityId("dwordButton");
-        public WindowsElement ByteButton => this.session.TryFindElementByAccessibilityId("byteButton");
-        public WindowsElement BitwiseButton => this.session.TryFindElementByAccessibilityId("bitwiseButton");
-        public WindowsElement BitShiftButton => this.session.TryFindElementByAccessibilityId("bitShiftButton");
-        public WindowsElement AndButton => this.session.TryFindElementByAccessibilityId("andButton");
-        public WindowsElement NandButton => this.session.TryFindElementByAccessibilityId("nandButton");
-        public WindowsElement OrButton => this.session.TryFindElementByAccessibilityId("orButton");
-        public WindowsElement NorButton => this.session.TryFindElementByAccessibilityId("norButton");
-        public WindowsElement NotButton => this.session.TryFindElementByAccessibilityId("notButton");
-        public WindowsElement XorButton => this.session.TryFindElementByAccessibilityId("xorButton");
-        public WindowsElement ArithmeticShiftButton => this.session.TryFindElementByAccessibilityId("arithmeticShiftButton");
-        public WindowsElement LogicalShiftButton => this.session.TryFindElementByAccessibilityId("logicalShiftButton");
-        public WindowsElement RotateCircularButton => this.session.TryFindElementByAccessibilityId("rotateCircularButton");
-        public WindowsElement RotateCarryShiftButton => this.session.TryFindElementByAccessibilityId("rotateCarryShiftButton");
-        public WindowsElement AButton => this.session.TryFindElementByAccessibilityId("aButton");
-        public WindowsElement BButton => this.session.TryFindElementByAccessibilityId("bButton");
-        public WindowsElement CButton => this.session.TryFindElementByAccessibilityId("cButton");
-        public WindowsElement DButton => this.session.TryFindElementByAccessibilityId("dButton");
-        public WindowsElement EButton => this.session.TryFindElementByAccessibilityId("eButton");
-        public WindowsElement FButton => this.session.TryFindElementByAccessibilityId("fButton");
-        public WindowsElement LeftShiftButton => this.session.TryFindElementByAccessibilityId("lshButton");
-        public WindowsElement RightShiftButton => this.session.TryFindElementByAccessibilityId("rshButton");
-        public WindowsElement LeftShiftLogicalButton => this.session.TryFindElementByAccessibilityId("lshLogicalButton");
-        public WindowsElement RightShiftLogicalButton => this.session.TryFindElementByAccessibilityId("rshLogicalButton");
-        public WindowsElement RoLButton => this.session.TryFindElementByAccessibilityId("rolButton");
-        public WindowsElement RoRButton => this.session.TryFindElementByAccessibilityId("rorButton");
-        public WindowsElement RoRCarryButton => this.session.TryFindElementByAccessibilityId("rorCarryButton");
-        public WindowsElement Bit0 => this.session.TryFindElementByAccessibilityId("Bit0");
-        public WindowsElement Bit1 => this.session.TryFindElementByAccessibilityId("Bit1");
-        public WindowsElement Bit2 => this.session.TryFindElementByAccessibilityId("Bit2");
-        public WindowsElement Bit3 => this.session.TryFindElementByAccessibilityId("Bit3");
-        public WindowsElement Bit4 => this.session.TryFindElementByAccessibilityId("Bit4");
-        public WindowsElement Bit5 => this.session.TryFindElementByAccessibilityId("Bit5");
-        public WindowsElement Bit6 => this.session.TryFindElementByAccessibilityId("Bit6");
-        public WindowsElement Bit7 => this.session.TryFindElementByAccessibilityId("Bit7");
-        public WindowsElement Bit8 => this.session.TryFindElementByAccessibilityId("Bit8");
-        public WindowsElement Bit9 => this.session.TryFindElementByAccessibilityId("Bit9");
-        public WindowsElement Bit10 => this.session.TryFindElementByAccessibilityId("Bit10");
-        public WindowsElement Bit11 => this.session.TryFindElementByAccessibilityId("Bit11");
-        public WindowsElement Bit12 => this.session.TryFindElementByAccessibilityId("Bit12");
-        public WindowsElement Bit13 => this.session.TryFindElementByAccessibilityId("Bit13");
-        public WindowsElement Bit14 => this.session.TryFindElementByAccessibilityId("Bit14");
-        public WindowsElement Bit15 => this.session.TryFindElementByAccessibilityId("Bit15");
-        public WindowsElement Bit16 => this.session.TryFindElementByAccessibilityId("Bit16");
-        public WindowsElement Bit17 => this.session.TryFindElementByAccessibilityId("Bit17");
-        public WindowsElement Bit18 => this.session.TryFindElementByAccessibilityId("Bit18");
-        public WindowsElement Bit19 => this.session.TryFindElementByAccessibilityId("Bit19");
-        public WindowsElement Bit20 => this.session.TryFindElementByAccessibilityId("Bit20");
-        public WindowsElement Bit21 => this.session.TryFindElementByAccessibilityId("Bit21");
-        public WindowsElement Bit22 => this.session.TryFindElementByAccessibilityId("Bit22");
-        public WindowsElement Bit23 => this.session.TryFindElementByAccessibilityId("Bit23");
-        public WindowsElement Bit24 => this.session.TryFindElementByAccessibilityId("Bit24");
-        public WindowsElement Bit25 => this.session.TryFindElementByAccessibilityId("Bit25");
-        public WindowsElement Bit26 => this.session.TryFindElementByAccessibilityId("Bit26");
-        public WindowsElement Bit27 => this.session.TryFindElementByAccessibilityId("Bit27");
-        public WindowsElement Bit28 => this.session.TryFindElementByAccessibilityId("Bit28");
-        public WindowsElement Bit29 => this.session.TryFindElementByAccessibilityId("Bit29");
-        public WindowsElement Bit30 => this.session.TryFindElementByAccessibilityId("Bit30");
-        public WindowsElement Bit31 => this.session.TryFindElementByAccessibilityId("Bit31");
-        public WindowsElement Bit32 => this.session.TryFindElementByAccessibilityId("Bit32");
-        public WindowsElement Bit33 => this.session.TryFindElementByAccessibilityId("Bit33");
-        public WindowsElement Bit34 => this.session.TryFindElementByAccessibilityId("Bit34");
-        public WindowsElement Bit35 => this.session.TryFindElementByAccessibilityId("Bit35");
-        public WindowsElement Bit36 => this.session.TryFindElementByAccessibilityId("Bit36");
-        public WindowsElement Bit37 => this.session.TryFindElementByAccessibilityId("Bit37");
-        public WindowsElement Bit38 => this.session.TryFindElementByAccessibilityId("Bit38");
-        public WindowsElement Bit39 => this.session.TryFindElementByAccessibilityId("Bit39");
-        public WindowsElement Bit40 => this.session.TryFindElementByAccessibilityId("Bit40");
-        public WindowsElement Bit41 => this.session.TryFindElementByAccessibilityId("Bit41");
-        public WindowsElement Bit42 => this.session.TryFindElementByAccessibilityId("Bit42");
-        public WindowsElement Bit43 => this.session.TryFindElementByAccessibilityId("Bit43");
-        public WindowsElement Bit44 => this.session.TryFindElementByAccessibilityId("Bit44");
-        public WindowsElement Bit45 => this.session.TryFindElementByAccessibilityId("Bit45");
-        public WindowsElement Bit46 => this.session.TryFindElementByAccessibilityId("Bit46");
-        public WindowsElement Bit47 => this.session.TryFindElementByAccessibilityId("Bit47");
-        public WindowsElement Bit48 => this.session.TryFindElementByAccessibilityId("Bit48");
-        public WindowsElement Bit49 => this.session.TryFindElementByAccessibilityId("Bit49");
-        public WindowsElement Bit50 => this.session.TryFindElementByAccessibilityId("Bit50");
-        public WindowsElement Bit51 => this.session.TryFindElementByAccessibilityId("Bit51");
-        public WindowsElement Bit52 => this.session.TryFindElementByAccessibilityId("Bit52");
-        public WindowsElement Bit53 => this.session.TryFindElementByAccessibilityId("Bit53");
-        public WindowsElement Bit54 => this.session.TryFindElementByAccessibilityId("Bit54");
-        public WindowsElement Bit55 => this.session.TryFindElementByAccessibilityId("Bit55");
-        public WindowsElement Bit56 => this.session.TryFindElementByAccessibilityId("Bit56");
-        public WindowsElement Bit57 => this.session.TryFindElementByAccessibilityId("Bit57");
-        public WindowsElement Bit58 => this.session.TryFindElementByAccessibilityId("Bit58");
-        public WindowsElement Bit59 => this.session.TryFindElementByAccessibilityId("Bit59");
-        public WindowsElement Bit60 => this.session.TryFindElementByAccessibilityId("Bit60");
-        public WindowsElement Bit61 => this.session.TryFindElementByAccessibilityId("Bit61");
-        public WindowsElement Bit62 => this.session.TryFindElementByAccessibilityId("Bit62");
-        public WindowsElement Bit63 => this.session.TryFindElementByAccessibilityId("Bit63");
+        public WindowsElement HexButton => session.TryFindElementByAccessibilityId("hexButton");
+        public WindowsElement DecButton => session.TryFindElementByAccessibilityId("decimalButton");
+        public WindowsElement OctButton => session.TryFindElementByAccessibilityId("octolButton");
+        public WindowsElement BinButton => session.TryFindElementByAccessibilityId("binaryButton");
+        public WindowsElement FullKeypad => session.TryFindElementByAccessibilityId("fullKeypad");
+        public WindowsElement BitFlip => session.TryFindElementByAccessibilityId("bitFlip");
+        public WindowsElement WordButton => session.TryFindElementByAccessibilityId("wordButton");
+        public WindowsElement QWordButton => session.TryFindElementByAccessibilityId("qwordButton");
+        public WindowsElement DWordButton => session.TryFindElementByAccessibilityId("dwordButton");
+        public WindowsElement ByteButton => session.TryFindElementByAccessibilityId("byteButton");
+        public WindowsElement BitwiseButton => session.TryFindElementByAccessibilityId("bitwiseButton");
+        public WindowsElement BitShiftButton => session.TryFindElementByAccessibilityId("bitShiftButton");
+        public WindowsElement AndButton => session.TryFindElementByAccessibilityId("andButton");
+        public WindowsElement NandButton => session.TryFindElementByAccessibilityId("nandButton");
+        public WindowsElement OrButton => session.TryFindElementByAccessibilityId("orButton");
+        public WindowsElement NorButton => session.TryFindElementByAccessibilityId("norButton");
+        public WindowsElement NotButton => session.TryFindElementByAccessibilityId("notButton");
+        public WindowsElement XorButton => session.TryFindElementByAccessibilityId("xorButton");
+        public WindowsElement ArithmeticShiftButton => session.TryFindElementByAccessibilityId("arithmeticShiftButton");
+        public WindowsElement LogicalShiftButton => session.TryFindElementByAccessibilityId("logicalShiftButton");
+        public WindowsElement RotateCircularButton => session.TryFindElementByAccessibilityId("rotateCircularButton");
+        public WindowsElement RotateCarryShiftButton => session.TryFindElementByAccessibilityId("rotateCarryShiftButton");
+        public WindowsElement AButton => session.TryFindElementByAccessibilityId("aButton");
+        public WindowsElement BButton => session.TryFindElementByAccessibilityId("bButton");
+        public WindowsElement CButton => session.TryFindElementByAccessibilityId("cButton");
+        public WindowsElement DButton => session.TryFindElementByAccessibilityId("dButton");
+        public WindowsElement EButton => session.TryFindElementByAccessibilityId("eButton");
+        public WindowsElement FButton => session.TryFindElementByAccessibilityId("fButton");
+        public WindowsElement LeftShiftButton => session.TryFindElementByAccessibilityId("lshButton");
+        public WindowsElement RightShiftButton => session.TryFindElementByAccessibilityId("rshButton");
+        public WindowsElement LeftShiftLogicalButton => session.TryFindElementByAccessibilityId("lshLogicalButton");
+        public WindowsElement RightShiftLogicalButton => session.TryFindElementByAccessibilityId("rshLogicalButton");
+        public WindowsElement RoLButton => session.TryFindElementByAccessibilityId("rolButton");
+        public WindowsElement RoRButton => session.TryFindElementByAccessibilityId("rorButton");
+        public WindowsElement RoRCarryButton => session.TryFindElementByAccessibilityId("rorCarryButton");
+        public WindowsElement Bit0 => session.TryFindElementByAccessibilityId("Bit0");
+        public WindowsElement Bit1 => session.TryFindElementByAccessibilityId("Bit1");
+        public WindowsElement Bit2 => session.TryFindElementByAccessibilityId("Bit2");
+        public WindowsElement Bit3 => session.TryFindElementByAccessibilityId("Bit3");
+        public WindowsElement Bit4 => session.TryFindElementByAccessibilityId("Bit4");
+        public WindowsElement Bit5 => session.TryFindElementByAccessibilityId("Bit5");
+        public WindowsElement Bit6 => session.TryFindElementByAccessibilityId("Bit6");
+        public WindowsElement Bit7 => session.TryFindElementByAccessibilityId("Bit7");
+        public WindowsElement Bit8 => session.TryFindElementByAccessibilityId("Bit8");
+        public WindowsElement Bit9 => session.TryFindElementByAccessibilityId("Bit9");
+        public WindowsElement Bit10 => session.TryFindElementByAccessibilityId("Bit10");
+        public WindowsElement Bit11 => session.TryFindElementByAccessibilityId("Bit11");
+        public WindowsElement Bit12 => session.TryFindElementByAccessibilityId("Bit12");
+        public WindowsElement Bit13 => session.TryFindElementByAccessibilityId("Bit13");
+        public WindowsElement Bit14 => session.TryFindElementByAccessibilityId("Bit14");
+        public WindowsElement Bit15 => session.TryFindElementByAccessibilityId("Bit15");
+        public WindowsElement Bit16 => session.TryFindElementByAccessibilityId("Bit16");
+        public WindowsElement Bit17 => session.TryFindElementByAccessibilityId("Bit17");
+        public WindowsElement Bit18 => session.TryFindElementByAccessibilityId("Bit18");
+        public WindowsElement Bit19 => session.TryFindElementByAccessibilityId("Bit19");
+        public WindowsElement Bit20 => session.TryFindElementByAccessibilityId("Bit20");
+        public WindowsElement Bit21 => session.TryFindElementByAccessibilityId("Bit21");
+        public WindowsElement Bit22 => session.TryFindElementByAccessibilityId("Bit22");
+        public WindowsElement Bit23 => session.TryFindElementByAccessibilityId("Bit23");
+        public WindowsElement Bit24 => session.TryFindElementByAccessibilityId("Bit24");
+        public WindowsElement Bit25 => session.TryFindElementByAccessibilityId("Bit25");
+        public WindowsElement Bit26 => session.TryFindElementByAccessibilityId("Bit26");
+        public WindowsElement Bit27 => session.TryFindElementByAccessibilityId("Bit27");
+        public WindowsElement Bit28 => session.TryFindElementByAccessibilityId("Bit28");
+        public WindowsElement Bit29 => session.TryFindElementByAccessibilityId("Bit29");
+        public WindowsElement Bit30 => session.TryFindElementByAccessibilityId("Bit30");
+        public WindowsElement Bit31 => session.TryFindElementByAccessibilityId("Bit31");
+        public WindowsElement Bit32 => session.TryFindElementByAccessibilityId("Bit32");
+        public WindowsElement Bit33 => session.TryFindElementByAccessibilityId("Bit33");
+        public WindowsElement Bit34 => session.TryFindElementByAccessibilityId("Bit34");
+        public WindowsElement Bit35 => session.TryFindElementByAccessibilityId("Bit35");
+        public WindowsElement Bit36 => session.TryFindElementByAccessibilityId("Bit36");
+        public WindowsElement Bit37 => session.TryFindElementByAccessibilityId("Bit37");
+        public WindowsElement Bit38 => session.TryFindElementByAccessibilityId("Bit38");
+        public WindowsElement Bit39 => session.TryFindElementByAccessibilityId("Bit39");
+        public WindowsElement Bit40 => session.TryFindElementByAccessibilityId("Bit40");
+        public WindowsElement Bit41 => session.TryFindElementByAccessibilityId("Bit41");
+        public WindowsElement Bit42 => session.TryFindElementByAccessibilityId("Bit42");
+        public WindowsElement Bit43 => session.TryFindElementByAccessibilityId("Bit43");
+        public WindowsElement Bit44 => session.TryFindElementByAccessibilityId("Bit44");
+        public WindowsElement Bit45 => session.TryFindElementByAccessibilityId("Bit45");
+        public WindowsElement Bit46 => session.TryFindElementByAccessibilityId("Bit46");
+        public WindowsElement Bit47 => session.TryFindElementByAccessibilityId("Bit47");
+        public WindowsElement Bit48 => session.TryFindElementByAccessibilityId("Bit48");
+        public WindowsElement Bit49 => session.TryFindElementByAccessibilityId("Bit49");
+        public WindowsElement Bit50 => session.TryFindElementByAccessibilityId("Bit50");
+        public WindowsElement Bit51 => session.TryFindElementByAccessibilityId("Bit51");
+        public WindowsElement Bit52 => session.TryFindElementByAccessibilityId("Bit52");
+        public WindowsElement Bit53 => session.TryFindElementByAccessibilityId("Bit53");
+        public WindowsElement Bit54 => session.TryFindElementByAccessibilityId("Bit54");
+        public WindowsElement Bit55 => session.TryFindElementByAccessibilityId("Bit55");
+        public WindowsElement Bit56 => session.TryFindElementByAccessibilityId("Bit56");
+        public WindowsElement Bit57 => session.TryFindElementByAccessibilityId("Bit57");
+        public WindowsElement Bit58 => session.TryFindElementByAccessibilityId("Bit58");
+        public WindowsElement Bit59 => session.TryFindElementByAccessibilityId("Bit59");
+        public WindowsElement Bit60 => session.TryFindElementByAccessibilityId("Bit60");
+        public WindowsElement Bit61 => session.TryFindElementByAccessibilityId("Bit61");
+        public WindowsElement Bit62 => session.TryFindElementByAccessibilityId("Bit62");
+        public WindowsElement Bit63 => session.TryFindElementByAccessibilityId("Bit63");
 
         public void SetArithmeticShift()
         {
             BitShiftButton.Click();
-            if (this.ArithmeticShiftButton.GetAttribute("isEnabled") != "True")
+            if (ArithmeticShiftButton.GetAttribute("isEnabled") != "True")
             {
                 ArithmeticShiftButton.Click();
             }
@@ -129,7 +129,7 @@ namespace CalculatorUITestFramework
         public void SetLogicalShift()
         {
             BitShiftButton.Click();
-            if (this.LogicalShiftButton.GetAttribute("isEnabled") != "True")
+            if (LogicalShiftButton.GetAttribute("isEnabled") != "True")
             {
                 LogicalShiftButton.Click();
             }
@@ -141,7 +141,7 @@ namespace CalculatorUITestFramework
         public void SetRotateCircularShift()
         {
             BitShiftButton.Click();
-            if (this.RotateCircularButton.GetAttribute("isEnabled") != "True")
+            if (RotateCircularButton.GetAttribute("isEnabled") != "True")
             {
                 RotateCircularButton.Click();
             }
@@ -153,7 +153,7 @@ namespace CalculatorUITestFramework
         public void SetRotateThroughCarryCircularShift()
         {
             BitShiftButton.Click();
-            if (this.RotateCarryShiftButton.GetAttribute("isEnabled") != "True")
+            if (RotateCarryShiftButton.GetAttribute("isEnabled") != "True")
             {
                 RotateCarryShiftButton.Click();
             }
@@ -164,7 +164,7 @@ namespace CalculatorUITestFramework
         }
         public void ResetWordSize()
         {
-            string source = this.session.PageSource;
+            string source = session.PageSource;
             if (source.Contains("qwordButton"))
             {
                 return;

--- a/src/CalculatorUITestFramework/ScientificCalculatorPage.cs
+++ b/src/CalculatorUITestFramework/ScientificCalculatorPage.cs
@@ -16,14 +16,14 @@ namespace CalculatorUITestFramework
         public MemoryPanel MemoryPanel = new MemoryPanel();
         public HistoryPanel HistoryPanel = new HistoryPanel();
         public NavigationMenu NavigationMenu = new NavigationMenu();
-        public WindowsElement Header => this.session.TryFindElementByAccessibilityId("Header");
+        public WindowsElement Header => session.TryFindElementByAccessibilityId("Header");
 
         public CalculatorResults CalculatorResults = new CalculatorResults();
 
         public void NavigateToScientificCalculator()
         {
             // Ensure that calculator is in scientific mode
-            this.NavigationMenu.ChangeCalculatorMode(CalculatorMode.ScientificCalculator);
+            NavigationMenu.ChangeCalculatorMode(CalculatorMode.ScientificCalculator);
         }
 
         /// <summary>
@@ -31,16 +31,16 @@ namespace CalculatorUITestFramework
         /// </summary>
         public void ClearAll()
         {
-            string source = this.session.PageSource;
+            string source = session.PageSource;
 
             if (source.Contains("clearEntryButton"))
             {
-                this.StandardOperators.ClearEntryButton.Click();
-                source = this.session.PageSource;
+                StandardOperators.ClearEntryButton.Click();
+                source = session.PageSource;
             }
             if (source.Contains("clearButton"))
             {
-                this.StandardOperators.ClearButton.Click();
+                StandardOperators.ClearButton.Click();
             }
             MemoryPanel.ResizeWindowToDisplayMemoryLabel();
             HistoryPanel.ClearHistory();

--- a/src/CalculatorUITestFramework/ScientificOperatorsPanel.cs
+++ b/src/CalculatorUITestFramework/ScientificOperatorsPanel.cs
@@ -27,66 +27,66 @@ namespace CalculatorUITestFramework
     public class ScientificOperatorsPanel
     {
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
-        public WindowsElement XPower3Button => this.session.TryFindElementByAccessibilityId("xpower3Button");
-        public WindowsElement XPowerYButton => this.session.TryFindElementByAccessibilityId("powerButton");
-        public WindowsElement PowerOf10Button => this.session.TryFindElementByAccessibilityId("powerOf10Button");
-        public WindowsElement LogButton => this.session.TryFindElementByAccessibilityId("logBase10Button");
-        public WindowsElement LnButton => this.session.TryFindElementByAccessibilityId("logBaseEButton");
-        public WindowsElement PiButton => this.session.TryFindElementByAccessibilityId("piButton");
-        public WindowsElement EulerButton => this.session.TryFindElementByAccessibilityId("eulerButton");
-        public WindowsElement AbsButton => this.session.TryFindElementByAccessibilityId("absButton");
-        public WindowsElement ExpButton => this.session.TryFindElementByAccessibilityId("expButton");
-        public WindowsElement ModButton => this.session.TryFindElementByAccessibilityId("modButton");
-        public WindowsElement ParenthesisLeftButton => this.session.TryFindElementByAccessibilityId("openParenthesisButton");
-        public WindowsElement ParenthesisRightButton => this.session.TryFindElementByAccessibilityId("closeParenthesisButton");
-        public WindowsElement FactorialButton => this.session.TryFindElementByAccessibilityId("factorialButton");
-        public WindowsElement BackSpaceButton => this.session.TryFindElementByAccessibilityId("backSpaceButton");
-        public WindowsElement DegButton => this.session.TryFindElementByAccessibilityId("degButton");
-        public WindowsElement RadButton => this.session.TryFindElementByAccessibilityId("radButton");
-        public WindowsElement GradButton => this.session.TryFindElementByAccessibilityId("gradButton");
-        public WindowsElement AngleOperator => this.session.TryFindElementByAccessibilityId("ScientificAngleOperators");
-        public WindowsElement TrigButton => this.session.TryFindElementByAccessibilityId("trigButton");
-        public WindowsElement FuncButton => this.session.TryFindElementByAccessibilityId("funcButton");
-        public WindowsElement SinButton => this.session.TryFindElementByAccessibilityId("sinButton");
-        public WindowsElement CosButton => this.session.TryFindElementByAccessibilityId("cosButton");
-        public WindowsElement TanButton => this.session.TryFindElementByAccessibilityId("tanButton");
-        public WindowsElement CscButton => this.session.TryFindElementByAccessibilityId("cscButton");
-        public WindowsElement SecButton => this.session.TryFindElementByAccessibilityId("secButton");
-        public WindowsElement CotButton => this.session.TryFindElementByAccessibilityId("cotButton");
-        public WindowsElement TrigShiftButton => this.session.TryFindElementByAccessibilityId("trigShiftButton");
-        public WindowsElement HypShiftButton => this.session.TryFindElementByAccessibilityId("hypShiftButton");
-        public WindowsElement InvSinButton => this.session.TryFindElementByAccessibilityId("invsinButton");
-        public WindowsElement InvCosButton => this.session.TryFindElementByAccessibilityId("invcosButton");
-        public WindowsElement InvTanButton => this.session.TryFindElementByAccessibilityId("invtanButton");
-        public WindowsElement InvCscButton => this.session.TryFindElementByAccessibilityId("invcscButton");
-        public WindowsElement InvSecButton => this.session.TryFindElementByAccessibilityId("invsecButton");
-        public WindowsElement InvCotButton => this.session.TryFindElementByAccessibilityId("invcotButton");
-        public WindowsElement SinhButton => this.session.TryFindElementByAccessibilityId("sinhButton");
-        public WindowsElement CoshButton => this.session.TryFindElementByAccessibilityId("coshButton");
-        public WindowsElement TanhButton => this.session.TryFindElementByAccessibilityId("tanhButton");
-        public WindowsElement CschButton => this.session.TryFindElementByAccessibilityId("cschButton");
-        public WindowsElement SechButton => this.session.TryFindElementByAccessibilityId("sechButton");
-        public WindowsElement CothButton => this.session.TryFindElementByAccessibilityId("cothButton");
-        public WindowsElement InvSinhButton => this.session.TryFindElementByAccessibilityId("invsinhButton");
-        public WindowsElement InvCoshButton => this.session.TryFindElementByAccessibilityId("invcoshButton");
-        public WindowsElement InvTanhButton => this.session.TryFindElementByAccessibilityId("invtanhButton");
-        public WindowsElement InvCschButton => this.session.TryFindElementByAccessibilityId("invcschButton");
-        public WindowsElement InvSechButton => this.session.TryFindElementByAccessibilityId("invsechButton");
-        public WindowsElement InvCothButton => this.session.TryFindElementByAccessibilityId("invcothButton");
-        public WindowsElement FloorButton => this.session.TryFindElementByAccessibilityId("floorButton");
-        public WindowsElement CeilButton => this.session.TryFindElementByAccessibilityId("ceilButton");
-        public WindowsElement RandButton => this.session.TryFindElementByAccessibilityId("randButton");
-        public WindowsElement DmsButton => this.session.TryFindElementByAccessibilityId("dmsButton");
-        public WindowsElement DegreesButton => this.session.TryFindElementByAccessibilityId("degreesButton");
-        public WindowsElement FixedToExponentialButton => this.session.TryFindElementByAccessibilityId("ftoeButton");
-        public WindowsElement NegateButton => this.session.TryFindElementByAccessibilityId("negateButton");
-        public WindowsElement ShiftButton => this.session.TryFindElementByAccessibilityId("shiftButton");
-        public WindowsElement TrigFlyout => this.session.TryFindElementByAccessibilityId("Trigflyout");
-        public WindowsElement LightDismiss => this.session.TryFindElementByAccessibilityId("Light Dismiss");
+        public WindowsElement XPower3Button => session.TryFindElementByAccessibilityId("xpower3Button");
+        public WindowsElement XPowerYButton => session.TryFindElementByAccessibilityId("powerButton");
+        public WindowsElement PowerOf10Button => session.TryFindElementByAccessibilityId("powerOf10Button");
+        public WindowsElement LogButton => session.TryFindElementByAccessibilityId("logBase10Button");
+        public WindowsElement LnButton => session.TryFindElementByAccessibilityId("logBaseEButton");
+        public WindowsElement PiButton => session.TryFindElementByAccessibilityId("piButton");
+        public WindowsElement EulerButton => session.TryFindElementByAccessibilityId("eulerButton");
+        public WindowsElement AbsButton => session.TryFindElementByAccessibilityId("absButton");
+        public WindowsElement ExpButton => session.TryFindElementByAccessibilityId("expButton");
+        public WindowsElement ModButton => session.TryFindElementByAccessibilityId("modButton");
+        public WindowsElement ParenthesisLeftButton => session.TryFindElementByAccessibilityId("openParenthesisButton");
+        public WindowsElement ParenthesisRightButton => session.TryFindElementByAccessibilityId("closeParenthesisButton");
+        public WindowsElement FactorialButton => session.TryFindElementByAccessibilityId("factorialButton");
+        public WindowsElement BackSpaceButton => session.TryFindElementByAccessibilityId("backSpaceButton");
+        public WindowsElement DegButton => session.TryFindElementByAccessibilityId("degButton");
+        public WindowsElement RadButton => session.TryFindElementByAccessibilityId("radButton");
+        public WindowsElement GradButton => session.TryFindElementByAccessibilityId("gradButton");
+        public WindowsElement AngleOperator => session.TryFindElementByAccessibilityId("ScientificAngleOperators");
+        public WindowsElement TrigButton => session.TryFindElementByAccessibilityId("trigButton");
+        public WindowsElement FuncButton => session.TryFindElementByAccessibilityId("funcButton");
+        public WindowsElement SinButton => session.TryFindElementByAccessibilityId("sinButton");
+        public WindowsElement CosButton => session.TryFindElementByAccessibilityId("cosButton");
+        public WindowsElement TanButton => session.TryFindElementByAccessibilityId("tanButton");
+        public WindowsElement CscButton => session.TryFindElementByAccessibilityId("cscButton");
+        public WindowsElement SecButton => session.TryFindElementByAccessibilityId("secButton");
+        public WindowsElement CotButton => session.TryFindElementByAccessibilityId("cotButton");
+        public WindowsElement TrigShiftButton => session.TryFindElementByAccessibilityId("trigShiftButton");
+        public WindowsElement HypShiftButton => session.TryFindElementByAccessibilityId("hypShiftButton");
+        public WindowsElement InvSinButton => session.TryFindElementByAccessibilityId("invsinButton");
+        public WindowsElement InvCosButton => session.TryFindElementByAccessibilityId("invcosButton");
+        public WindowsElement InvTanButton => session.TryFindElementByAccessibilityId("invtanButton");
+        public WindowsElement InvCscButton => session.TryFindElementByAccessibilityId("invcscButton");
+        public WindowsElement InvSecButton => session.TryFindElementByAccessibilityId("invsecButton");
+        public WindowsElement InvCotButton => session.TryFindElementByAccessibilityId("invcotButton");
+        public WindowsElement SinhButton => session.TryFindElementByAccessibilityId("sinhButton");
+        public WindowsElement CoshButton => session.TryFindElementByAccessibilityId("coshButton");
+        public WindowsElement TanhButton => session.TryFindElementByAccessibilityId("tanhButton");
+        public WindowsElement CschButton => session.TryFindElementByAccessibilityId("cschButton");
+        public WindowsElement SechButton => session.TryFindElementByAccessibilityId("sechButton");
+        public WindowsElement CothButton => session.TryFindElementByAccessibilityId("cothButton");
+        public WindowsElement InvSinhButton => session.TryFindElementByAccessibilityId("invsinhButton");
+        public WindowsElement InvCoshButton => session.TryFindElementByAccessibilityId("invcoshButton");
+        public WindowsElement InvTanhButton => session.TryFindElementByAccessibilityId("invtanhButton");
+        public WindowsElement InvCschButton => session.TryFindElementByAccessibilityId("invcschButton");
+        public WindowsElement InvSechButton => session.TryFindElementByAccessibilityId("invsechButton");
+        public WindowsElement InvCothButton => session.TryFindElementByAccessibilityId("invcothButton");
+        public WindowsElement FloorButton => session.TryFindElementByAccessibilityId("floorButton");
+        public WindowsElement CeilButton => session.TryFindElementByAccessibilityId("ceilButton");
+        public WindowsElement RandButton => session.TryFindElementByAccessibilityId("randButton");
+        public WindowsElement DmsButton => session.TryFindElementByAccessibilityId("dmsButton");
+        public WindowsElement DegreesButton => session.TryFindElementByAccessibilityId("degreesButton");
+        public WindowsElement FixedToExponentialButton => session.TryFindElementByAccessibilityId("ftoeButton");
+        public WindowsElement NegateButton => session.TryFindElementByAccessibilityId("negateButton");
+        public WindowsElement ShiftButton => session.TryFindElementByAccessibilityId("shiftButton");
+        public WindowsElement TrigFlyout => session.TryFindElementByAccessibilityId("Trigflyout");
+        public WindowsElement LightDismiss => session.TryFindElementByAccessibilityId("Light Dismiss");
         private WindowsElement DegRadGradButton => GetAngleOperatorButton();
         private WindowsElement GetAngleOperatorButton()
         {
-            string source = this.session.PageSource;
+            string source = session.PageSource;
             if (source.Contains("degButton"))
             {
                 return DegButton;
@@ -116,15 +116,15 @@ namespace CalculatorUITestFramework
                 AngleOperatorState.Radians => "radButton",
                 _ => throw new NotImplementedException()
             };
-            while (this.DegRadGradButton.GetAttribute("AutomationId") != desiredId)
+            while (DegRadGradButton.GetAttribute("AutomationId") != desiredId)
             {
-                this.DegRadGradButton.Click();
+                DegRadGradButton.Click();
             }
         }
 
         public void ResetFEButton(FEButtonState value)
         {
-            if (this.FixedToExponentialButton.GetAttribute("Toggle.ToggleState") != "0")
+            if (FixedToExponentialButton.GetAttribute("Toggle.ToggleState") != "0")
             {
                 FixedToExponentialButton.Click();
             }
@@ -133,7 +133,7 @@ namespace CalculatorUITestFramework
         public WindowsElement ResetTrigDropdownToggles()
         {
             TrigButton.Click();
-            string source = this.session.PageSource;
+            string source = session.PageSource;
             if (source.Contains("sinButton"))
             {
                 LightDismiss.Click();

--- a/src/CalculatorUITestFramework/StandardAoTCalculatorPage.cs
+++ b/src/CalculatorUITestFramework/StandardAoTCalculatorPage.cs
@@ -18,8 +18,8 @@ namespace CalculatorUITestFramework
     {
         public StandardOperatorsPanel StandardOperators = new StandardOperatorsPanel();
         public NavigationMenu NavigationMenu = new NavigationMenu();
-        public WindowsElement EnterAlwaysOnTopButton => this.session.TryFindElementByAccessibilityId("NormalAlwaysOnTopButton");
-        public WindowsElement ExitAlwaysOnTopButton => this.session.TryFindElementByAccessibilityId("ExitAlwaysOnTopButton");
+        public WindowsElement EnterAlwaysOnTopButton => session.TryFindElementByAccessibilityId("NormalAlwaysOnTopButton");
+        public WindowsElement ExitAlwaysOnTopButton => session.TryFindElementByAccessibilityId("ExitAlwaysOnTopButton");
         public AppiumWebElement ToolTip => CalculatorDriver.Instance.CalculatorSession.FindElementByClassName("ToolTip").FindElementByClassName("TextBlock");
 
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
@@ -29,15 +29,15 @@ namespace CalculatorUITestFramework
         ///// </summary>
         public void NavigateToStandardMode()
         {
-            string source = this.session.PageSource;
+            string source = session.PageSource;
             if (source.Contains("ExitAlwaysOnTopButton"))
             {
-                this.ExitAlwaysOnTopButton.Click();
+                ExitAlwaysOnTopButton.Click();
                 Assert.AreEqual("Standard", CalculatorApp.GetCalculatorHeaderText());
             }
             else
             {
-                source = this.session.PageSource;
+                source = session.PageSource;
                 if (source.Contains("NormalAlwaysOnTopButton"))
                 {
                     return;
@@ -54,11 +54,11 @@ namespace CalculatorUITestFramework
         ///// </summary>
         public void NavigateToStandardAoTMode()
         {
-            string source = this.session.PageSource;
+            string source = session.PageSource;
             if (source.Contains("NormalAlwaysOnTopButton"))
             {
-                this.EnterAlwaysOnTopButton.Click();
-                this.ExitAlwaysOnTopButton.WaitForDisplayed();
+                EnterAlwaysOnTopButton.Click();
+                ExitAlwaysOnTopButton.WaitForDisplayed();
                 source = CalculatorDriver.Instance.CalculatorSession.PageSource;
                 if (source.Contains("Header"))
                 {
@@ -72,7 +72,7 @@ namespace CalculatorUITestFramework
         ///// </summary>
         public string GetAoTToolTipText()
         {
-            string source = this.session.PageSource;
+            string source = session.PageSource;
             if ((source.Contains("Keep on top")) || (source.Contains("Back to full view")))
             {
                 if (source.Contains("Keep on top"))
@@ -100,7 +100,7 @@ namespace CalculatorUITestFramework
         /// </summary>
         public bool IsKeepOnTopButtonPresent()
         {
-            string source = this.session.PageSource;
+            string source = session.PageSource;
             return source.Contains("Keep on top");
         }
 
@@ -109,7 +109,7 @@ namespace CalculatorUITestFramework
         /// </summary>
         public bool IsInAlwaysOnTopMode()
         {
-            string source = this.session.PageSource;
+            string source = session.PageSource;
             if ((source.Contains("Keep on top")) && (source.Contains("Header")))
             {
                 return false;
@@ -141,7 +141,7 @@ namespace CalculatorUITestFramework
                 throw new NotFoundException("Could not find the Invert Button");
             }
 
-            if (!this.session.PageSource.Contains("invertButton"))
+            if (!session.PageSource.Contains("invertButton"))
             {
                 var width = CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size.Width;
                 CalculatorDriver.Instance.CalculatorSession.Manage().Window.Size = new Size(width, height);

--- a/src/CalculatorUITestFramework/StandardCalculatorPage.cs
+++ b/src/CalculatorUITestFramework/StandardCalculatorPage.cs
@@ -25,8 +25,8 @@ namespace CalculatorUITestFramework
         public void NavigateToStandardCalculator()
         {
             // Ensure that calculator is in standard mode
-            this.NavigationMenu.ChangeCalculatorMode(CalculatorMode.StandardCalculator);
-            this.CalculatorResults.IsResultsDisplayPresent();
+            NavigationMenu.ChangeCalculatorMode(CalculatorMode.StandardCalculator);
+            CalculatorResults.IsResultsDisplayPresent();
         }
 
         /// <summary>
@@ -34,11 +34,11 @@ namespace CalculatorUITestFramework
         /// </summary>
         public void ClearAll()
         {
-            this.StandardAoTCalculatorPage.NavigateToStandardMode();
-            this.MemoryPanel.ResizeWindowToDisplayMemoryLabel();
-            this.StandardOperators.ClearButton.Click();
-            this.MemoryPanel.NumberpadMCButton.Click();
-            this.HistoryPanel.ClearHistory();
+            StandardAoTCalculatorPage.NavigateToStandardMode();
+            MemoryPanel.ResizeWindowToDisplayMemoryLabel();
+            StandardOperators.ClearButton.Click();
+            MemoryPanel.NumberpadMCButton.Click();
+            HistoryPanel.ClearHistory();
         }
 
         ///// <summary>
@@ -46,9 +46,9 @@ namespace CalculatorUITestFramework
         ///// </summary>
         public void EnsureCalculatorResultTextIsZero()
         {
-            if ("0" != this.CalculatorResults.GetCalculatorResultText())
+            if ("0" != CalculatorResults.GetCalculatorResultText())
             {
-                this.ClearAll();
+                ClearAll();
             }
         }
 
@@ -67,12 +67,12 @@ namespace CalculatorUITestFramework
                 }
                 else
                 {
-                    this.NavigateToStandardCalculator();
+                    NavigateToStandardCalculator();
                 }
             }
             else
             {
-                this.StandardAoTCalculatorPage.NavigateToStandardMode();
+                StandardAoTCalculatorPage.NavigateToStandardMode();
             }
         }
 

--- a/src/CalculatorUITestFramework/StandardOperatorsPanel.cs
+++ b/src/CalculatorUITestFramework/StandardOperatorsPanel.cs
@@ -13,19 +13,19 @@ namespace CalculatorUITestFramework
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
         public NumberPad NumberPad = new NumberPad();
 
-        public WindowsElement PercentButton => this.session.TryFindElementByAccessibilityId("percentButton");
-        public WindowsElement SquareRootButton => this.session.TryFindElementByAccessibilityId("squareRootButton");
-        public WindowsElement XPower2Button => this.session.TryFindElementByAccessibilityId("xpower2Button");
-        public WindowsElement XPower3Button => this.session.TryFindElementByAccessibilityId("xpower3Button");
-        public WindowsElement InvertButton => this.session.TryFindElementByAccessibilityId("invertButton");
-        public WindowsElement DivideButton => this.session.TryFindElementByAccessibilityId("divideButton");
-        public WindowsElement MultiplyButton => this.session.TryFindElementByAccessibilityId("multiplyButton");
-        public WindowsElement MinusButton => this.session.TryFindElementByAccessibilityId("minusButton");
-        public WindowsElement PlusButton => this.session.TryFindElementByAccessibilityId("plusButton");
-        public WindowsElement EqualButton => this.session.TryFindElementByAccessibilityId("equalButton");
-        public WindowsElement ClearEntryButton => this.session.TryFindElementByAccessibilityId("clearEntryButton");
-        public WindowsElement ClearButton => this.session.TryFindElementByAccessibilityId("clearButton");
-        public WindowsElement BackSpaceButton => this.session.TryFindElementByAccessibilityId("backSpaceButton");
-        public WindowsElement NegateButton => this.session.TryFindElementByAccessibilityId("negateButton");
+        public WindowsElement PercentButton => session.TryFindElementByAccessibilityId("percentButton");
+        public WindowsElement SquareRootButton => session.TryFindElementByAccessibilityId("squareRootButton");
+        public WindowsElement XPower2Button => session.TryFindElementByAccessibilityId("xpower2Button");
+        public WindowsElement XPower3Button => session.TryFindElementByAccessibilityId("xpower3Button");
+        public WindowsElement InvertButton => session.TryFindElementByAccessibilityId("invertButton");
+        public WindowsElement DivideButton => session.TryFindElementByAccessibilityId("divideButton");
+        public WindowsElement MultiplyButton => session.TryFindElementByAccessibilityId("multiplyButton");
+        public WindowsElement MinusButton => session.TryFindElementByAccessibilityId("minusButton");
+        public WindowsElement PlusButton => session.TryFindElementByAccessibilityId("plusButton");
+        public WindowsElement EqualButton => session.TryFindElementByAccessibilityId("equalButton");
+        public WindowsElement ClearEntryButton => session.TryFindElementByAccessibilityId("clearEntryButton");
+        public WindowsElement ClearButton => session.TryFindElementByAccessibilityId("clearButton");
+        public WindowsElement BackSpaceButton => session.TryFindElementByAccessibilityId("backSpaceButton");
+        public WindowsElement NegateButton => session.TryFindElementByAccessibilityId("negateButton");
     }
 }

--- a/src/CalculatorUITestFramework/UnitConverterOperatorsPanel.cs
+++ b/src/CalculatorUITestFramework/UnitConverterOperatorsPanel.cs
@@ -8,9 +8,9 @@ namespace CalculatorUITestFramework
     {
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
         public NumberPad NumberPad = new NumberPad();
-        public WindowsElement ClearButton => this.session.TryFindElementByAccessibilityId("ClearEntryButtonPos0");
-        public WindowsElement BackSpaceButton => this.session.TryFindElementByAccessibilityId("BackSpaceButtonSmall");
-        public WindowsElement Units1 => this.session.TryFindElementByAccessibilityId("Units1");
-        public WindowsElement Units2 => this.session.TryFindElementByAccessibilityId("Units2");
+        public WindowsElement ClearButton => session.TryFindElementByAccessibilityId("ClearEntryButtonPos0");
+        public WindowsElement BackSpaceButton => session.TryFindElementByAccessibilityId("BackSpaceButtonSmall");
+        public WindowsElement Units1 => session.TryFindElementByAccessibilityId("Units1");
+        public WindowsElement Units2 => session.TryFindElementByAccessibilityId("Units2");
     }
 }

--- a/src/CalculatorUITestFramework/UnitConverterPage.cs
+++ b/src/CalculatorUITestFramework/UnitConverterPage.cs
@@ -17,7 +17,7 @@ namespace CalculatorUITestFramework
         /// </summary>
         public void ClearAll()
         {
-            this.UnitConverterOperators.ClearButton.Click();
+            UnitConverterOperators.ClearButton.Click();
         }
 
         ///// <summary>
@@ -25,9 +25,9 @@ namespace CalculatorUITestFramework
         ///// </summary>
         public void EnsureCalculatorResultTextIsZero()
         {
-            if ("0" != this.UnitConverterResults.GetCalculationResult1Text())
+            if ("0" != UnitConverterResults.GetCalculationResult1Text())
             {
-                this.ClearAll();
+                ClearAll();
             }
         }
 
@@ -37,8 +37,8 @@ namespace CalculatorUITestFramework
         public void NavigateToUnitConverter()
         {
             // Ensure that calculator is in Currency Mode
-            this.NavigationMenu.ChangeCalculatorMode(CalculatorMode.Currency);
-            this.UnitConverterResults.IsResultsDisplayPresent();
+            NavigationMenu.ChangeCalculatorMode(CalculatorMode.Currency);
+            UnitConverterResults.IsResultsDisplayPresent();
         }
 
         ///// <summary>
@@ -56,7 +56,7 @@ namespace CalculatorUITestFramework
                 }
                 else
                 {
-                    this.NavigateToUnitConverter();
+                    NavigateToUnitConverter();
                 }
             }
         }

--- a/src/CalculatorUITestFramework/UnitConverterResults.cs
+++ b/src/CalculatorUITestFramework/UnitConverterResults.cs
@@ -11,9 +11,9 @@ namespace CalculatorUITestFramework
     public class UnitConverterResults
     {
         private WindowsDriver<WindowsElement> session => CalculatorDriver.Instance.CalculatorSession;
-        private WindowsElement CalculationResult1 => this.session.TryFindElementByAccessibilityId("Value1");
+        private WindowsElement CalculationResult1 => session.TryFindElementByAccessibilityId("Value1");
 
-        private WindowsElement CalculationResult2 => this.session.TryFindElementByAccessibilityId("Value2");
+        private WindowsElement CalculationResult2 => session.TryFindElementByAccessibilityId("Value2");
 
         /// <summary>
         /// Gets the text from the Value1 control and removes the narrator text that is not displayed in the UI.
@@ -21,7 +21,7 @@ namespace CalculatorUITestFramework
         /// <returns>The string shown in the UI.</returns>
         public string GetCalculationResult1Text()
         {
-            return Regex.Replace(this.CalculationResult1.Text.Trim(), "[^0-9.]", "");
+            return Regex.Replace(CalculationResult1.Text.Trim(), "[^0-9.]", "");
         }
 
         /// <summary>
@@ -30,8 +30,8 @@ namespace CalculatorUITestFramework
         /// <returns>The string shown in the UI.</returns>
         public void IsResultsDisplayPresent()
         {
-            Assert.IsNotNull(this.CalculationResult1);
-            Assert.IsNotNull(this.CalculationResult2);
+            Assert.IsNotNull(CalculationResult1);
+            Assert.IsNotNull(CalculationResult2);
         }
 
         /// <summary>
@@ -40,7 +40,7 @@ namespace CalculatorUITestFramework
         /// <returns>The string shown in the UI.</returns>
         public string GetCalculationResult2Text()
         {
-            return Regex.Replace(this.CalculationResult2.Text.Trim(), "[^0-9.]", "");
+            return Regex.Replace(CalculationResult2.Text.Trim(), "[^0-9.]", "");
         }
 
     }

--- a/src/CalculatorUITestFramework/WinAppDriverLocalServer.cs
+++ b/src/CalculatorUITestFramework/WinAppDriverLocalServer.cs
@@ -39,23 +39,23 @@ namespace CalculatorUITestFramework
                 throw new Exception("Could not find winappdriver.exe in program files. Make sure WinAppDriver is installed: https://aka.ms/winappdriver");
             }
 
-            this.winAppDriverProcess = new Process();
-            this.winAppDriverProcess.StartInfo.CreateNoWindow = true;
-            this.winAppDriverProcess.StartInfo.FileName = path;
-            this.winAppDriverProcess.StartInfo.UseShellExecute = false;
-            this.winAppDriverProcess.StartInfo.RedirectStandardInput = true;
-            this.winAppDriverProcess.StartInfo.RedirectStandardOutput = true;
-            this.winAppDriverProcess.StartInfo.RedirectStandardError = true;
-            this.winAppDriverProcess.OutputDataReceived += this.OnProcessOutputDataReceived;
-            this.winAppDriverProcess.ErrorDataReceived += this.OnProcessErrorDataReceived;
-            if (!this.winAppDriverProcess.Start())
+            winAppDriverProcess = new Process();
+            winAppDriverProcess.StartInfo.CreateNoWindow = true;
+            winAppDriverProcess.StartInfo.FileName = path;
+            winAppDriverProcess.StartInfo.UseShellExecute = false;
+            winAppDriverProcess.StartInfo.RedirectStandardInput = true;
+            winAppDriverProcess.StartInfo.RedirectStandardOutput = true;
+            winAppDriverProcess.StartInfo.RedirectStandardError = true;
+            winAppDriverProcess.OutputDataReceived += OnProcessOutputDataReceived;
+            winAppDriverProcess.ErrorDataReceived += OnProcessErrorDataReceived;
+            if (!winAppDriverProcess.Start())
             {
                 throw new Exception("WinAppDriver process failed to start.");
             }
-            this.winAppDriverProcess.BeginOutputReadLine();
-            this.winAppDriverProcess.BeginErrorReadLine();
+            winAppDriverProcess.BeginOutputReadLine();
+            winAppDriverProcess.BeginErrorReadLine();
 
-            var pingUri = new Uri(this.ServiceUrl, "/status");
+            var pingUri = new Uri(ServiceUrl, "/status");
             var status = new HttpClient().GetAsync(pingUri);
             var timeout = TimeSpan.FromSeconds(10);
             if (!status.Wait(timeout))
@@ -71,7 +71,7 @@ namespace CalculatorUITestFramework
             var data = e.Data?.Replace("\0", string.Empty);
             if (!string.IsNullOrEmpty(data))
             {
-                Console.WriteLine(this.PrependWinAppDriverToEachLine(data));
+                Console.WriteLine(PrependWinAppDriverToEachLine(data));
             }
         }
 
@@ -80,7 +80,7 @@ namespace CalculatorUITestFramework
             var data = e.Data?.Replace("\0", string.Empty);
             if (!string.IsNullOrEmpty(data))
             {
-                Console.Error.WriteLine(this.PrependWinAppDriverToEachLine(data));
+                Console.Error.WriteLine(PrependWinAppDriverToEachLine(data));
             }
         }
 
@@ -94,18 +94,18 @@ namespace CalculatorUITestFramework
 
         ~WinAppDriverLocalServer()
         {
-            if (!this.processExited)
+            if (!processExited)
             {
-                this.winAppDriverProcess.Kill();
-                this.winAppDriverProcess.WaitForExit();
+                winAppDriverProcess.Kill();
+                winAppDriverProcess.WaitForExit();
             }
         }
 
         public void Dispose()
         {
-            this.winAppDriverProcess.Kill();
-            this.winAppDriverProcess.WaitForExit();
-            this.processExited = true;
+            winAppDriverProcess.Kill();
+            winAppDriverProcess.WaitForExit();
+            processExited = true;
             GC.SuppressFinalize(this);
         }
     }


### PR DESCRIPTION
### Description of the changes:
- Expand the stub `.editorconfig` into a single source of truth: universal defaults plus C#, C++, XML/MSBuild, JSON/YAML, and Markdown sections, including .NET naming rules and code-style preferences.
- Promote IDE0003 (remove unnecessary `this.` qualification) to `warning` and apply the fix across the `CalculatorUITestFramework` sources.
- Add `build/scripts/VerifyCodeStyle.ps1`, which runs `dotnet format style --verify-no-changes` on the SDK-style C# projects (`CalculatorUITestFramework`, `CalculatorUITests`). This surfaces IDE-prefixed Roslyn analyzers (IDE0003) that `csc` does not reliably emit at build time. Old-style UWP projects and native C++ test projects are excluded because the dotnet workspace loader cannot evaluate them.
- Add a `Verify code style (IDE0003)` job to `action-ci.yml` so the gate runs on every pull request.

### How changes were validated:
- Ran `dotnet format style` locally (.NET SDK 10.0.301) to apply the IDE0003 fixes.
- Ran `build/scripts/VerifyCodeStyle.ps1` locally; it passes with no violations on both allowlisted projects.
- No functional/runtime code changed; existing build, unit test, and UI test jobs are unmodified.
