### PR TITLE
fix: operator-panel flyout buttons expose ExpandCollapse instead of Toggle (a11y)

### DIFF
--- a/src/Calculator/App.xaml
+++ b/src/Calculator/App.xaml
@@ -869,7 +869,7 @@
             </Style>
 
             <Style x:Key="OperatorPanelButtonStyle"
-                   BasedOn="{StaticResource DefaultToggleButtonStyle}"
+                   BasedOn="{StaticResource DefaultButtonStyle}"
                    TargetType="Controls:OperatorPanelButton">
                 <Setter Property="FontSize" Value="{StaticResource CaptionFontSize}"/>
                 <Setter Property="GlyphFontSize" Value="{StaticResource CaptionFontSize}"/>

--- a/src/Calculator/Calculator.csproj
+++ b/src/Calculator/Calculator.csproj
@@ -127,6 +127,7 @@
     <Compile Include="Controls\CalculationResultAutomationPeer.cs" />
     <Compile Include="Controls\CalculatorButton.cs" />
     <Compile Include="Controls\OperatorPanelButton.cs" />
+    <Compile Include="Controls\OperatorPanelButtonAutomationPeer.cs" />
     <Compile Include="Controls\OperatorPanelListView.cs" />
     <Compile Include="Controls\OverflowTextBlock.cs" />
     <Compile Include="Controls\OverflowTextBlockAutomationPeer.cs" />

--- a/src/Calculator/Controls/OperatorPanelButton.cs
+++ b/src/Calculator/Controls/OperatorPanelButton.cs
@@ -2,16 +2,29 @@
 // Licensed under the MIT License.
 
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Input;
 
 namespace CalculatorApp
 {
     namespace Controls
     {
-        public sealed class OperatorPanelButton : Windows.UI.Xaml.Controls.Primitives.ToggleButton
+        // OperatorPanelButton opens a flyout menu. It derives from Button (not ToggleButton) so
+        // that it does not advertise the Toggle pattern, which would make Narrator announce a
+        // misleading On/Off state for a menu opener. The "checked while the flyout is open" visual
+        // is reproduced here by driving the template's visual states from IsChecked, and the peer
+        // exposes the ExpandCollapse pattern instead of Toggle.
+        public sealed class OperatorPanelButton : Windows.UI.Xaml.Controls.Button
         {
+            private bool m_isPointerOver;
+            private bool m_isPressed;
+
             public OperatorPanelButton()
             {
+                IsEnabledChanged += OnIsEnabledChanged;
+                Click += OnClicked;
             }
 
             public string Text
@@ -64,27 +77,140 @@ namespace CalculatorApp
             public static readonly DependencyProperty FlyoutMenuProperty =
                 DependencyProperty.Register(nameof(FlyoutMenu), typeof(Flyout), typeof(OperatorPanelButton), new PropertyMetadata(default(Flyout)));
 
+            // True while the flyout is open. Replaces ToggleButton.IsChecked so the button no longer
+            // exposes the Toggle pattern, while still driving the "open" visual and ExpandCollapse state.
+            public bool IsChecked
+            {
+                get => (bool)GetValue(IsCheckedProperty);
+                set => SetValue(IsCheckedProperty, value);
+            }
+
+            public static readonly DependencyProperty IsCheckedProperty =
+                DependencyProperty.Register(nameof(IsChecked), typeof(bool), typeof(OperatorPanelButton), new PropertyMetadata(false, OnIsCheckedPropertyChanged));
+
             protected override void OnApplyTemplate()
             {
+                base.OnApplyTemplate();
+
                 if (FlyoutMenu != null)
                 {
                     FlyoutMenu.Closed += FlyoutClosed;
                 }
+
+                UpdateVisualState(false);
             }
 
-            protected override void OnToggle()
+            private void OnClicked(object sender, RoutedEventArgs e)
             {
-                base.OnToggle();
+                IsChecked = !IsChecked;
 
-                if (IsChecked == true)
+                if (IsChecked)
                 {
-                    FlyoutMenu.ShowAt(this);
+                    FlyoutMenu?.ShowAt(this);
                 }
+            }
+
+            protected override void OnPointerEntered(PointerRoutedEventArgs e)
+            {
+                base.OnPointerEntered(e);
+                m_isPointerOver = true;
+                UpdateVisualState();
+            }
+
+            protected override void OnPointerExited(PointerRoutedEventArgs e)
+            {
+                base.OnPointerExited(e);
+                m_isPointerOver = false;
+                m_isPressed = false;
+                UpdateVisualState();
+            }
+
+            protected override void OnPointerPressed(PointerRoutedEventArgs e)
+            {
+                base.OnPointerPressed(e);
+                m_isPressed = true;
+                UpdateVisualState();
+            }
+
+            protected override void OnPointerReleased(PointerRoutedEventArgs e)
+            {
+                base.OnPointerReleased(e);
+                m_isPressed = false;
+                UpdateVisualState();
+            }
+
+            protected override void OnPointerCanceled(PointerRoutedEventArgs e)
+            {
+                base.OnPointerCanceled(e);
+                m_isPressed = false;
+                m_isPointerOver = false;
+                UpdateVisualState();
+            }
+
+            protected override void OnPointerCaptureLost(PointerRoutedEventArgs e)
+            {
+                base.OnPointerCaptureLost(e);
+                m_isPressed = false;
+                m_isPointerOver = false;
+                UpdateVisualState();
+            }
+
+            protected override AutomationPeer OnCreateAutomationPeer()
+            {
+                return new OperatorPanelButtonAutomationPeer(this);
             }
 
             private void FlyoutClosed(object sender, object args)
             {
                 IsChecked = false;
+            }
+
+            private void OnIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs e)
+            {
+                UpdateVisualState();
+            }
+
+            private static void OnIsCheckedPropertyChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+            {
+                ((OperatorPanelButton)d).OnIsCheckedChanged((bool)e.NewValue);
+            }
+
+            private void OnIsCheckedChanged(bool isChecked)
+            {
+                UpdateVisualState();
+
+                if (FrameworkElementAutomationPeer.FromElement(this) is OperatorPanelButtonAutomationPeer peer)
+                {
+                    peer.RaiseExpandCollapseAutomationEvent(
+                        isChecked ? ExpandCollapseState.Collapsed : ExpandCollapseState.Expanded,
+                        isChecked ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed);
+                }
+            }
+
+            // Mirrors ToggleButton's own visual-state selection so the existing template (with its
+            // Checked/CheckedPointerOver/CheckedPressed/CheckedDisabled states) keeps working now
+            // that the base control is a Button rather than a ToggleButton.
+            private void UpdateVisualState(bool useTransitions = true)
+            {
+                string state;
+                if (!IsEnabled)
+                {
+                    state = IsChecked ? "CheckedDisabled" : "Disabled";
+                }
+                else if (m_isPressed)
+                {
+                    state = IsChecked ? "CheckedPressed" : "Pressed";
+                }
+                else if (m_isPointerOver)
+                {
+                    state = IsChecked ? "CheckedPointerOver" : "PointerOver";
+                }
+                else
+                {
+                    state = IsChecked ? "Checked" : "Normal";
+                }
+
+                VisualStateManager.GoToState(this, state, useTransitions);
             }
         }
     }

--- a/src/Calculator/Controls/OperatorPanelButtonAutomationPeer.cs
+++ b/src/Calculator/Controls/OperatorPanelButtonAutomationPeer.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Windows.UI.Xaml.Automation;
+using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Automation.Provider;
+using Windows.UI.Xaml.Controls;
+
+namespace CalculatorApp
+{
+    namespace Controls
+    {
+        // OperatorPanelButton opens a flyout menu. Because it derives from Button (not
+        // ToggleButton), this peer builds on ButtonAutomationPeer, which does not advertise the
+        // Toggle pattern that would make Narrator announce a misleading On/Off state for a menu
+        // opener. It adds the ExpandCollapse pattern (collapsed/expanded) on top.
+        public sealed class OperatorPanelButtonAutomationPeer : ButtonAutomationPeer, IExpandCollapseProvider
+        {
+            public OperatorPanelButtonAutomationPeer(Button owner)
+                : base(owner)
+            {
+            }
+
+            public ExpandCollapseState ExpandCollapseState =>
+                ((OperatorPanelButton)Owner).IsChecked ? ExpandCollapseState.Expanded : ExpandCollapseState.Collapsed;
+
+            public void Expand()
+            {
+                var owner = (OperatorPanelButton)Owner;
+                if (!owner.IsChecked)
+                {
+                    owner.IsChecked = true;
+                    owner.FlyoutMenu?.ShowAt(owner);
+                }
+            }
+
+            public void Collapse()
+            {
+                var owner = (OperatorPanelButton)Owner;
+                if (owner.IsChecked)
+                {
+                    owner.FlyoutMenu?.Hide();
+                }
+            }
+
+            public void RaiseExpandCollapseAutomationEvent(ExpandCollapseState oldState, ExpandCollapseState newState)
+            {
+                RaisePropertyChangedEvent(ExpandCollapsePatternIdentifiers.ExpandCollapseStateProperty, oldState, newState);
+            }
+
+            protected override object GetPatternCore(PatternInterface pattern)
+            {
+                if (pattern == PatternInterface.ExpandCollapse)
+                {
+                    return this;
+                }
+
+                return base.GetPatternCore(pattern);
+            }
+        }
+    }
+}

--- a/src/CalculatorUITests/ScientificModeFunctionalTests.cs
+++ b/src/CalculatorUITests/ScientificModeFunctionalTests.cs
@@ -755,5 +755,39 @@ namespace CalculatorUITests
                 "Display should render in fixed form after Clear-Entry resets F-E.");
         }
         #endregion
+
+        #region Accessibility Tests
+
+        /// <summary>
+        /// In Scientific mode, the Trigonometry operator-panel button opens a flyout
+        /// menu, so it exposes the ExpandCollapse automation pattern: collapsed while
+        /// the flyout is closed and expanded while it is open, so screen-reader users
+        /// hear a menu expander rather than a misleading On/Off toggle state.
+        /// </summary>
+        [TestMethod]
+        [Priority(1)]
+        public void TrigButtonExposesExpandCollapseState()
+        {
+            // A flyout opener reports ExpandCollapse, collapsed while the flyout is closed.
+            Assert.AreEqual(
+                "Collapsed",
+                page.ScientificOperators.TrigButton.GetAttribute("ExpandCollapse.ExpandCollapseState"),
+                "Trigonometry flyout button should report Collapsed when its flyout is closed.");
+
+            // Opening the flyout transitions the button to Expanded.
+            page.ScientificOperators.TrigButton.Click();
+            Assert.AreEqual(
+                "Expanded",
+                page.ScientificOperators.TrigButton.GetAttribute("ExpandCollapse.ExpandCollapseState"),
+                "Trigonometry flyout button should report Expanded while its flyout is open.");
+
+            // Dismissing the flyout transitions it back to Collapsed.
+            page.ScientificOperators.LightDismiss.Click();
+            Assert.AreEqual(
+                "Collapsed",
+                page.ScientificOperators.TrigButton.GetAttribute("ExpandCollapse.ExpandCollapseState"),
+                "Trigonometry flyout button should report Collapsed after its flyout is dismissed.");
+        }
+        #endregion
     }
 }


### PR DESCRIPTION
 Fixes #1378
 
 ## Summary
 The operator-panel flyout-opener buttons (Trigonometry, Function, Bitwise, Bit Shift, Inequality) in Scientific, Programmer, and Graphing modes are announced by screen readers as toggle buttons with an On/Off state. They open a flyout menu, so they should expose the ExpandCollapse UI Automation pattern (collapsed/expanded), not the Toggle pattern.
 
 ## Root cause
 OperatorPanelButton derived from ToggleButton to reuse the "checked while the flyout is open" visual. Deriving from ToggleButton makes the control expose the Toggle UIA pattern at the control level, so Narrator announces a misleading On/Off state. The Toggle pattern comes from the control type itself, so it cannot be removed by only customizing the automation peer.
 
 ## Fix
 Change OperatorPanelButton to derive from Button instead of ToggleButton, and reproduce the flyout-open visual by driving the existing template visual states from a new IsChecked property in code. The automation peer now derives from ButtonAutomationPeer and adds the ExpandCollapse pattern (collapsed when the flyout is closed, expanded when open), raising an ExpandCollapseState automation event on open and close. The control template is unchanged; only the style BasedOn switches from the default ToggleButton style to the default Button style.
 
 Because the fix is at the shared control level, this single change corrects all affected buttons across Scientific, Programmer, and Graphing modes.
 
 ## Testing
 - Added a WinAppDriver regression test (Scientific mode) asserting the Trigonometry button reports the ExpandCollapse state across the flyout lifecycle: collapsed when closed, expanded when open, collapsed after dismiss. The shared control-level fix applies identically to the other consumers.
 - Verified with Narrator / Accessibility Insights that the flyout-opener buttons announce as collapsed/expanded menu buttons (no On/Off state) and still open via mouse and keyboard.